### PR TITLE
Add markdownlint-cli2

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,15 @@
+name: "markdownlint-cli2"
+
+# Disable automatic runs
+on: [workflow_dispatch]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: DavidAnson/markdownlint-cli2-action@v15
+      with:
+        # Only finds files with directory, glob, then *.mdx file glob
+        globs: |
+          platform_versioned_docs/**/*.mdx

--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -1,0 +1,222 @@
+const path = require('path');
+
+// Based on
+// https://raw.githubusercontent.com/moodle/devdocs/main/.markdownlint-cli2.cjs
+
+const config = {};
+
+// Set the default state for all rules.
+config.default = true;
+
+// MD001 / heading - increment / header - increment - Heading levels should only increment by one level at a time
+// MD002 / first - heading - h1 / first - header - h1 - First heading should be a top - level heading
+// MD003 / heading - style / header - style - Heading style
+
+// MD004 / ul - style - Unordered list style
+config.MD004 = {
+    style: 'dash',
+};
+
+// MD005 / list - indent - Inconsistent indentation for list items at the same level
+// MD006 / ul - start - left - Consider starting bulleted lists at the beginning of the line
+
+// MD007 / ul - indent - Unordered list indentation
+// MD009 / no - trailing - spaces - Trailing spaces
+// MD010 / no - hard - tabs - Hard tabs
+//config.MD010 = false;
+config.MD010 = {
+  spaces_per_tab: 2,
+  code_blocks: false
+};
+
+// MD011 / no - reversed - links - Reversed link syntax
+// MD012 / no - multiple - blanks - Multiple consecutive blank lines
+
+// MD013 / line - length - Line length
+// Disable for better readability.
+config.MD013 = false;
+
+// MD014 / commands - show - output - Dollar signs used before commands without showing output
+config.MD014 = false;
+
+// MD018 / no - missing - space - atx - No space after hash on atx style heading
+// MD019 / no - multiple - space - atx - Multiple spaces after hash on atx style heading
+// MD020 / no - missing - space - closed - atx - No space inside hashes on closed atx style heading
+// MD021 / no - multiple - space - closed - atx - Multiple spaces inside hashes on closed atx style heading
+// MD022 / blanks - around - headings / blanks - around - headers - Headings should be surrounded by blank lines
+// MD023 / heading - start - left / header - start - left - Headings must start at the beginning of the line
+
+// MD024 / no - duplicate - heading / no - duplicate - header - Multiple headings with the same content
+config.MD024 = false;
+
+// MD025 / single - title / single - h1 - Multiple top - level headings in the same document
+
+// MD026 / no - trailing - punctuation - Trailing punctuation in heading
+config.MD026 = false;
+
+// MD027 / no - multiple - space - blockquote - Multiple spaces after blockquote symbol
+
+// MD028 / no - blanks - blockquote - Blank line inside blockquote
+config.MD028 = false;
+
+// MD029 / ol - prefix - Ordered list item prefix
+// MD030 / list - marker - space - Spaces after list markers
+
+//config.MD030 = false;
+config.MD030 = {
+  ol_single: 2,
+  ol_multi: 2
+}
+
+// MD031 / blanks - around - fences - Fenced code blocks should be surrounded by blank lines
+// MD032 / blanks - around - lists - Lists should be surrounded by blank lines
+
+// MD033 / no - inline - html - Inline HTML
+config.MD033 = {
+    "allowed_elements": [
+        "a",
+        "abbr",
+        "annotation",
+        "base",
+        "br",
+        "caption",
+        "cite",
+        "code",
+        "col",
+        "colgroup",
+        "dd",
+        "details",
+        "dfn",
+        "div",
+        "dl",
+        "dt",
+        "em",
+        "figure",
+        "figcaption",
+        "h4",
+        "h5",
+        "img",
+        "kbd",
+        "li",
+        "math",
+        "menclose",
+        "mfenced",
+        "mfrac",
+        "mfrac",
+        "mi",
+        "mmultiscripts",
+        "mn",
+        "mo",
+        "mover",
+        "mphantom",
+        "mprescripts",
+        "mroot",
+        "mrow",
+        "ms",
+        "mspace",
+        "mspace",
+        "msqrt",
+        "mstyle",
+        "msub",
+        "msubsup",
+        "msup",
+        "mtable",
+        "mtd",
+        "mtext",
+        "mtr",
+        "munder",
+        "munderover",
+        "none",
+        "ol",
+        "p",
+        "pre",
+        "q",
+        "section",
+        "semantics",
+        "span",
+        "strong",
+        "sub",
+        "summary",
+        "sup",
+        "table",
+        "tbody",
+        "td",
+        "tfoot",
+        "th",
+        "thead",
+        "tr",
+        "tt",
+        "ul",
+        "var",
+
+        // These are custom React elements, either from Docusaurus, or our own.
+        "CodeBlock",
+        "Tabs",
+        "TabItem",
+        "TabItems",
+        "Since",
+        "DeprecatedSince",
+        "ValidExample",
+        "InvalidExample",
+        "ReactPlayer",
+        "Link",
+        "ReleaseNoteIntro",
+        "ReleaseDate",
+        "ReleaseVersion",
+    ]
+};
+
+// MD034 / no - bare - urls - Bare URL used
+config.MD034 = false;
+
+// MD035 / hr - style - Horizontal rule style
+
+// MD036 / no - emphasis - as - heading / no - emphasis - as - header - Emphasis used instead of a heading
+//config.MD036 = false;
+
+// MD037 / no - space -in -emphasis - Spaces inside emphasis markers
+//config.MD037 = false;
+
+// MD038 / no - space -in -code - Spaces inside code span elements
+config.MD038 = false;
+
+// MD039 / no - space -in -links - Spaces inside link text
+
+// MD040 / fenced - code - language - Fenced code blocks should have a language specified
+//config.MD040 = false;
+
+// MD041 / first - line - heading / first - line - h1 - First line in a file should be a top - level heading
+
+// MD042 / no - empty - links - No empty links
+//config.MD042 = false;
+
+// MD043 / required - headings / required - headers - Required heading structure
+// MD044 / proper - names - Proper names should have the correct capitalization
+
+// MD045 / no - alt - text - Images should have alternate text(alt text)
+//config.MD045 = false;
+
+// MD046 / code - block - style - Code block style
+config.MD046 = {
+    style: 'fenced',
+}
+
+// MD047 / single - trailing - newline - Files should end with a single newline character
+// MD048 / code - fence - style - Code fence style
+
+// MD049 / emphasis - style - Emphasis style should be consistent
+//config.MD049 = false;
+
+// MD050 / strong - style - Strong style should be consistent
+//config.MD050 = false;
+
+// MDL051 / link-fragments - Links fragments should be valid
+// This rule is not compatible with Docusaurus as Docusaurus generates ids not present in the source.
+config.MD051 = false;
+
+// MD052 / reference-links-images - Reference links and images should use a label that is defined
+// MD053 / link-image-reference-definitions - Link and image reference definitions should be needed
+
+module.exports = {
+    config,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint-plugin-react": "^7.33.2",
         "fast-glob": "^3.3.1",
         "fs-extra": "^11.1.1",
+        "markdownlint-cli2": "^0.12.1",
         "path": "^0.12.7",
         "postcss": "^8.4.32",
         "prettier": "^3.0.3",
@@ -3266,6 +3267,18 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-1.0.0.tgz",
+      "integrity": "sha512-rUV5WyJrJLoloD4NDN1V1+LDMDWOa4OTsT4yYJwQNpTU6FWxkxHpL7eu4w+DmiH8x/EAM1otkPE1+LaspIbplw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@slorber/remark-comment": {
@@ -9740,6 +9753,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -9869,6 +9888,15 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",
@@ -10024,6 +10052,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.0.0.tgz",
+      "integrity": "sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.0.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
@@ -10031,6 +10076,119 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.33.0.tgz",
+      "integrity": "sha512-4lbtT14A3m0LPX1WS/3d1m7Blg+ZwiLq36WvjQqFGsX3Gik99NV+VXp/PW3n+Q62xyPdbvGOCfjPqjW+/SKMig==",
+      "dev": true,
+      "dependencies": {
+        "markdown-it": "14.0.0",
+        "markdownlint-micromark": "0.1.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.12.1.tgz",
+      "integrity": "sha512-RcK+l5FjJEyrU3REhrThiEUXNK89dLYNJCYbvOUKypxqIGfkcgpz8g08EKqhrmUbYfYoLC5nEYQy53NhJSEtfQ==",
+      "dev": true,
+      "dependencies": {
+        "globby": "14.0.0",
+        "jsonc-parser": "3.2.0",
+        "markdownlint": "0.33.0",
+        "markdownlint-cli2-formatter-default": "0.0.4",
+        "micromatch": "4.0.5",
+        "yaml": "2.3.4"
+      },
+      "bin": {
+        "markdownlint-cli2": "markdownlint-cli2.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2-formatter-default": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.4.tgz",
+      "integrity": "sha512-xm2rM0E+sWgjpPn1EesPXx5hIyrN2ddUnUwnbCsD/ONxYtw3PX6LydvdH6dciWAoFDpwzbHM1TO7uHfcMd6IYg==",
+      "dev": true,
+      "peerDependencies": {
+        "markdownlint-cli2": ">=0.0.4"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/globby": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.0.tgz",
+      "integrity": "sha512-/1WM/LNHRAOH9lZta77uGbq0dAEQM+XjNesWwhlERDVenqothRbnzTrL3/LrIoEPPjeUHC3vrS6TwoyxeHs7MQ==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^1.0.0",
+        "fast-glob": "^3.3.2",
+        "ignore": "^5.2.4",
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/yaml": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/markdownlint-micromark": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.8.tgz",
+      "integrity": "sha512-1ouYkMRo9/6gou9gObuMDnvZM8jC/ly3QCFQyoSPCS2XV1ZClU0xpKbL1Ar3bWWRT1RnBZkWUEiNKrI2CwiBQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
       }
     },
     "node_modules/mdast-util-directive": {
@@ -10432,6 +10590,12 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -13969,6 +14133,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pupa": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz",
@@ -16740,6 +16913,12 @@
         "node": "*"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -16802,6 +16981,18 @@
       "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
     "fetch-docs": "node internal/fetch-docs.mjs",
-    "sanitize-existing": "node internal/sanitize-existing.mjs"
+    "sanitize-existing": "node internal/sanitize-existing.mjs",
+    "markdownlint": "markdownlint-cli2 'platform_versioned_docs/**/*.mdx' 'wave_docs/**/*.mdx' 'fusion_docs/**/*.mdx' --config .markdownlint-cli2.cjs"
   },
   "dependencies": {
     "@docusaurus/core": "3.0.0",
@@ -48,6 +49,7 @@
     "eslint-plugin-react": "^7.33.2",
     "fast-glob": "^3.3.1",
     "fs-extra": "^11.1.1",
+    "markdownlint-cli2": "^0.12.1",
     "path": "^0.12.7",
     "postcss": "^8.4.32",
     "prettier": "^3.0.3",


### PR DESCRIPTION
Add the actual markdown lint CLI.

@justinegeffen @llewellyn-sl 

This summarized what these rules find. Only really the first three might merit a consensus.

## Hard tabs

This isn't currently enabled, but fires when there's a TAB instead of a SPACE in the text. Can also fire when this happens in code blocks, or code blocks can be ignored and treated as-is.

https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md010.md

## Spaces after list markers

This isn't currently enabled. It presents kind of a style preference, and there's no right answer.

I've always preferred a single space for unordered lists, because it's easy and always correct. For enumerated lists, this is harder, because you've got two characters: `1.`

So a _single_ space _after_ means you're at _3_ spaces. Most of markdown is done in 2 or 4 spaces. So you have to use TAB and SPACEBAR to deal with enumerated lists. This is sad. I'd like to adopt `2` spaces after this, so you can hit TAB, and then start your writing. When doing sub-enumerated lists, then, you can hit tab _twice_, put in your `1.`, hit tab again,  and begin writing. No TAB, space, TAB, blah, whatever. Just TABs and writing.

This is a personal preference, though, and we might not want to enforce this, or enforce a single space instead.

https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md030.md

## ol-prefix

This is a question of using `-` or `*` in unordered lists. We can do both & disable this rule or pick one.

## no-emphasis-as-heading

As it says on the tin. https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md036.md

## no-trailing-spaces

Fixed in separate PR. https://github.com/seqeralabs/docs/pull/1

## no-alt-text

Image ALT tag.

## fenced-code-language

This is whether we specify a language or not. Because many commands are terminal commands, I'm not sure this matters, although we could maybe use `bash`, but that's not exactly right. Depends on the code syntax highlighting library as to whether a `terminal` style exists that recognizes `$` or `#`. But we don't use those currently, so `bash` might work just as well.

## blanks-around-lists

This is valid markdown, so I'd be a fan of this. This is actually fixed in: https://github.com/seqeralabs/docs/pull/1

## ul-indent

Seems reasonable?

https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md007.md

```
* List item
  * Nested list item indented by 2 spaces
```

## blanks-around-fences

Fixed in https://github.com/seqeralabs/docs/pull/1

## no-multiple-blanks

Fixed in https://github.com/seqeralabs/docs/pull/1

## single-trailing-newline

Fixed in https://github.com/seqeralabs/docs/pull/1

## single-title

Should definitely fix this, must be done manually. Multiple H1s. Because Docusaurus injects H1 from the frontmatter block, I think we should remove all H1s in our documents. The frontmatter is the source of truth for both the sidebar and the markdown file, then.

## first-line-heading

This supposedly works with frontmatter and should not trigger a violation.

https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md041.md

## reference-links-images

Should probably fix these.

https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md052.md

## no-missing-space-atx

Should fix these.

https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md018.md

## no-reversed-links

This can lead to broken links, unless Docusaurus doesn't care. Might be fixed in Fixed in https://github.com/seqeralabs/docs/pull/1

https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md011.md

## emphasis-style

Be consistent in each file or across the doc set itself. Basically `*foo*` or `_foo_`.

## no-space-in-emphasis

Fixed in Fixed in https://github.com/seqeralabs/docs/pull/1

## no-inline-html

We have a broad list of default exceptions for this, I guess I missed one; We probably don't care about HTML in Markdown, because that's valid. So the whitelist is huge.

https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md049.md

Existing rule hits:

```
   1 MD033/no-inline-html
   2 MD037/no-space-in-emphasis
   4 MD049/emphasis-style
   5 MD011/no-reversed-links
   8 MD018/no-missing-space-atx
  12 MD052/reference-links-images
  15 MD041/first-line-heading
  17 MD025/single-title
  17 MD047/single-trailing-newline
  20 MD022/blanks-around-headings
  24 MD001/heading-increment
  25 MD012/no-multiple-blanks
  28 MD031/blanks-around-fences
  36 MD007/ul-indent
  39 MD032/blanks-around-lists
 151 MD046/code-block-style
 214 MD040/fenced-code-language
 273 MD045/no-alt-text
 361 MD009/no-trailing-spaces
 367 MD036/no-emphasis-as-heading
 506 MD029/ol-prefix
```