### PR TITLE
Apply markdownlint-cli2 fixes

### DIFF
--- a/fusion_docs/guide/aws-batch-s3.mdx
+++ b/fusion_docs/guide/aws-batch-s3.mdx
@@ -3,9 +3,9 @@
 Fusion simplifies and makes more efficient the execution of Nextflow pipelines with [AWS Batch](https://aws.amazon.com/batch/) in several ways:
 
 1. No need to use the AWS CLI tool for copying data from and to S3.
-2. No need to create a custom AMI or create custom containers to include the AWS CLI tool.
-3. Fusion uses an efficient data transfer and caching algorithm that provides much faster throughput compared to AWS CLI and does not require the local copy of the data files.
-4. Replacing the AWS CLI with a native API client, the transfer is much more robust at scale.
+1. No need to create a custom AMI or create custom containers to include the AWS CLI tool.
+1. Fusion uses an efficient data transfer and caching algorithm that provides much faster throughput compared to AWS CLI and does not require the local copy of the data files.
+1. Replacing the AWS CLI with a native API client, the transfer is much more robust at scale.
 
 A minimal pipeline configuration looks like the following:
 

--- a/fusion_docs/guide/gcp-gke-object.mdx
+++ b/fusion_docs/guide/gcp-gke-object.mdx
@@ -11,8 +11,8 @@ and maintain a shared file system in your cluster.
 ## Cluster preparation
 
 1. Create a GKE "standard" cluster ("Autopilot" is not supported yet). See [Google documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-zonal-cluster) for details.
-2. Make sure to use instance types with 2 or more CPUs and providing SSD instance storage (families: `n1`, `n2`, `c2`, `m1`, `m2`, `m3`)
-3. Make sure to enable the [Workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) feature when creating (or updating) the cluster
+1. Make sure to use instance types with 2 or more CPUs and providing SSD instance storage (families: `n1`, `n2`, `c2`, `m1`, `m2`, `m3`)
+1. Make sure to enable the [Workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) feature when creating (or updating) the cluster
     - "Enable Workload Identity" in the cluster "Security" setting
     - "Enable GKE Metadata Server" in the node group "Security" settings
     - Configure the cluster following the See the [Google documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#kubectl) for details. documentation
@@ -25,7 +25,7 @@ and maintain a shared file system in your cluster.
         - `GSA_PROJECT`: the Google project id e.g. `my-nf-project-261815`
         - `PROJECT_ID`: the Google project id e.g. `my-nf-project-261815`
         - `ROLE_NAME`: the role to grant access permission to the Google Storage bucket e.g. `roles/storage.admin`
-4. Create the K8s _role_ and _rolebinding_ required to run Nextflow applying the Kubernetes config shown below:
+1. Create the K8s _role_ and _rolebinding_ required to run Nextflow applying the Kubernetes config shown below:
 
 ```yaml
 ---

--- a/platform_versioned_docs/version-22.4.0/agent.mdx
+++ b/platform_versioned_docs/version-22.4.0/agent.mdx
@@ -14,27 +14,27 @@ jobs. The jobs are submitted on behalf of the user running the agent.
 
 Tower Agent is distributed as a single executable file to simply download and execute.
 
-1. Download the latest release from [Github](https://github.com/seqeralabs/tower-agent):
+1.  Download the latest release from [Github](https://github.com/seqeralabs/tower-agent):
 
    ```bash
    curl -fSL https://github.com/seqeralabs/tower-agent/releases/latest/download/tw-agent-linux-x86_64 > tw-agent
    ```
 
-2. Make it executable:
+1.  Make it executable:
 
    ```bash
    chmod +x ./tw-agent
    ```
 
-3. (Optional) Move it into a folder that is in your path.
+1.  (Optional) Move it into a folder that is in your path.
 
 ### Quickstart
 
 Before running the Agent:
 
-1. Create a [**personal access token**](api/overview.mdx#authentication) in Tower.
+1.  Create a [**personal access token**](api/overview.mdx#authentication) in Tower.
 
-2. Create **Tower Agent** credentials in a Tower workspace. See [here](credentials/overview.mdx) for more instructions.
+1.  Create **Tower Agent** credentials in a Tower workspace. See [here](credentials/overview.mdx) for more instructions.
 
 :::note
 To share a single Tower Agent instance with all members of a workspace, create a Tower Agent credential with **Shared agent** enabled.

--- a/platform_versioned_docs/version-22.4.0/compute-envs/altair-grid-engine.mdx
+++ b/platform_versioned_docs/version-22.4.0/compute-envs/altair-grid-engine.mdx
@@ -23,33 +23,33 @@ To create a new compute environment for **Grid Engine** in Tower:
 
 1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2.  Enter a descriptive name for this environment, e.g. "Grid Engine".
+1.  Enter a descriptive name for this environment, e.g. "Grid Engine".
 
-3.  Select **Altair Grid Engine** as the target platform.
+1.  Select **Altair Grid Engine** as the target platform.
 
-4.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5.  Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6.  Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8.  Enter the **Login hostname**, which is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**, which is usually the hostname or public IP address of the cluster's login node.
 
-9.  Enter the **Head queue name**, the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**, the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**, the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**, the cluster queue to which the Nextflow job will submit tasks.
 
     :::tip
     The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [docs](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
     :::
 
-11. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-12. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-13. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [Launching Pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-22.4.0/compute-envs/altair-pbs-pro.mdx
+++ b/platform_versioned_docs/version-22.4.0/compute-envs/altair-pbs-pro.mdx
@@ -23,33 +23,33 @@ To create a new compute environment for **PBS Pro** in Tower:
 
 1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2.  Enter a descriptive name for this environment, e.g. "PBS Pro cluster".
+1.  Enter a descriptive name for this environment, e.g. "PBS Pro cluster".
 
-3.  Select **Altair PBS Pro** as the target platform.
+1.  Select **Altair PBS Pro** as the target platform.
 
-4.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5.  Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6.  Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8.  Enter the **Login hostname**, which is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**, which is usually the hostname or public IP address of the cluster's login node.
 
-9.  Enter the **Head queue name**, the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**, the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**, the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**, the cluster queue to which the Nextflow job will submit tasks.
 
     :::tip
     The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [docs](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
     :::
 
-11. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-12. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-13. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [Launching Pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-22.4.0/compute-envs/aws-batch.mdx
+++ b/platform_versioned_docs/version-22.4.0/compute-envs/aws-batch.mdx
@@ -11,9 +11,9 @@ This guide assumes you have an existing [Amazon Web Service (AWS)](https://aws.a
 
 There are two ways to create a **Compute Environment** for **AWS Batch** with Tower:
 
-1. **Batch Forge**: This option automatically manages the AWS Batch resources in your AWS account.
+1.  **Batch Forge**: This option automatically manages the AWS Batch resources in your AWS account.
 
-2. **Manual**: This option allows you to create a compute environment using existing AWS Batch resources.
+1.  **Manual**: This option allows you to create a compute environment using existing AWS Batch resources.
 
 If you don't have an AWS Batch environment fully set up yet, follow the [Batch Forge](#tower-forge) guide.
 
@@ -35,69 +35,69 @@ We recommend creating separate IAM policies for Batch Forge and Tower launch per
 
 #### Create Tower IAM policies
 
-1. Open the [AWS IAM console](https://console.aws.amazon.com/iam).
+1.  Open the [AWS IAM console](https://console.aws.amazon.com/iam).
 
-2. From the left navigation menu, select **Policies** under **Access management**.
+1.  From the left navigation menu, select **Policies** under **Access management**.
 
-3. Select **Create policy**.
+1.  Select **Create policy**.
 
-4. On the **Create policy** page, select the **JSON** tab.
+1.  On the **Create policy** page, select the **JSON** tab.
 
-5. Copy the contents of your policy JSON file ([Forge](https://github.com/seqeralabs/nf-tower-aws/blob/master/forge/forge-policy.json) or [Launch](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/launch-policy.json), depending on the policy being created) and replace the default text in the policy editor area under the JSON tab. To create a Launch user, you must also create the [S3 bucket write policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) separately to attach to your Launch user.
+1.  Copy the contents of your policy JSON file ([Forge](https://github.com/seqeralabs/nf-tower-aws/blob/master/forge/forge-policy.json) or [Launch](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/launch-policy.json), depending on the policy being created) and replace the default text in the policy editor area under the JSON tab. To create a Launch user, you must also create the [S3 bucket write policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) separately to attach to your Launch user.
 
-6. Select **Next: Tags**.
+1.  Select **Next: Tags**.
 
-7. Select **Next: Review**.
+1.  Select **Next: Review**.
 
-8. Enter a name and description for the policy on the Review policy page, then select **Create policy**.
+1.  Enter a name and description for the policy on the Review policy page, then select **Create policy**.
 
-9. Repeat these steps for both the `forge-policy.json` and `launch-policy.json` files. For a Launch user, also create the `s3-bucket-write-policy.json` listed in step 5 above.
+1.  Repeat these steps for both the `forge-policy.json` and `launch-policy.json` files. For a Launch user, also create the `s3-bucket-write-policy.json` listed in step 5 above.
 
 #### Create an IAM user
 
-1. From the [AWS IAM console](https://console.aws.amazon.com/iam), select **Users** in the left navigation menu, then select **Add User** at the top rigt of the page.
+1.  From the [AWS IAM console](https://console.aws.amazon.com/iam), select **Users** in the left navigation menu, then select **Add User** at the top rigt of the page.
 
-2. Enter a name for your user (e.g. `tower`) and select the **Programmatic access** type.
+1.  Enter a name for your user (e.g. `tower`) and select the **Programmatic access** type.
 
-3. Select **Next: Permissions**.
+1.  Select **Next: Permissions**.
 
-4. Select **Next: Tags**, then **Next: Review** and **Create User**.
+1.  Select **Next: Tags**, then **Next: Review** and **Create User**.
 
    :::caution
    For the time being, you can ignore the warning. Permissions will be applied using the **IAM Policy**.
    :::
 
-5. Save the **Access key ID** and **Secret access key** in a secure location as we will use these in the next section.
+1.  Save the **Access key ID** and **Secret access key** in a secure location as we will use these in the next section.
 
-6. Once you have saved the keys, select **Close**.
+1.  Once you have saved the keys, select **Close**.
 
-7. Back in the users table, select the newly created user,then select **Add permissions** under the Permissions tab.
+1.  Back in the users table, select the newly created user,then select **Add permissions** under the Permissions tab.
 
-8. Select **Attach existing policies**, then search for the policies created in the previous section ([Create Tower IAM policies](./aws-batch.mdx#create-tower-iam-policies)) and check each one.
+1.  Select **Attach existing policies**, then search for the policies created in the previous section ([Create Tower IAM policies](./aws-batch.mdx#create-tower-iam-policies)) and check each one.
 
-9. Select **Next: Review**.
+1.  Select **Next: Review**.
 
-10. Select **Add permissions**.
+1.  Select **Add permissions**.
 
 ### S3 Bucket
 
 S3 stands for "Simple Storage Service" and is a type of **object storage**. To access files and store the results for our pipelines, we have to create an **S3 Bucket** and grant our new Tower IAM user access to it.
 
-1. Navigate to [S3 service](https://console.aws.amazon.com/s3/home).
+1.  Navigate to [S3 service](https://console.aws.amazon.com/s3/home).
 
-2. Select **Create New Bucket**.
+1.  Select **Create New Bucket**.
 
-3. Enter a unique name for your Bucket and select a region.
+1.  Enter a unique name for your Bucket and select a region.
 
    :::caution
    The region of the bucket should be in the _same region as the compute environment that we create in the next section_. Typically users select a region closest to their physical location but Batch Forge supports creating resources in any available AWS region.
    :::
 
-4. Select the default options for **Configure options**.
+1.  Select the default options for **Configure options**.
 
-5. Select the default options for **Set permissions**.
+1.  Select the default options for **Set permissions**.
 
-6. Review and select **Create bucket**.
+1.  Review and select **Create bucket**.
 
    :::caution
    S3 is used by Nextflow for the storage of intermediate files. For production pipelines, this can amount to a large quantity of data. To reduce costs, when configuring a bucket, users should consider using a retention policy, such as automatically deleting intermediate files after 30 days. For more information on this process, see [here](https://aws.amazon.com/premiumsupport/knowledge-center/s3-empty-bucket-lifecycle-rule/).
@@ -111,15 +111,15 @@ Once the AWS resources are set up, we can add a new **AWS Batch** environment in
 
 1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2.  Enter a descriptive name for this environment, e.g. "AWS Batch Spot (eu-west-1)"
+1.  Enter a descriptive name for this environment, e.g. "AWS Batch Spot (eu-west-1)"
 
-3.  Select **Amazon Batch** as the target platform.
+1.  Select **Amazon Batch** as the target platform.
 
-4.  From the **Credentials** drop-down, select existing AWS credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing AWS credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
 
-5.  Enter a name, e.g. "AWS Credentials".
+1.  Enter a name, e.g. "AWS Credentials".
 
-6.  Add the **Access key** and **Secret key**. These are the keys you saved previously when you created the AWS [IAM user](#iam).
+1.  Add the **Access key** and **Secret key**. These are the keys you saved previously when you created the AWS [IAM user](#iam).
 
     :::tip
     You can create multiple credentials in your Tower environment.
@@ -129,27 +129,27 @@ Once the AWS resources are set up, we can add a new **AWS Batch** environment in
     From version 22.3, Tower supports the use of credentials for container registry services. These credentials can be created from the [Credentials](../credentials/overview.mdx/#container-registry-credentials) tab.
     :::
 
-7.  Select a **Region**, for example "eu-west-1 - Europe (Ireland)".
+1.  Select a **Region**, for example "eu-west-1 - Europe (Ireland)".
 
-8.  Enter the S3 bucket path created in the previous section to the **Pipeline work directory** field, e.g. `s3://unique-tower-bucket`.
+1.  Enter the S3 bucket path created in the previous section to the **Pipeline work directory** field, e.g. `s3://unique-tower-bucket`.
 
     :::caution
     The bucket should be in the same Region selected in the previous step.
     :::
 
-9.  Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://seqera.io/wave/) for more information.
+1.  Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://seqera.io/wave/) for more information.
 
-10. Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://seqera.io/fusion/) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
+1.  Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://seqera.io/fusion/) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
 
-11. Select **Enable fast instance storage** to allow the use of NVMe instance storage to speed up I/O and disk access operations. NVMe instance storage requires Fusion v2 to be enabled (see above).
+1.  Select **Enable fast instance storage** to allow the use of NVMe instance storage to speed up I/O and disk access operations. NVMe instance storage requires Fusion v2 to be enabled (see above).
 
     :::note
     Fast instance storage requires an EC2 instance type that uses NVMe disks. Tower validates any instance types you specify (from **Advanced options > Instance types**) during compute environment creation. If you do not specify an instance type, a standard EC2 instance with NVMe disks will be used (`'c5ad', 'c5d', 'c6id', 'i3', 'i4i', 'm5ad', 'm5d', 'm6id', 'r5ad', 'r5d', 'r6id'` EC2 instance families) for fast storage.
     :::
 
-12. Set the **Config mode** to **Batch Forge**.
+1.  Set the **Config mode** to **Batch Forge**.
 
-13. Select a **Provisioning model**. In most cases this will be **Spot**.
+1.  Select a **Provisioning model**. In most cases this will be **Spot**.
 
     :::tip
     You can choose to create a compute environment that launches either Spot or On-demand instances. Spot instances can cost as little as 20% of on-demand instances, and with Nextflow's ability to automatically relaunch failed tasks, Spot is almost always the recommended provisioning model.
@@ -157,41 +157,41 @@ Once the AWS resources are set up, we can add a new **AWS Batch** environment in
     Note, however, that when choosing Spot instances, Tower will also create a dedicated queue for running the main Nextflow job using a single on-demand instance in order to prevent any execution interruptions.
     :::
 
-14. Enter the **Max CPUs** e.g. `64`. This is the maximum number of combined CPUs (the sum of all instances CPUs) AWS Batch will provision at any time.
+1.  Enter the **Max CPUs** e.g. `64`. This is the maximum number of combined CPUs (the sum of all instances CPUs) AWS Batch will provision at any time.
 
-15. Select **EBS Auto scale** to allow the EC2 virtual machines to dynamically expand the amount of available disk space during task execution.
+1.  Select **EBS Auto scale** to allow the EC2 virtual machines to dynamically expand the amount of available disk space during task execution.
 
     :::caution
     When running large AWS Batch clusters (hundreds of compute nodes or more), EC2 API rate limits may cause the deletion of unattached EBS volumes to fail. Volumes that remain active after Nextflow jobs have completed will incur additional costs, and should be manually deleted. Monitor your AWS account for any orphaned EBS volumes via the EC2 console, or with a Lambda function. See [here](https://aws.amazon.com/blogs/mt/controlling-your-aws-costs-by-deleting-unused-amazon-ebs-volumes/) for more information.
     :::
 
-16. With the optional **Enable Fusion mounts** feature enabled, S3 buckets specified in **Pipeline work directory** and **Allowed S3 Buckets** will be mounted as file system volumes in the EC2 instances carrying out the Batch job execution. These buckets will be accessible at `/fusion/s3/<bucket-name>`. For example, if the bucket name is `s3://imputation-gp2`, the Nextflow pipeline will access it using the file system path `/fusion/s3/imputation-gp2`.
+1.  With the optional **Enable Fusion mounts** feature enabled, S3 buckets specified in **Pipeline work directory** and **Allowed S3 Buckets** will be mounted as file system volumes in the EC2 instances carrying out the Batch job execution. These buckets will be accessible at `/fusion/s3/<bucket-name>`. For example, if the bucket name is `s3://imputation-gp2`, the Nextflow pipeline will access it using the file system path `/fusion/s3/imputation-gp2`.
 
     :::tip
     You do not need to modify your pipeline or files to take advantage of this feature. Nextflow is able to recognise these buckets automatically and will replace any reference to files prefixed with `s3://` with the corresponding Fusion mount paths.
     :::
 
-17. Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. See [GPU usage](./overview.mdx#aws-batch) for more information.
+1.  Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. See [GPU usage](./overview.mdx#aws-batch) for more information.
 
-18. Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.
+1.  Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.
 
-19. To use **EFS**, you can either select **Use existing EFS file system** and specify an existing EFS instance, or select **Create new EFS file system** to create one. If you intend to use the EFS file system as your work directory, you will need to specify `<your_EFS_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
+1.  To use **EFS**, you can either select **Use existing EFS file system** and specify an existing EFS instance, or select **Create new EFS file system** to create one. If you intend to use the EFS file system as your work directory, you will need to specify `<your_EFS_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
 
     - To use an existing EFS file system, enter the **EFS file system id** and **EFS mount path**. This is the path where the EFS volume is accessible to the compute environment. For simplicity, we advise that you use `/mnt/efs` as the EFS mount path.
     - To create a new EFS file system, enter the **EFS mount path**. We advise that you specify `/mnt/efs` as the EFS mount path.
 
-20. To use **FSx for Lustre**, you can either select **Use existing FSx file system** and specify an existing FSx instance, or select **Create new FSx file system** to create one. If you intend to use the FSx file system as your work directory, you will need to specify `<your_FSx_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
+1.  To use **FSx for Lustre**, you can either select **Use existing FSx file system** and specify an existing FSx instance, or select **Create new FSx file system** to create one. If you intend to use the FSx file system as your work directory, you will need to specify `<your_FSx_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
 
     - To use an existing FSx file system, enter the **FSx DNS name** and **FSx mount path**. The FSx mount path is the path where the FSx volume is accessible to the compute environment. For simplicity, we advise that you use `/mnt/fsx` as the FSx mount path.
     - To create a new FSx file system, enter the **FSx size** (in GB) and the **FSx mount path**. We advise that you specify `/mnt/fsx` as the FSx mount path.
 
-21. Select **Dispose resources** if you want Tower to automatically delete these AWS resources if you delete the compute environment in Tower.
+1.  Select **Dispose resources** if you want Tower to automatically delete these AWS resources if you delete the compute environment in Tower.
 
-22. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-23. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-24. Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
+1.  Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 
@@ -259,51 +259,51 @@ With these permissions set, we can add a new **AWS Batch** compute environment i
 
 Tower can use S3 to store intermediate and output data generated by pipelines. You need to create a policy for your Tower IAM user that grants access to specific buckets.
 
-1. Go to the IAM User table in the [IAM service](https://console.aws.amazon.com/iam/home)
+1.  Go to the IAM User table in the [IAM service](https://console.aws.amazon.com/iam/home)
 
-2. Select the IAM user.
+1.  Select the IAM user.
 
-3. Select **Add inline policy**.
+1.  Select **Add inline policy**.
 
-4. Copy the contents of [this policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) into the **JSON** tab. Replace `YOUR-BUCKET-NAME` (lines 10 and 21) with your bucket name.
+1.  Copy the contents of [this policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) into the **JSON** tab. Replace `YOUR-BUCKET-NAME` (lines 10 and 21) with your bucket name.
 
-5. Name your policy and select **Create policy**.
+1.  Name your policy and select **Create policy**.
 
 ### Compute Environment
 
 To create a new compute environment for AWS Batch (without Forge):
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g. "AWS Batch Manual (eu-west-1)".
+1.  Enter a descriptive name for this environment, e.g. "AWS Batch Manual (eu-west-1)".
 
-3. Select **Amazon Batch** as the target platform.
+1.  Select **Amazon Batch** as the target platform.
 
-4. Add new credentials by selecting the **+** button.
+1.  Add new credentials by selecting the **+** button.
 
-5. Enter a name for the credentials, e.g. "AWS Credentials".
+1.  Enter a name for the credentials, e.g. "AWS Credentials".
 
-6. Enter the **Access key** and **Secret key** for your IAM user.
+1.  Enter the **Access key** and **Secret key** for your IAM user.
 
    :::tip
    You can create multiple credentials in your Tower environment. See the [Credentials](../credentials/overview.mdx) section.
    :::
 
-7. Select a **Region**, e.g. "eu-west-1 - Europe (Ireland)"
+1.  Select a **Region**, e.g. "eu-west-1 - Europe (Ireland)"
 
-8. Enter an S3 bucket path for the **Pipeline work directory**, for example `s3://tower-bucket`
+1.  Enter an S3 bucket path for the **Pipeline work directory**, for example `s3://tower-bucket`
 
-9. Set the **Config mode** to **Manual**.
+1.  Set the **Config mode** to **Manual**.
 
-10. Enter the **Head queue**, which is the name of the AWS Batch queue that the Nextflow driver job will run.
+1.  Enter the **Head queue**, which is the name of the AWS Batch queue that the Nextflow driver job will run.
 
-11. Enter the **Compute queue**, which is the name of the AWS Batch queue that tasks will be submitted to.
+1.  Enter the **Compute queue**, which is the name of the AWS Batch queue that tasks will be submitted to.
 
-12. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [Launching Pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-22.4.0/compute-envs/azure-batch.mdx
+++ b/platform_versioned_docs/version-22.4.0/compute-envs/azure-batch.mdx
@@ -20,9 +20,9 @@ This guide assumes you have an existing [Azure Account](https://azure.microsoft.
 
 There are two ways to create a **Compute Environment** for **Azure Batch** with Tower.
 
-1. **Batch Forge**: This option automatically manages the Azure Batch resources in your Azure account.
+1.  **Batch Forge**: This option automatically manages the Azure Batch resources in your Azure account.
 
-2. **Manual**: This option allows you to create a compute environment using existing Azure Batch resources.
+1.  **Manual**: This option allows you to create a compute environment using existing Azure Batch resources.
 
 If you don't yet have an Azure Batch environment fully set up, follow the [Batch Forge](#tower-forge) guide to do so.
 
@@ -40,13 +40,13 @@ To create the necessary Azure Batch and Azure Storage accounts, we must first cr
 
 When you open [this link](https://portal.azure.com/#create/Microsoft.ResourceGroup), you'll notice the **Create new resource group** dialogue.
 
-1. Enter a name for the resource group (e.g. `towerrg`).
+1.  Enter a name for the resource group (e.g. `towerrg`).
 
-2. Select the preferred region for this resource group.
+1.  Select the preferred region for this resource group.
 
-3. Select **Review and Create** to proceed to the review screen.
+1.  Select **Review and Create** to proceed to the review screen.
 
-4. Select **Create** to create the resources.
+1.  Select **Create** to create the resources.
 
 ### Storage account
 
@@ -54,23 +54,23 @@ The next step is to create the necessary Azure Storage.
 
 When you open [this link](https://portal.azure.com/#blade/HubsExtension/BrowseResource/resourceType/Microsoft.Storage%2FStorageAccounts), you'll notice the **Create a storage account** dialogue.
 
-1. Enter a name for the storage account (e.g. `towerrgstorage`).
+1.  Enter a name for the storage account (e.g. `towerrgstorage`).
 
-2. Select the preferred region for this resource group.
+1.  Select the preferred region for this resource group.
 
-3. Select **Review and Create** to proceed to the review screen.
+1.  Select **Review and Create** to proceed to the review screen.
 
-4. Select **Create** to create the Azure Storage account.
+1.  Select **Create** to create the Azure Storage account.
 
-5. Navigate to your new storage account and select **Container**.
+1.  Navigate to your new storage account and select **Container**.
 
-6. Create a new Blob container by selecting **+ Container**.
+1.  Create a new Blob container by selecting **+ Container**.
 
    A new container dialogue will open. Enter a suitable name (e.g. `towerrgstorage-container`).
 
-7. Once the new Blob container is created, navigate to the **Access Keys** section of the storage account (`towerrgstorage` in this example).
+1.  Once the new Blob container is created, navigate to the **Access Keys** section of the storage account (`towerrgstorage` in this example).
 
-8. Store the access keys for the newly created Azure Storage account.
+1.  Store the access keys for the newly created Azure Storage account.
 
    :::note
    Blob container storage credentials are associated with the Batch pool configuration when it is created. Once your compute environment has been created with Batch Forge, these credentials should not be changed in Tower.
@@ -82,13 +82,13 @@ The next step is to create the necessary Batch account.
 
 When you open [this link](https://portal.azure.com/#blade/HubsExtension/BrowseResource/resourceType/Microsoft.Batch%2FbatchAccounts), you'll notice the **Create a batch account** dialogue.
 
-1. Enter a name for the storage account (e.g. `towerrgbatch`).
+1.  Enter a name for the storage account (e.g. `towerrgbatch`).
 
-2. Select the preferred region for this resource group.
+1.  Select the preferred region for this resource group.
 
-3. Select **Review and Create** to proceed to the review screen.
+1.  Select **Review and Create** to proceed to the review screen.
 
-4. Select **Create** to create the Azure Batch account.
+1.  Select **Create** to create the Azure Batch account.
 
 ### Compute Environment
 
@@ -96,19 +96,19 @@ Batch Forge automates the configuration of an [Azure Batch](https://azure.micros
 
 Once the Azure resources are set up, we can add a new **Azure Batch** environment in Tower. To create a new compute environment:
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g. "Azure Batch (east-us)"
+1.  Enter a descriptive name for this environment, e.g. "Azure Batch (east-us)"
 
-3. Select **Azure Batch** as the target platform.
+1.  Select **Azure Batch** as the target platform.
 
    ![](./_images/azure_new_env_name.png)
 
-4. From the **Credentials** drop-down, select existing Azure credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing Azure credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
 
-5. Enter a name, e.g. "Azure Credentials".
+1.  Enter a name, e.g. "Azure Credentials".
 
-6. Add the **Batch account** and **Blob Storage** credentials that we created previously.
+1.  Add the **Batch account** and **Blob Storage** credentials that we created previously.
 
    ![](./_images/azure_keys.png)
 
@@ -120,29 +120,29 @@ Once the Azure resources are set up, we can add a new **Azure Batch** environmen
    From version 22.3, Tower supports the use of credentials for container registry services. These credentials can be created from the [Credentials](../credentials/overview.mdx/#container-registry-credentials) tab.
    :::
 
-7. Select a **Region**, for example "eastus (East US)".
+1.  Select a **Region**, for example "eastus (East US)".
 
-8. Enter the **Pipeline work directory** as the Azure blob container we created in the previous section, e.g. `az://towerrgstorage-container/work`.
+1.  Enter the **Pipeline work directory** as the Azure blob container we created in the previous section, e.g. `az://towerrgstorage-container/work`.
 
    :::caution
    The blob container should be in the same **Region** from the previous step.
    :::
 
-9. Set the **Config mode** to **Batch Forge**.
+1.  Set the **Config mode** to **Batch Forge**.
 
    ![](./_images/azure_tower_forge.png)
 
-10. Enter the default VM type depending on your quota limits. The default is `Standard_D4_v3`.
+1.  Enter the default VM type depending on your quota limits. The default is `Standard_D4_v3`.
 
-11. Enter the **VMs count**, which is the number of VMs you'd like to deploy.
+1.  Enter the **VMs count**, which is the number of VMs you'd like to deploy.
 
-12. Enable **Autoscale** if you'd like to automatically scale up and down based on the number of tasks. The number of VMs will vary from **0** to **VMs count**.
+1.  Enable **Autoscale** if you'd like to automatically scale up and down based on the number of tasks. The number of VMs will vary from **0** to **VMs count**.
 
-13. Enable **Dispose resources** if you'd like Tower to automatically delete the Batch pool once the workflow is complete.
+1.  Enable **Dispose resources** if you'd like Tower to automatically delete the Batch pool once the workflow is complete.
 
-14. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-15. Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
+1.  Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
 
     ![](./_images/azure_newly_created_env.png)
 
@@ -160,19 +160,19 @@ This section is for users with a pre-configured Azure environment. You will need
 
 To create a new compute environment for AWS Batch (without Forge):
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g. "Azure Batch (east-us)"
+1.  Enter a descriptive name for this environment, e.g. "Azure Batch (east-us)"
 
-3. Select **Azure Batch** as the target platform.
+1.  Select **Azure Batch** as the target platform.
 
    ![](./_images/azure_new_env_name.png)
 
-4. Select your Azure credentials or add new credentials by selecting the **+** button.
+1.  Select your Azure credentials or add new credentials by selecting the **+** button.
 
-5. Enter a name, e.g. "Azure Credentials".
+1.  Enter a name, e.g. "Azure Credentials".
 
-6. Add the **Batch account** and **Blob Storage** credentials that we created previously.
+1.  Add the **Batch account** and **Blob Storage** credentials that we created previously.
 
    ![](./_images/azure_keys.png)
 
@@ -180,25 +180,25 @@ To create a new compute environment for AWS Batch (without Forge):
    You can create multiple credentials in your Tower environment.
    :::
 
-7. Select a **Region**, for example "eastus (East US)".
+1.  Select a **Region**, for example "eastus (East US)".
 
-8. Enter the **Pipeline work directory** as the Azure blob container we created in the previous section, e.g. `az://towerrgstorage-container/work`.
+1.  Enter the **Pipeline work directory** as the Azure blob container we created in the previous section, e.g. `az://towerrgstorage-container/work`.
 
    :::caution
    The blob container should be in the same **Region** you specified in step 7 above.
    :::
 
-9. Set the **Config mode** to **Manual**.
+1.  Set the **Config mode** to **Manual**.
 
-10. Enter the **Compute Pool name**, the name of the Azure Batch pool provided to you by your Azure administrator.
+1.  Enter the **Compute Pool name**, the name of the Azure Batch pool provided to you by your Azure administrator.
 
     ![](./_images/azure_tower_manual.png)
 
-11. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-12. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-13. Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
+1.  Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
 
     ![](./_images/azure_newly_created_env.png)
 

--- a/platform_versioned_docs/version-22.4.0/compute-envs/eks.mdx
+++ b/platform_versioned_docs/version-22.4.0/compute-envs/eks.mdx
@@ -54,13 +54,13 @@ For more details, refer to the [AWS documentation](https://docs.aws.amazon.com/e
 
 ### Compute Environment
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g. "Amazon EKS (eu-west-1)".
+1.  Enter a descriptive name for this environment, e.g. "Amazon EKS (eu-west-1)".
 
-3. Select **Amazon EKS** as the target platform.
+1.  Select **Amazon EKS** as the target platform.
 
-4. From the **Credentials** drop-down, select existing AWS credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing AWS credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
 
    :::note
    Make sure the user has the IAM permissions required to describe and list EKS clusters as explained [here](#requirements).
@@ -70,21 +70,21 @@ For more details, refer to the [AWS documentation](https://docs.aws.amazon.com/e
    From version 22.3, Tower supports the use of credentials for container registry services. These credentials can be created from the [Credentials](../credentials/overview.mdx/#container-registry-credentials) tab.
    :::
 
-5. Select a **Region**, for example "eu-west-1 - Europe (Ireland)".
+1.  Select a **Region**, for example "eu-west-1 - Europe (Ireland)".
 
-6. Select a **Cluster name** from the list of available EKS clusters in the selected region.
+1.  Select a **Cluster name** from the list of available EKS clusters in the selected region.
 
-7. Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-nf` by default.
+1.  Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-nf` by default.
 
-8. Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
+1.  Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
 
-9. Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. In each of the provided examples, the storage claim is called `tower-scratch`.
+1.  Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. In each of the provided examples, the storage claim is called `tower-scratch`.
 
-10. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-11. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-12. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [Launching Pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-22.4.0/compute-envs/gke.mdx
+++ b/platform_versioned_docs/version-22.4.0/compute-envs/gke.mdx
@@ -42,17 +42,17 @@ For more details, refer to the [Google documentation](https://cloud.google.com/k
 
 ### Compute Environment
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g. "Google GKE (europe-west1)".
+1.  Enter a descriptive name for this environment, e.g. "Google GKE (europe-west1)".
 
-3. From the **Provider** drop-down, select **Google GKE**.
+1.  From the **Provider** drop-down, select **Google GKE**.
 
-4. From the **Credentials** drop-down, select existing GKE credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing GKE credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
 
-5. Enter a name for the credentials, e.g. "GKE Credentials".
+1.  Enter a name for the credentials, e.g. "GKE Credentials".
 
-6. Enter the **Service account key** for your Google Service account.
+1.  Enter the **Service account key** for your Google Service account.
 
    :::tip
    You can create multiple credentials in your Tower environment.
@@ -62,7 +62,7 @@ For more details, refer to the [Google documentation](https://cloud.google.com/k
    From version 22.3, Tower supports the use of credentials for container registry services. These credentials can be created from the [Credentials](../credentials/overview.mdx/#container-registry-credentials.mdx) tab.
    :::
 
-7. Select the **Location** of your GKE cluster.
+1.  Select the **Location** of your GKE cluster.
 
    :::caution
    GKE clusters can be either _regional_ or _zonal_. For example, `us-west1` identifies the United States West-Coast region, which has three zones: `us-west1-a`, `us-west1-b`, and `us-west1-c`.
@@ -71,19 +71,19 @@ For more details, refer to the [Google documentation](https://cloud.google.com/k
    ![](./_images/gke_regions.png)
    :::
 
-8. Select or enter the **Cluster name** of your GKE cluster.
+1.  Select or enter the **Cluster name** of your GKE cluster.
 
-9. Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-nf` by default.
+1.  Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-nf` by default.
 
-10. Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
+1.  Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
 
-11. Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. In each of the provided examples, the storage claim is called `tower-scratch`.
+1.  Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. In each of the provided examples, the storage claim is called `tower-scratch`.
 
-12. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [Launching Pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-22.4.0/compute-envs/google-cloud-batch.mdx
+++ b/platform_versioned_docs/version-22.4.0/compute-envs/google-cloud-batch.mdx
@@ -15,9 +15,9 @@ Tower provides integration to Google Cloud via the [Batch API](https://cloud.goo
 
 The guide is split into two parts:
 
-1. How to configure your Google Cloud account to use the Batch API.
+1.  How to configure your Google Cloud account to use the Batch API.
 
-2. How to create a Google Cloud Batch compute environment in Tower.
+1.  How to create a Google Cloud Batch compute environment in Tower.
 
 ### Configure Google Cloud
 
@@ -53,15 +53,15 @@ Alternatively, you can enable each API manually by selecting your project in the
 
 #### Create a service account key
 
-1. In the navigation menu, select **IAM & Admin** and then **Service Accounts**.
+1.  In the navigation menu, select **IAM & Admin** and then **Service Accounts**.
 
-2. Select the email address of the **Compute Engine default service account**.
+1.  Select the email address of the **Compute Engine default service account**.
 
-3. Select **Keys**, then **Add key**, then **Create new key**.
+1.  Select **Keys**, then **Add key**, then **Create new key**.
 
-4. Select **JSON** as the key type.
+1.  Select **JSON** as the key type.
 
-5. Select **Create**.
+1.  Select **Create**.
 
 A JSON file will be downloaded to your computer. This file contains the credential that will be used by Tower. You will need it to configure the compute environment in Tower.
 
@@ -69,33 +69,33 @@ You can manage your key from the **Service Accounts** page.
 
 #### Create a Cloud Storage bucket
 
-1. In the navigation menu (**≡**), select **Cloud Storage** and then **Create bucket**.
+1.  In the navigation menu (**≡**), select **Cloud Storage** and then **Create bucket**.
 
-2. Enter a name for your bucket. You will reference this name when creating the compute environment in Tower.
+1.  Enter a name for your bucket. You will reference this name when creating the compute environment in Tower.
 
    :::caution
    Do not use underscores (`_`) in your bucket name. Use hyphens (`-`) instead.
    :::
 
-3. Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Tower.
+1.  Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Tower.
 
-4. Select **Standard** for the default storage class.
+1.  Select **Standard** for the default storage class.
 
-5. Select **Uniform** for the **Access control**.
+1.  Select **Uniform** for the **Access control**.
 
    :::note
    The Batch API is available in a limited number of [locations](https://cloud.google.com/batch/docs/locations). However, these locations are only used to store metadata about the pipeline operations. The storage bucket and compute resources can be in any region.
    :::
 
-6. Select **Create**.
+1.  Select **Create**.
 
-7. Once the bucket is created, you will be redirected to the **Bucket details** page.
+1.  Once the bucket is created, you will be redirected to the **Bucket details** page.
 
-8. Select **Permissions**, then **+ Add**.
+1.  Select **Permissions**, then **+ Add**.
 
-9. Copy the email address of the Compute Engine default service account into **New principals**.
+1.  Copy the email address of the Compute Engine default service account into **New principals**.
 
-10. Select the following roles:
+1.  Select the following roles:
 
 - Storage Admin
 - Storage Legacy Bucket Owner
@@ -114,29 +114,29 @@ The following guide to configure Tower assumes you have (1) a service account ke
 
 To create a new compute environment for Google Cloud in Tower:
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g. "Google Cloud Batch (europe-north1)".
+1.  Enter a descriptive name for this environment, e.g. "Google Cloud Batch (europe-north1)".
 
-3. Select **Google Cloud Batch** as the target platform.
+1.  Select **Google Cloud Batch** as the target platform.
 
-4. Add new credentials by selecting the **+** button.
+1.  Add new credentials by selecting the **+** button.
 
-5. Enter a name for the credentials, e.g. "Google Cloud Credentials".
+1.  Enter a name for the credentials, e.g. "Google Cloud Credentials".
 
-6. Enter the **Service account key** for your Google Cloud account. This key was created in the [previous section](#create-a-service-account-key).
+1.  Enter the **Service account key** for your Google Cloud account. This key was created in the [previous section](#create-a-service-account-key).
 
-7. Select the [**Location**](https://cloud.google.com/compute/docs/regions-zones#available) where you'd like to execute pipelines.
+1.  Select the [**Location**](https://cloud.google.com/compute/docs/regions-zones#available) where you'd like to execute pipelines.
 
-8. Enter your bucket URL for the **Pipeline work directory**. The URL is the name of your bucket with the `gs://` prefix, e.g. `gs://my-bucket`. This bucket should be accessible in the region selected in the previous step.
+1.  Enter your bucket URL for the **Pipeline work directory**. The URL is the name of your bucket with the `gs://` prefix, e.g. `gs://my-bucket`. This bucket should be accessible in the region selected in the previous step.
 
-9. You can enable **Spot** to use spot instances, which have significantly reduced cost compared to on-demand instances.
+1.  You can enable **Spot** to use spot instances, which have significantly reduced cost compared to on-demand instances.
 
-10. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-11. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-12. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [Launching Pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-22.4.0/compute-envs/google-cloud-lifesciences.mdx
+++ b/platform_versioned_docs/version-22.4.0/compute-envs/google-cloud-lifesciences.mdx
@@ -11,9 +11,9 @@ Tower provides integration to Google Cloud via the [Cloud Life Sciences API](htt
 
 The guide is split into two parts:
 
-1. How to configure your Google Cloud account to use the Cloud Life Sciences API.
+1.  How to configure your Google Cloud account to use the Cloud Life Sciences API.
 
-2. How to create a Google Life Sciences compute environment in Tower.
+1.  How to create a Google Life Sciences compute environment in Tower.
 
 ### Configure Google Cloud
 
@@ -49,15 +49,15 @@ Alternatively, you can enable each API manually by selecting your project in the
 
 #### Create a service account key
 
-1. In the navigation menu, select **IAM & Admin** and then **Service Accounts**.
+1.  In the navigation menu, select **IAM & Admin** and then **Service Accounts**.
 
-2. Select the email address of the **Compute Engine default service account**.
+1.  Select the email address of the **Compute Engine default service account**.
 
-3. Select **Keys**, then **Add key**, then **Create new key**.
+1.  Select **Keys**, then **Add key**, then **Create new key**.
 
-4. Select **JSON** as the key type.
+1.  Select **JSON** as the key type.
 
-5. Select **Create**.
+1.  Select **Create**.
 
 A JSON file will be downloaded to your computer. This file contains the credential that will be used by Tower. You will need it to configure the compute environment in Tower.
 
@@ -65,33 +65,33 @@ You can manage your key from the **Service Accounts** page.
 
 #### Create a Cloud Storage bucket
 
-1. In the navigation menu (**≡**), select **Cloud Storage** and then **Create bucket**.
+1.  In the navigation menu (**≡**), select **Cloud Storage** and then **Create bucket**.
 
-2. Enter a name for your bucket. You will reference this name when creating the compute environment in Tower.
+1.  Enter a name for your bucket. You will reference this name when creating the compute environment in Tower.
 
    :::caution
    Do not use underscores (`_`) in your bucket name. Use hyphens (`-`) instead.
    :::
 
-3. Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Tower.
+1.  Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Tower.
 
-4. Select **Standard** for the default storage class.
+1.  Select **Standard** for the default storage class.
 
-5. Select **Uniform** for the **Access control**.
+1.  Select **Uniform** for the **Access control**.
 
    :::note
    The Cloud Life Sciences API is available in a limited number of [locations](https://cloud.google.com/life-sciences/docs/concepts/locations). However, these locations are only used to store metadata about the pipeline operations. The storage bucket and compute resources can be in any region.
    :::
 
-6. Select **Create**.
+1.  Select **Create**.
 
-7. Once the bucket is created, you will be redirected to the **Bucket details** page.
+1.  Once the bucket is created, you will be redirected to the **Bucket details** page.
 
-8. Select **Permissions**, then **+ Add**.
+1.  Select **Permissions**, then **+ Add**.
 
-9. Copy the email address of the Compute Engine default service account into **New principals**.
+1.  Copy the email address of the Compute Engine default service account into **New principals**.
 
-10. Select the following roles:
+1.  Select the following roles:
 
 - Storage Admin
 - Storage Legacy Bucket Owner
@@ -106,17 +106,17 @@ The following guide to configure Tower assumes you have (1) a service account ke
 
 To create a new compute environment for Google Cloud in Tower:
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g. "Google Life Sciences (europe-west2)".
+1.  Enter a descriptive name for this environment, e.g. "Google Life Sciences (europe-west2)".
 
-3. Select **Google Life Sciences** as the target platform.
+1.  Select **Google Life Sciences** as the target platform.
 
-4. From the **Credentials** drop-down, select existing Google Cloud credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing Google Cloud credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
 
-5. Enter a name for the credentials, e.g. "Google Cloud Credentials".
+1.  Enter a name for the credentials, e.g. "Google Cloud Credentials".
 
-6. Enter the **Service account key** for your Google Cloud account. This key was created in the [previous section](#create-a-service-account-key).
+1.  Enter the **Service account key** for your Google Cloud account. This key was created in the [previous section](#create-a-service-account-key).
 
    :::tip
    You can create multiple credentials in your Tower workspace.
@@ -126,19 +126,19 @@ To create a new compute environment for Google Cloud in Tower:
    From version 22.3, Tower supports the use of credentials for container registry services. These credentials can be created from the [Credentials](../credentials/overview.mdx/#container-registry-credentials) tab.
    :::
 
-7. Select the [**Region** and **Zones**](https://cloud.google.com/compute/docs/regions-zones#available) where you'd like to execute pipelines. You can leave the **Location** empty and the Cloud Life Sciences API will use the closest available location.
+1.  Select the [**Region** and **Zones**](https://cloud.google.com/compute/docs/regions-zones#available) where you'd like to execute pipelines. You can leave the **Location** empty and the Cloud Life Sciences API will use the closest available location.
 
-8. Enter your bucket URL for the **Pipeline work directory**. The URL is the name of your bucket with the `gs://` prefix, e.g. `gs://my-bucket`. This bucket should be accessible in the region selected in the previous step.
+1.  Enter your bucket URL for the **Pipeline work directory**. The URL is the name of your bucket with the `gs://` prefix, e.g. `gs://my-bucket`. This bucket should be accessible in the region selected in the previous step.
 
-9. You can enable **Preemptible** to use preemptible instances, which have significantly reduced cost compared to on-demand instances.
+1.  You can enable **Preemptible** to use preemptible instances, which have significantly reduced cost compared to on-demand instances.
 
-10. You can use a **Filestore file system** to automatically mount a Google Filestore volume in your pipelines.
+1.  You can use a **Filestore file system** to automatically mount a Google Filestore volume in your pipelines.
 
-11. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-12. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-13. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [Launching Pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-22.4.0/compute-envs/k8s.mdx
+++ b/platform_versioned_docs/version-22.4.0/compute-envs/k8s.mdx
@@ -15,13 +15,13 @@ The following instructions are for a **generic Kubernetes** distribution. If you
 
 This section describes the steps required to prepare your Kubernetes cluster for the deployment of Nextflow pipelines using Tower. It is assumed the cluster itself has already been created and you have administrative privileges.
 
-1. Verify the connection to your Kubernetes cluster:
+1.  Verify the connection to your Kubernetes cluster:
 
    ```bash
    kubectl cluster-info
    ```
 
-2. Create the Tower launcher:
+1.  Create the Tower launcher:
 
    ```bash
    kubectl apply -f https://help.tower.nf/22.1/_templates/k8s/tower-launcher.yml
@@ -29,7 +29,7 @@ This section describes the steps required to prepare your Kubernetes cluster for
 
    This command creates a service account called `tower-launcher-sa`, and associated role bindings. Everything is contained in a namespace called `tower-nf`. The service account is used by Tower to launch Nextflow pipelines. Use this service account name when setting up the compute environment for this Kubernetes cluster in Tower.
 
-3. Create persistent storage. Tower requires a `ReadWriteMany` persistent volume claim (PVC) that is mounted by all nodes where workflow pods will be dispatched.
+1.  Create persistent storage. Tower requires a `ReadWriteMany` persistent volume claim (PVC) that is mounted by all nodes where workflow pods will be dispatched.
 
    You can use any storage solution that supports the `ReadWriteMany` [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes). The setup of this storage is beyond the scope of these instructions, because the right solution for you will depend on what is available for your infrastructure or cloud vendor (NFS, GlusterFS, CephFS, Amazon FSx, etc). Ask your cluster administrator for more information.
 
@@ -39,17 +39,17 @@ This section describes the steps required to prepare your Kubernetes cluster for
 
 ### Compute Environment
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g. "K8s cluster".
+1.  Enter a descriptive name for this environment, e.g. "K8s cluster".
 
-3. Select **Kubernetes** as the target platform.
+1.  Select **Kubernetes** as the target platform.
 
-4. Select your Kubernetes credentials or add new credentials by selecting the **+** button.
+1.  Select your Kubernetes credentials or add new credentials by selecting the **+** button.
 
-5. Enter a name, e.g. "K8s Credentials".
+1.  Enter a name, e.g. "K8s Credentials".
 
-6. Enter the **Service account token**.
+1.  Enter the **Service account token**.
 
    The token can be obtained with the following command:
 
@@ -60,7 +60,7 @@ This section describes the steps required to prepare your Kubernetes cluster for
 
    Replace `<SERVICE-ACCOUNT-NAME>` with the name of the service account created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
 
-7. Enter the **Master server** URL.
+1.  Enter the **Master server** URL.
 
    The master server URL can be obtained with the following command:
 
@@ -70,21 +70,21 @@ This section describes the steps required to prepare your Kubernetes cluster for
 
    It can also be found in your `~/.kube/config` file under the `server` field corresponding to your cluster.
 
-8. Specify the **SSL Certificate** to authenticate your connection.
+1.  Specify the **SSL Certificate** to authenticate your connection.
 
    The certificate data can be found in your `~/.kube/config` file. It is the `certificate-authority-data` field corresponding to your cluster.
 
-9. Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-nf` by default.
+1.  Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-nf` by default.
 
-10. Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
+1.  Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
 
-11. Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. In each of the provided examples, the storage claim is called `tower-scratch`.
+1.  Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. In each of the provided examples, the storage claim is called `tower-scratch`.
 
-12. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [Launching Pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-22.4.0/compute-envs/lsf.mdx
+++ b/platform_versioned_docs/version-22.4.0/compute-envs/lsf.mdx
@@ -23,33 +23,33 @@ To create a new compute environment for **LSF** in Tower:
 
 1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2.  Enter a descriptive name for this environment, e.g. "LSF".
+1.  Enter a descriptive name for this environment, e.g. "LSF".
 
-3.  Select **IBM LSF** as the target platform.
+1.  Select **IBM LSF** as the target platform.
 
-4.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5.  Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6.  Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8.  Enter the **Login hostname**, which is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**, which is usually the hostname or public IP address of the cluster's login node.
 
-9.  Enter the **Head queue name**, the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**, the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**, the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**, the cluster queue to which the Nextflow job will submit tasks.
 
     :::tip
     The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [docs](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
     :::
 
-11. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-12. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-13. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [Launching Pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-22.4.0/compute-envs/moab.mdx
+++ b/platform_versioned_docs/version-22.4.0/compute-envs/moab.mdx
@@ -23,33 +23,33 @@ To create a new compute environment for **Moab** in Tower:
 
 1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2.  Enter a descriptive name for this environment, e.g. "Moab cluster".
+1.  Enter a descriptive name for this environment, e.g. "Moab cluster".
 
-3.  Select **Moab Workload Manager** as the target platform.
+1.  Select **Moab Workload Manager** as the target platform.
 
-4.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5.  Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6.  Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8.  If using SSH credentials, enter the **Login hostname**, which is usually the hostname or public IP address of the cluster's login node.
+1.  If using SSH credentials, enter the **Login hostname**, which is usually the hostname or public IP address of the cluster's login node.
 
-9.  Enter the **Head queue name**, the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**, the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**, the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**, the cluster queue to which the Nextflow job will submit tasks.
 
     :::tip
     The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [docs](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
     :::
 
-11. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-12. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-13. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [Launching Pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-22.4.0/compute-envs/overview.mdx
+++ b/platform_versioned_docs/version-22.4.0/compute-envs/overview.mdx
@@ -28,9 +28,9 @@ Each compute environment must be configured to enable Tower to submit tasks. See
 
 If you have more than one compute environment, you can select which one will be used by default when launching a pipeline.
 
-1. In a workspace, select **Compute Environments**.
+1.  In a workspace, select **Compute Environments**.
 
-2. Select **Make primary** for a particular compute environment to make it your default.
+1.  Select **Make primary** for a particular compute environment to make it your default.
 
 ### GPU usage
 

--- a/platform_versioned_docs/version-22.4.0/compute-envs/slurm.mdx
+++ b/platform_versioned_docs/version-22.4.0/compute-envs/slurm.mdx
@@ -23,33 +23,33 @@ To create a new compute environment for **Slurm** in Tower:
 
 1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2.  Enter a descriptive name for this environment, e.g. "Slurm cluster".
+1.  Enter a descriptive name for this environment, e.g. "Slurm cluster".
 
-3.  Select **Slurm Workload Manager** as the target platform.
+1.  Select **Slurm Workload Manager** as the target platform.
 
-4.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5.  Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6.  Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8.  Enter the **Login hostname**, which is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**, which is usually the hostname or public IP address of the cluster's login node.
 
-9.  Enter the **Head queue name**, the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**, the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**, the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**, the cluster queue to which the Nextflow job will submit tasks.
 
     :::tip
     The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [docs](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
     :::
 
-11. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-12. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-13. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [Launching Pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-22.4.0/credentials/aws_registry_credentials.mdx
+++ b/platform_versioned_docs/version-22.4.0/credentials/aws_registry_credentials.mdx
@@ -18,13 +18,13 @@ Wave requires programmatic access to your private registry via [long-term access
 
 An IAM administrator can create and manage access keys from the AWS management console:
 
-1. Open the [IAM console](https://console.aws.amazon.com/iam/).
-2. Select **Users** from the navigation pane.
-3. Select the name of the user whose keys you want to manage, then select the **Security credentials** tab. We recommend creating an IAM user specifically for Wave authentication instead of using existing credentials with broader permissions.
-4. In the **Access keys** section, select **Create access key**. Each IAM user can have only two access keys at a time, so if the Create option is deactivated, delete an existing access key first.
-5. On the **Access key best practices & alternatives** page, select **Other** and then **Next**.
-6. On the **Retrieve access key** page, you can either **Show** the user's secret access key details, or store them by selecting **Download .csv file**.
-7. The newly created access key pair is active by default and can be stored as a container registry credential in Tower.
+1.  Open the [IAM console](https://console.aws.amazon.com/iam/).
+1.  Select **Users** from the navigation pane.
+1.  Select the name of the user whose keys you want to manage, then select the **Security credentials** tab. We recommend creating an IAM user specifically for Wave authentication instead of using existing credentials with broader permissions.
+1.  In the **Access keys** section, select **Create access key**. Each IAM user can have only two access keys at a time, so if the Create option is deactivated, delete an existing access key first.
+1.  On the **Access key best practices & alternatives** page, select **Other** and then **Next**.
+1.  On the **Retrieve access key** page, you can either **Show** the user's secret access key details, or store them by selecting **Download .csv file**.
+1.  The newly created access key pair is active by default and can be stored as a container registry credential in Tower.
 
 :::note
 Your credential must be stored in Tower as a **container registry** credential, even if the same access keys already exist in Tower as a workspace credential.

--- a/platform_versioned_docs/version-22.4.0/credentials/azure_registry_credentials.mdx
+++ b/platform_versioned_docs/version-22.4.0/credentials/azure_registry_credentials.mdx
@@ -18,18 +18,18 @@ Azure container registry makes use of Azure RBAC (Role-Based Access Control) to 
 
 You must use Azure credentials with long-term registry read (**content/read**) access to authenticate Tower to your registry. We recommend a [token with repository-scoped permissions](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions) that is used only by Tower.
 
-1. In the Azure portal, navigate to your container registry.
-2. Under **Repository permissions**, select **Tokens -> +Add**.
-3. Enter a token name.
-4. Under **Scope map**, select **Create new**.
-5. In the **Create scope map** section, enter a name and description for the new scope map.
-6. Select your **Repository** from the drop-down menu.
-7. Select **content/read** from the **Permissions** drop-down menu, then select **Add** to create the scope map.
-8. In the **Create token** section, ensure the **Status** is **Enabled** (default), then select **Create**.
-9. Return to **Repository permissions -> Tokens** for your registry, then select the token you just created.
-10. On the token details page, select **password1** or **password2**.
-11. In the password details section, uncheck the **Set expiration date?** checkbox, then select **Generate**.
-12. Copy and save the password after it is generated. The password will be displayed only once.
+1.  In the Azure portal, navigate to your container registry.
+1.  Under **Repository permissions**, select **Tokens -> +Add**.
+1.  Enter a token name.
+1.  Under **Scope map**, select **Create new**.
+1.  In the **Create scope map** section, enter a name and description for the new scope map.
+1.  Select your **Repository** from the drop-down menu.
+1.  Select **content/read** from the **Permissions** drop-down menu, then select **Add** to create the scope map.
+1.  In the **Create token** section, ensure the **Status** is **Enabled** (default), then select **Create**.
+1.  Return to **Repository permissions -> Tokens** for your registry, then select the token you just created.
+1.  On the token details page, select **password1** or **password2**.
+1.  In the password details section, uncheck the **Set expiration date?** checkbox, then select **Generate**.
+1.  Copy and save the password after it is generated. The password will be displayed only once.
 
 ### Add credentials to Tower
 

--- a/platform_versioned_docs/version-22.4.0/credentials/docker_hub_registry_credentials.mdx
+++ b/platform_versioned_docs/version-22.4.0/credentials/docker_hub_registry_credentials.mdx
@@ -18,11 +18,11 @@ You must use Docker Hub credentials with **Read-only** access to authenticate To
 
 To create your access token in Docker Hub:
 
-1. Log in to [Docker Hub](https://hub.docker.com/).
-2. Select your username in the top right corner and select **Account Settings**.
-3. Select **Security -> New Access Token**.
-4. Enter a token description and select **Read-only** from the Access permissions drop-down menu, then select **Generate**.
-5. Copy and save the generated access token (this is only displayed once).
+1.  Log in to [Docker Hub](https://hub.docker.com/).
+1.  Select your username in the top right corner and select **Account Settings**.
+1.  Select **Security -> New Access Token**.
+1.  Enter a token description and select **Read-only** from the Access permissions drop-down menu, then select **Generate**.
+1.  Copy and save the generated access token (this is only displayed once).
 
 ### Add credentials to Tower
 

--- a/platform_versioned_docs/version-22.4.0/credentials/quay_registry_credentials.mdx
+++ b/platform_versioned_docs/version-22.4.0/credentials/quay_registry_credentials.mdx
@@ -16,12 +16,12 @@ Container registry credentials are only leveraged by the Wave containers service
 
 For Quay repositories, we recommend using [robot accounts](https://docs.quay.io/glossary/robot-accounts.html) with **Read** access permissions for authentication:
 
-1. Sign in to [quay.io](https://quay.io/).
-2. From the user or organization view, select the **Robot Accounts** tab.
-3. Select **Create Robot Account**.
-4. Enter a robot account name. The username for robot accounts have the format `namespace+accountname`, where `namespace` is the user or organization name and `accountname` is your chosen robot account name.
-5. Grant the robot account repository **Read** permissions from **Settings -> User and Robot Permissions** in the repository view.
-6. Select the robot account in your admin panel to retrieve the token value.
+1.  Sign in to [quay.io](https://quay.io/).
+1.  From the user or organization view, select the **Robot Accounts** tab.
+1.  Select **Create Robot Account**.
+1.  Enter a robot account name. The username for robot accounts have the format `namespace+accountname`, where `namespace` is the user or organization name and `accountname` is your chosen robot account name.
+1.  Grant the robot account repository **Read** permissions from **Settings -> User and Robot Permissions** in the repository view.
+1.  Select the robot account in your admin panel to retrieve the token value.
 
 ### Add credentials to Tower
 

--- a/platform_versioned_docs/version-22.4.0/credentials/ssh_credentials.mdx
+++ b/platform_versioned_docs/version-22.4.0/credentials/ssh_credentials.mdx
@@ -19,12 +19,12 @@ To use SSH public key authentication:
 
 To generate an SSH key pair:
 
-1. From the target machine, open a terminal and run `ssh-keygen`.
-2. Follow the prompts to:
+1.  From the target machine, open a terminal and run `ssh-keygen`.
+1.  Follow the prompts to:
    - specify a file path and name (or keep the default)
    - specify a passphrase (recommended)
-3. Navigate to the target folder (default `/home/user/.ssh/id_rsa`) and open the private key file with a plain text editor.
-4. Copy the private key file contents before navigating to Tower.
+1.  Navigate to the target folder (default `/home/user/.ssh/id_rsa`) and open the private key file with a plain text editor.
+1.  Copy the private key file contents before navigating to Tower.
 
 ### Create an SSH credential in Tower
 

--- a/platform_versioned_docs/version-22.4.0/datasets/overview.mdx
+++ b/platform_versioned_docs/version-22.4.0/datasets/overview.mdx
@@ -35,11 +35,11 @@ All Tower users have access to the datasets feature in organization workspaces.
 
 To create a new dataset, follow these steps:
 
-1. Open the **Datasets** tab in your organization workspace.
-2. Select **New dataset**.
-3. Complete the **Name** and **Description** fields using information relevant to your dataset.
-4. Add the dataset file to your workspace with drag-and-drop or the system file explorer dialog.
-5. For dataset files that use the first row for column names, customize the dataset view with the **First row as header** option.
+1.  Open the **Datasets** tab in your organization workspace.
+1.  Select **New dataset**.
+1.  Complete the **Name** and **Description** fields using information relevant to your dataset.
+1.  Add the dataset file to your workspace with drag-and-drop or the system file explorer dialog.
+1.  For dataset files that use the first row for column names, customize the dataset view with the **First row as header** option.
 
 :::caution
 The size of the dataset file cannot exceed 10MB.
@@ -49,9 +49,9 @@ The size of the dataset file cannot exceed 10MB.
 
 Datasets in Tower can accommodate multiple versions of a dataset. To add a new version for an existing dataset, follow these steps:
 
-1. Select **Edit** next to the dataset you wish to update.
-2. In the Edit dialog, select **Add a new version**.
-3. Upload the newer version of the dataset and select **Update**.
+1.  Select **Edit** next to the dataset you wish to update.
+1.  In the Edit dialog, select **Add a new version**.
+1.  Upload the newer version of the dataset and select **Update**.
 
 :::caution
 All subsequent versions of a dataset must be in the same format (.csv or .tsv) as the initial version.
@@ -61,9 +61,9 @@ All subsequent versions of a dataset must be in the same format (.csv or .tsv) a
 
 To use a dataset with the saved pipelines in your workspace, follow these steps:
 
-1. Open any pipeline that contains a pipeline-schema from the Launchpad.
-2. Select the input field for the pipeline, removing any default value.
-3. Pick the dataset to use as input to your pipeline.
+1.  Open any pipeline that contains a pipeline-schema from the Launchpad.
+1.  Select the input field for the pipeline, removing any default value.
+1.  Pick the dataset to use as input to your pipeline.
 
 :::note
 The datasets shown in the drop-down menu depend on the chosen format in your `pipeline-schema.json`. If the schema specifies `"mimetype": "text/csv"`, no TSV datasets will be available, and vice versa.

--- a/platform_versioned_docs/version-22.4.0/faqs.mdx
+++ b/platform_versioned_docs/version-22.4.0/faqs.mdx
@@ -12,10 +12,10 @@ description: "Frequestly Asked Questions"
 
 The Administration Console allows Tower instance administrators to interact with all users and organizations registered with the platform. Administrators must be identified in your Tower instance configuration files prior to instantiation of the application.
 
-1. Create a `TOWER_ROOT_USERS` environment variable (e.g. via _tower.env_ or Kubernetes ConfigMap).
-2. Populate the variable with a sequence of comma-delimited email addresses (no spaces).<br/>Example: `TOWER_ROOT_USERS=foo@foo.com,bar@bar.com`
-3. If using a Tower version earlier than 21.12:
-   1. Add the following configuration to _tower.yml_:
+1.  Create a `TOWER_ROOT_USERS` environment variable (e.g. via _tower.env_ or Kubernetes ConfigMap).
+1.  Populate the variable with a sequence of comma-delimited email addresses (no spaces).<br/>Example: `TOWER_ROOT_USERS=foo@foo.com,bar@bar.com`
+1.  If using a Tower version earlier than 21.12:
+   1.  Add the following configuration to _tower.yml_:
 
    ```yml
    tower:
@@ -23,8 +23,8 @@ The Administration Console allows Tower instance administrators to interact with
        root-users: "${TOWER_ROOT_USERS:[]}"
    ```
 
-4. Restart the `cron` and `backend` containers/Deployments.
-5. The console will now be available via your Profile drop-down menu.
+1.  Restart the `cron` and `backend` containers/Deployments.
+1.  The console will now be available via your Profile drop-down menu.
 
 ### API
 
@@ -54,11 +54,11 @@ One such value is `launch.id`; attempting to launch a pipeline without specifyin
 
 If you have encountered the 403 error as a result of being a Launch user who did not provide a `launch.id`, please try resolving the problem as follows:
 
-1. Provide the launch ID to the payload sent to the tower using the same endpoint. To do this;
+1.  Provide the launch ID to the payload sent to the tower using the same endpoint. To do this;
 
-   1. Query the list of pipelines via the `/pipelines` endpoint. Find the `pipelineId` of the pipeline you intend to launch.
-   2. Once you have the `pipelineId`, call the `/pipelines/{pipelineId}/launch` API to retrieve the pipeline's `launch.id`.
-   3. Include the `launch.id` in your call to the `/workflow/launch` API endpoint (see example below).
+   1.  Query the list of pipelines via the `/pipelines` endpoint. Find the `pipelineId` of the pipeline you intend to launch.
+   2.  Once you have the `pipelineId`, call the `/pipelines/{pipelineId}/launch` API to retrieve the pipeline's `launch.id`.
+   3.  Include the `launch.id` in your call to the `/workflow/launch` API endpoint (see example below).
 
       ```
       {
@@ -73,7 +73,7 @@ If you have encountered the 403 error as a result of being a Launch user who did
       }
       ```
 
-2. If a launch id remains unavailable to you, upgrade your user role to 'Maintain' or higher. This will allow you to execute quick launch-type pipeline invocations.
+1.  If a launch id remains unavailable to you, upgrade your user role to 'Maintain' or higher. This will allow you to execute quick launch-type pipeline invocations.
 
 ### Common Errors
 
@@ -89,9 +89,9 @@ Github imposes [rate limits](https://docs.github.com/en/rest/overview/resources-
 
 To resolve the problem, please try the following:
 
-1. Ensure there is at least one Github credential in your Workspace's Credentials tab.
-2. Ensure that the **Access token** field of all Github Credential objects is populated with a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) value, NOT a user password. (_Github PATs are typically several dozen characters long and begin with a `ghp_`prefix; example:`ghp*IqIMNOZH6zOwIEB4T9A2g4EHMy8Ji42q4HA`*)
-3. Confirm that your PAT is providing the elevated threshold and transactions are being charged against it:
+1.  Ensure there is at least one Github credential in your Workspace's Credentials tab.
+1.  Ensure that the **Access token** field of all Github Credential objects is populated with a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) value, NOT a user password. (_Github PATs are typically several dozen characters long and begin with a `ghp_`prefix; example:`ghp*IqIMNOZH6zOwIEB4T9A2g4EHMy8Ji42q4HA`*)
+1.  Confirm that your PAT is providing the elevated threshold and transactions are being charged against it:
 
    `curl -H "Authorization: token ghp_LONG_ALPHANUMERIC_PAT" -H "Accept: application/vnd.github.v3+json" https://api.github.com/rate_limit`
 
@@ -101,14 +101,14 @@ This error can occur if incorrect configuration values are assigned to the `back
 
 Please verify the following:
 
-1. The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `backend` container:
+1.  The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `backend` container:
    - Contains `prod,redis,ha`
    - Does not contain `cron`
-2. The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `cron` container:
+1.  The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `cron` container:
    - Contains `prod,redis,cron`
    - Does not contain `ha`
-3. You do not have another copy of the `MICRONAUT_ENVIRONMENTS` environment variable defined elsewhere in your application (e.g. a _tower.env_ file or Kubernetes ConfigMap).
-4. If you are using a separate container/pod to execute _migrate-db.sh_, there is no `MICRONAUT_ENVIRONMENTS` environment variable assigned to it.
+1.  You do not have another copy of the `MICRONAUT_ENVIRONMENTS` environment variable defined elsewhere in your application (e.g. a _tower.env_ file or Kubernetes ConfigMap).
+1.  If you are using a separate container/pod to execute _migrate-db.sh_, there is no `MICRONAUT_ENVIRONMENTS` environment variable assigned to it.
 
 **<p data-question>Q: Why do I get a `chmod: cannot access PATH/TO/bin/*: No such file or directory` exception?</p>**
 
@@ -179,8 +179,8 @@ Clients who use Amazon Aurora as their database solution may encounter a `java.s
 
 Please modify Tower Enterprise configuration as follows to try resolving the problem:
 
-1. Ensure your `TOWER_DB_DRIVER` uses the specified MariaDB URI.
-2. Modify your `TOWER_DB_URL` to: `TOWER_DB_URL=jdbc:mysql://YOUR_DOMAIN:YOUR_PORT/YOUR_TOWER_DB?usePipelineAuth=false&useBatchMultiSend=false`
+1.  Ensure your `TOWER_DB_DRIVER` uses the specified MariaDB URI.
+1.  Modify your `TOWER_DB_URL` to: `TOWER_DB_URL=jdbc:mysql://YOUR_DOMAIN:YOUR_PORT/YOUR_TOWER_DB?usePipelineAuth=false&useBatchMultiSend=false`
 
 ### Datasets
 
@@ -188,10 +188,10 @@ Please modify Tower Enterprise configuration as follows to try resolving the pro
 
 When uploading Datasets via the Tower UI or CLI, some steps are automatically done on your behalf. To upload Datasets via the TOwer API, additional steps are required:
 
-1. Explicitly define the MIME type of the file being uploaded.
-2. Make two calls to the API:
-   1. Create a Dataset object
-   2. Upload the samplesheet to the Dataset object.
+1.  Explicitly define the MIME type of the file being uploaded.
+1.  Make two calls to the API:
+   1.  Create a Dataset object
+   2.  Upload the samplesheet to the Dataset object.
 
 Example:
 
@@ -251,13 +251,13 @@ TLS connection errors can occur due to variability in the [default TLS version s
 
 To fix the problem, you can either:
 
-1. Set a JDK environment variable to force Nextflow and/or the Tower containers to use TLSv1.2 by default:
+1.  Set a JDK environment variable to force Nextflow and/or the Tower containers to use TLSv1.2 by default:
 
 ```
 export JAVA_OPTIONS="-Dmail.smtp.ssl.protocols=TLSv1.2"
 ```
 
-2. Add the following parameter to your nextflow.config file:
+1.  Add the following parameter to your nextflow.config file:
 
 ```
 mail {
@@ -332,17 +332,17 @@ The Azure AD app integrated with Tower must have user consent settings configure
 
 This can occur for several reasons. Please verify the following:
 
-1. Your `TOWER_SERVER_URL` environment variable uses the `https://` prefix.
-2. Your `tower.yml` has `micronaut.ssl.enabled` set to `true`.
-3. Any Load Balancer instance that sends traffic to the Tower application is configured to use HTTPS as its backend protocol rather than TCP.
+1.  Your `TOWER_SERVER_URL` environment variable uses the `https://` prefix.
+1.  Your `tower.yml` has `micronaut.ssl.enabled` set to `true`.
+1.  Any Load Balancer instance that sends traffic to the Tower application is configured to use HTTPS as its backend protocol rather than TCP.
 
 **<p data-question>Q: Why isn't my OIDC callback working?</p>**
 
 Callbacks could fail for many reasons. To more effectively investigate the problem:
 
-1. Set the Tower environment variable to `TOWER_SECURITY_LOGLEVEL=DEBUG`.
-2. Ensure your `TOWER_OIDC_CLIENT`, `TOWER_OIDC_SECRET`, and `TOWER_OIDC_ISSUER` environment variables all match the values specified in your OIDC provider's corresponding application.
-3. Ensure your network infrastructure allow necessary egress and ingress traffic.
+1.  Set the Tower environment variable to `TOWER_SECURITY_LOGLEVEL=DEBUG`.
+1.  Ensure your `TOWER_OIDC_CLIENT`, `TOWER_OIDC_SECRET`, and `TOWER_OIDC_ISSUER` environment variables all match the values specified in your OIDC provider's corresponding application.
+1.  Ensure your network infrastructure allow necessary egress and ingress traffic.
 
 **<p data-question>Q: Why did Google SMTP start returning `Username and Password not accepted` errors?</p>**
 Previously functioning Tower Enterprise email integration with Google SMTP are likely to encounter errors as of May 30, 2022 due to a [security posture change](https://support.google.com/accounts/answer/6010255#more-secure-apps-how&zippy=%2Cuse-more-secure-apps) implemented by Google.
@@ -376,7 +376,7 @@ Yes. You can mount the APM solution's JAR file in the `backend` container and se
 **<p data-question>Q: Is it possible to retrieve the trace file for a Tower-based workflow run?</p>**
 Yes. Although it is not possible to directly download the file via Tower, you can configure your workflow to export the file to persistent storage:
 
-1. Set the following block in your `nextflow.config`:
+1.  Set the following block in your `nextflow.config`:
 
 ```nextflow
 trace {
@@ -384,7 +384,7 @@ trace {
 }
 ```
 
-2. Add a copy command to your pipeline's **Advanced options > Post-run script** field:
+1.  Add a copy command to your pipeline's **Advanced options > Post-run script** field:
 
 ```
 # Example: Export the generated trace file to an S3 bucket
@@ -596,8 +596,8 @@ If you are restricted from using public container registries, please see Tower E
 
 Each Nextflow Tower release uses a specific nf-launcher image by default. This image is loaded with a specific Nextflow version, meaning that any workflow run in the container uses this Nextflow version by default. You can force your jobs to use a newer/older version of Nextflow with any of the following strategies:
 
-1. Use the **Pre-run script** advanced launch option to set the desired Nextflow version. Example: `export NXF_VER=22.08.0-edge`
-2. For jobs executing in an AWS Batch compute environment, create a [custom job definition](https://install.tower.nf/22.2/advanced-topics/custom-launch-container/) which references a different nf-launcher image.
+1.  Use the **Pre-run script** advanced launch option to set the desired Nextflow version. Example: `export NXF_VER=22.08.0-edge`
+1.  For jobs executing in an AWS Batch compute environment, create a [custom job definition](https://install.tower.nf/22.2/advanced-topics/custom-launch-container/) which references a different nf-launcher image.
 
 ### OIDC
 
@@ -677,8 +677,8 @@ This error can occur if the Nextflow head job fails to retrieve the necessary re
 
 To determine if this is the case, please do the following:
 
-1. Check your Nextflow log for an entry like `DEBUG nextflow.scm.RepositoryProvider - Request [credentials -:-]`.
-2. If the above is true, please check the protocol of the string that was assigned to your Tower instance's `TOWER_SERVER_URL` configuration value. It is possible this has been erroneously set to `http` rather than `https`.
+1.  Check your Nextflow log for an entry like `DEBUG nextflow.scm.RepositoryProvider - Request [credentials -:-]`.
+1.  If the above is true, please check the protocol of the string that was assigned to your Tower instance's `TOWER_SERVER_URL` configuration value. It is possible this has been erroneously set to `http` rather than `https`.
 
 ### Secrets
 
@@ -705,8 +705,8 @@ Users may encounter a few different errors when executing pipelines that use Sec
 
   To resolve the issue, please upgrade your Nextflow version to 22.08.0-edge. If you cannot upgrade, you can use the following as workarounds:
 
-  1. Use a different container image for each process.
-  2. Define the same set of Secrets in each process that uses the same container image.
+  1.  Use a different container image for each process.
+  2.  Define the same set of Secrets in each process that uses the same container image.
 
 ### Tower Agent
 
@@ -728,8 +728,8 @@ Yes. Provide a POSIX-compliant path to the `TOWER_CONFIG_FILE` environment varia
 
 There are two reasons why configurations specified in `tower.yml` are not being expressed by your Tower instance:
 
-1. There is a typo in one of the key value pairs.
-2. There is a duplicate key present in your file.
+1.  There is a typo in one of the key value pairs.
+1.  There is a duplicate key present in your file.
 
    ```yaml
    # EXAMPLE
@@ -765,8 +765,8 @@ You can force your Nextflow head job to use DSL2 syntax via any of the following
 
 Yes. As of v22.1, Nextflow Tower Enterprise can link to workflows stored in "local" git repositories. To do so:
 
-1. Volume mount your repository folder into the Tower Enterprise `backend` container.
-2. Update your `tower.yml` with the following configuration:
+1.  Volume mount your repository folder into the Tower Enterprise `backend` container.
+1.  Update your `tower.yml` with the following configuration:
 
 ```yml
 tower:
@@ -790,9 +790,9 @@ Activating the **Enable GPU** field while creating an AWS Batch environment with
 
 Note:
 
-1. Activation does not cause GPU-enabled instances to automatically spawn in your Batch cluster. You must still specify these in the Forge screen's **Advanced options > Instance types** field.
-2. Population of the Forge screen's **Advanced options > AMI Id** field will supersede the AWS-recommended AMI.
-3. Your Nextflow script must include [accelerator directives](https://www.nextflow.io/docs/latest/process.html?highlight=accelerator) to use the provisioned GPUs.
+1.  Activation does not cause GPU-enabled instances to automatically spawn in your Batch cluster. You must still specify these in the Forge screen's **Advanced options > Instance types** field.
+1.  Population of the Forge screen's **Advanced options > AMI Id** field will supersede the AWS-recommended AMI.
+1.  Your Nextflow script must include [accelerator directives](https://www.nextflow.io/docs/latest/process.html?highlight=accelerator) to use the provisioned GPUs.
 
 ### tw CLI
 
@@ -854,8 +854,8 @@ This problem will express itself with the following entry in your Nextflow log: 
 
 This can occur due to the following reasons:
 
-1. An access token value has been hardcoded in the `tower.accessToken` block of your `nextflow.config` (either via the git repository itself or override value in the launch form).
-2. In cases where your compute environment is an HPC cluster, the credentialized user's home directory contains a stateful `nextflow.config` with a hardcoded token (e.g. `~/.nextflow/config).
+1.  An access token value has been hardcoded in the `tower.accessToken` block of your `nextflow.config` (either via the git repository itself or override value in the launch form).
+1.  In cases where your compute environment is an HPC cluster, the credentialized user's home directory contains a stateful `nextflow.config` with a hardcoded token (e.g. `~/.nextflow/config).
 
 **<p data-question>Q: What privilege level is granted to a user assigned to a Workspace both as a Participant and Team member?</p>**
 
@@ -912,9 +912,9 @@ There are multiple reasons why your pipeline could fail with an `Essential conta
 
 Please try the following:
 
-1. [Upgrade your ECS Agent](https://github.com/aws/amazon-ecs-agent/releases) to [1.54.1](https://github.com/aws/amazon-ecs-agent/pull/2940) or newer ([instructions for checking your ECS Agent version](https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/ECS/latest-agent-version.html));
-2. Provision more storage space for your EC2 instance (preferably via ebs-autoscaling to ensure scalability).
-3. If the error is accompanied by `command exit status: 123` and a `permissions denied` error tied to a system command, please ensure that the binary is set to be executable (i.e. `chmod u+x`).
+1.  [Upgrade your ECS Agent](https://github.com/aws/amazon-ecs-agent/releases) to [1.54.1](https://github.com/aws/amazon-ecs-agent/pull/2940) or newer ([instructions for checking your ECS Agent version](https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/ECS/latest-agent-version.html));
+1.  Provision more storage space for your EC2 instance (preferably via ebs-autoscaling to ensure scalability).
+1.  If the error is accompanied by `command exit status: 123` and a `permissions denied` error tied to a system command, please ensure that the binary is set to be executable (i.e. `chmod u+x`).
 
 ### Queues
 
@@ -960,7 +960,7 @@ As of Nextflow Tower v21.12, you can specify an Amazon FSX for Lustre instance a
 
 If you need to save files to an S3 bucket protected by a [bucket policy which enforces AES256 server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html), additional configuration settings must be provided to the [nf-launcher](https://quay.io/repository/seqeralabs/nf-launcher?tab=tags) script which invokes the Nextflow head job:
 
-1. Add the following configuration to the **Advanced options > Nextflow config file** textbox of the **Launch Pipeline** screen:
+1.  Add the following configuration to the **Advanced options > Nextflow config file** textbox of the **Launch Pipeline** screen:
 
    ```
    aws {
@@ -970,7 +970,7 @@ If you need to save files to an S3 bucket protected by a [bucket policy which en
    }
    ```
 
-2. Add the following configuration to the **Advanced options > Pre-run script** textbox of the **Launch Pipeline** screen:
+1.  Add the following configuration to the **Advanced options > Pre-run script** textbox of the **Launch Pipeline** screen:
 
    ```bash
    export TOWER_AWS_SSE=AES256
@@ -1011,7 +1011,7 @@ This can occur if a tool/library in your task container requires SSL certificate
 
 You may be able to solve the issue by:
 
-1. Mounting host certificates into the container ([example](https://github.com/nextflow-io/nextflow/blob/v21.10.6/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy#L348-L351)).
+1.  Mounting host certificates into the container ([example](https://github.com/nextflow-io/nextflow/blob/v21.10.6/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy#L348-L351)).
 
 **<p data-question>Q: Why is my deployment using Azure SQL database returning an error about `Connections using insecure transport are prohibited while --require_secure_transport=ON.`</p>**
 
@@ -1039,10 +1039,10 @@ process {
 
 The following roles are needed to be granted to the `nextflow-service-account`.
 
-1. Cloud Life Sciences Workflows Runner
-2. Service Account User
-3. Service Usage Consumer
-4. Storage Object Admin
+1.  Cloud Life Sciences Workflows Runner
+1.  Service Account User
+1.  Service Usage Consumer
+1.  Storage Object Admin
 
 For detailed information, please refer to this [guide.](https://cloud.google.com/life-sciences/docs/tutorials/nextflow#create_a_service_account_and_add_roles)
 
@@ -1088,14 +1088,14 @@ Nextflow is trying to use the Java VM defined for the following environment vari
 
 Possible reasons for this error:
 
-1. The queue where the Nextflow head job runs in a different environment/node than your login node userspace.
-2. If your HPC cluster uses modules, the Java module may not be loaded by default.
+1.  The queue where the Nextflow head job runs in a different environment/node than your login node userspace.
+1.  If your HPC cluster uses modules, the Java module may not be loaded by default.
 
 To troubleshoot:
 
-1. Open an interactive session with the head job queue.
-2. Launch the Nextflow job from the interactive session.
-3. If you cluster used modules:
-   1. Add `module load <your_java_module>` in the **Advanced Features > Pre-run script** field when creating your HPC Compute Environment within Nextflow Tower.
-4. If you cluster does not use modules:
-   1. Source an environment with java and Nextflow using the **Advanced Features > Pre-run script** field when creating your HPC Compute Environment within Nextflow Tower.
+1.  Open an interactive session with the head job queue.
+1.  Launch the Nextflow job from the interactive session.
+1.  If you cluster used modules:
+   1.  Add `module load <your_java_module>` in the **Advanced Features > Pre-run script** field when creating your HPC Compute Environment within Nextflow Tower.
+1.  If you cluster does not use modules:
+   1.  Source an environment with java and Nextflow using the **Advanced Features > Pre-run script** field when creating your HPC Compute Environment within Nextflow Tower.

--- a/platform_versioned_docs/version-22.4.0/getting-started/usage.mdx
+++ b/platform_versioned_docs/version-22.4.0/getting-started/usage.mdx
@@ -7,11 +7,11 @@ You can use Tower through the web interface, the API, the CLI, or in Nextflow di
 
 ### Tower web interface
 
-1. Create an account and log in to Tower, available free of charge at [tower.nf](https://cloud.tower.nf).
+1.  Create an account and log in to Tower, available free of charge at [tower.nf](https://cloud.tower.nf).
 
-2. Create and configure a new [compute environment](../compute-envs/overview.mdx).
+1.  Create and configure a new [compute environment](../compute-envs/overview.mdx).
 
-3. Start [launching pipelines](../launch/launchpad.mdx).
+1.  Start [launching pipelines](../launch/launchpad.mdx).
 
 ### Tower API
 
@@ -23,17 +23,17 @@ See [CLI](../cli.mdx).
 
 ### Nextflow `-with-tower`
 
-1. Create an account and log in to Tower.
+1.  Create an account and log in to Tower.
 
-2. Create a new token. You can access your tokens from the **Settings** drop-down menu:
+1.  Create a new token. You can access your tokens from the **Settings** drop-down menu:
 
    ![](./_images/usage_create_token.png)
 
-3. Name your token.
+1.  Name your token.
 
    ![](./_images/usage_name_token.png)
 
-4. Store your token securely.
+1.  Store your token securely.
 
    ![](./_images/usage_token.png)
 
@@ -41,7 +41,7 @@ See [CLI](../cli.mdx).
 The token will only be displayed once. You must copy and save the token before closing the Personal Access Token window.
 :::
 
-5. Open a terminal and enter the following commands:
+1.  Open a terminal and enter the following commands:
 
    ```bash
    export TOWER_ACCESS_TOKEN=eyxxxxxxxxxxxxxxxQ1ZTE=
@@ -62,7 +62,7 @@ The token will only be displayed once. You must copy and save the token before c
    The workspace ID can be found on the organization workspaces overview page.
    :::
 
-6. Run your Nextflow pipeline with the `-with-tower` flag:
+1.  Run your Nextflow pipeline with the `-with-tower` flag:
 
    ```bash
    nextflow run hello.nf -with-tower

--- a/platform_versioned_docs/version-22.4.0/git/overview.mdx
+++ b/platform_versioned_docs/version-22.4.0/git/overview.mdx
@@ -37,13 +37,13 @@ All credentials are (AES-256) encrypted before secure storage and are not expose
 
 When your Tower instance has multiple stored credentials, selection of the most relevant credential for your repository takes precedence in the following order:
 
-1. Tower evaluates all the stored credentials available to the current Workspace.
+1.  Tower evaluates all the stored credentials available to the current Workspace.
 
-2. Credentials are filtered by Git provider (GitHub, GitLab, Bitbucket, etc.)
+1.  Credentials are filtered by Git provider (GitHub, GitLab, Bitbucket, etc.)
 
-3. Tower selects the credential with a **Repository base URL** most similar to the target repository.
+1.  Tower selects the credential with a **Repository base URL** most similar to the target repository.
 
-4. If no **Repository base URL** values are specified in the Workspace credentials, the the most long-lived credential is selected.
+1.  If no **Repository base URL** values are specified in the Workspace credentials, the the most long-lived credential is selected.
 
 **Example**:
 
@@ -97,17 +97,17 @@ For **fine-grained** tokens, the repository's organization must [opt in](https:/
 
 Once you have created and copied your access token, create a new credential in Tower using these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "GitHub" as the **Provider**.
+1.  Select "GitHub" as the **Provider**.
 
-5. Enter your **Username** and **Access token**.
+1.  Enter your **Username** and **Access token**.
 
-6. Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://github.com/seqeralabs`.
+1.  Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://github.com/seqeralabs`.
 
 ### GitLab
 
@@ -115,19 +115,19 @@ GitLab supports [Personal](https://docs.gitlab.com/ee/user/profile/personal_acce
 
 To connect Tower to a private [GitLab](https://gitlab.com/) repository:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "GitLab" as the **Provider**.
+1.  Select "GitLab" as the **Provider**.
 
-5. Enter your **Username**. For Group and Project access tokens, the username can be any non-empty value.
+1.  Enter your **Username**. For Group and Project access tokens, the username can be any non-empty value.
 
-6. Enter your token value in the **Password** and **Access token** fields.
+1.  Enter your token value in the **Password** and **Access token** fields.
 
-7. Enter the **Repository base URL** (recommended). This option is used to apply the credentials to a specific repository, e.g. `https://gitlab.com/seqeralabs`.
+1.  Enter the **Repository base URL** (recommended). This option is used to apply the credentials to a specific repository, e.g. `https://gitlab.com/seqeralabs`.
 
 ### Gitea
 
@@ -135,51 +135,51 @@ To connect Tower to a private [GitLab](https://gitlab.com/) repository:
 
 To connect to a private [Gitea](https://gitea.io/) repository, supply your Gitea user credentials to create a new credential in Tower with these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "Gitea" as the **Provider**.
+1.  Select "Gitea" as the **Provider**.
 
-5. Enter your **Username**.
+1.  Enter your **Username**.
 
-6. Enter your **Password**.
+1.  Enter your **Password**.
 
-7. Enter your **Repository base URL** (required).
+1.  Enter your **Repository base URL** (required).
 
 ### Bitbucket
 
 To connect to a private BitBucket repository, refer to the [BitBucket documentation](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) to learn how to create a BitBucket App password. Then, create a new credential in Tower using these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "BitBucket" as the **Provider**.
+1.  Select "BitBucket" as the **Provider**.
 
-5. Enter your **Username** and **Password**.
+1.  Enter your **Username** and **Password**.
 
-6. Enter the **Repository base URL** (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://bitbucket.org/seqeralabs`.
+1.  Enter the **Repository base URL** (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://bitbucket.org/seqeralabs`.
 
 ### AWS CodeCommit
 
 To connect to a private AWS CodeCommit repository, refer to the [AWS documentation](https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-iam-identity-based-access-control.html) to learn more about IAM permissions for CodeCommit. Then, supply the IAM account access key and secret key to create a credential in Tower using these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "CodeCommit" as the **Provider**.
+1.  Select "CodeCommit" as the **Provider**.
 
-5. Enter the **Access key** and **Secret key** of the AWS IAM account that will be used to access the desired CodeCommit repository.
+1.  Enter the **Access key** and **Secret key** of the AWS IAM account that will be used to access the desired CodeCommit repository.
 
-6. Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific region, e.g. `https://git-codecommit.eu-west-1.amazonaws.com`.
+1.  Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific region, e.g. `https://git-codecommit.eu-west-1.amazonaws.com`.
 
 ### Self-hosted Git
 

--- a/platform_versioned_docs/version-22.4.0/labels/overview.mdx
+++ b/platform_versioned_docs/version-22.4.0/labels/overview.mdx
@@ -48,6 +48,7 @@ Apply a label to workflow run at any moment, when launching a workflow run, as w
 ![](./_images/launch_labels.png)
 
 ### Search and filter with labels
+
 Search and filter pipelines and workflow runs using one or more labels.
 Filter and search are complementary.
 

--- a/platform_versioned_docs/version-22.4.0/launch/launch.mdx
+++ b/platform_versioned_docs/version-22.4.0/launch/launch.mdx
@@ -10,23 +10,23 @@ The **Launch Form** can be used for launching pipelines and for adding pipelines
 
 To launch a pipeline:
 
-1. Select **Start Quick Launch** in the navigation bar. The Launch Form will appear.
+1.  Select **Start Quick Launch** in the navigation bar. The Launch Form will appear.
 
-2. Select a **Compute Environment** from the available options.
+1.  Select a **Compute Environment** from the available options.
 
    Visit the [Compute Environment](../compute-envs/overview.mdx) documentation to learn how to create an environment for your preferred execution platform.
 
-3. Enter a repository URL for the **Pipeline to launch** (e.g. `https://github.com/nf-core/rnaseq.git`).
+1.  Enter a repository URL for the **Pipeline to launch** (e.g. `https://github.com/nf-core/rnaseq.git`).
 
 :::tip
 Nextflow pipelines are just Git repositories and they can reside on any public or private Git-hosting platform. See [Git Integration](../git/overview.mdx) in the Tower docs and [Pipeline Sharing](https://www.nextflow.io/docs/latest/sharing.html) in the Nextflow docs for more details.
 :::
 
-4. You can select a **Revision number** to use a specific version of the pipeline.
+1.  You can select a **Revision number** to use a specific version of the pipeline.
 
    The Git default branch (e.g. `main` or `master`) or `manifest.defaultBranch` in the Nextflow configuration will be used by default.
 
-5. Enter the **Work directory**, which corresponds to the Nextflow work directory.
+1.  Enter the **Work directory**, which corresponds to the Nextflow work directory.
 
    The default work directory of the compute environment will be used by default.
 
@@ -34,11 +34,11 @@ Nextflow pipelines are just Git repositories and they can reside on any public o
 The credentials associated with the compute environment must be able to access the work directory (e.g. an S3 bucket).
 :::
 
-6.  Select any **Config profiles** you would like to use.
+1.  Select any **Config profiles** you would like to use.
 
     Visit the Nextflow [Config profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) documentation for more details.
 
-7.  Enter any **Pipeline parameters** in YAML or JSON format.
+1.  Enter any **Pipeline parameters** in YAML or JSON format.
 
         YAML example:
         ```yaml
@@ -50,4 +50,4 @@ The credentials associated with the compute environment must be able to access t
 In YAML, quotes should be used for paths but not for numbers or Booleans.
 :::
 
-8.  Select **Launch** to launch the pipeline.
+1.  Select **Launch** to launch the pipeline.

--- a/platform_versioned_docs/version-22.4.0/orgs-and-teams/organizations.mdx
+++ b/platform_versioned_docs/version-22.4.0/orgs-and-teams/organizations.mdx
@@ -12,17 +12,17 @@ Organizations are the top-level structure and contain Workspaces, Members, Teams
 
 To create a new organization:
 
-1. Navigate to [Your organizations](https://tower.nf/orgs) and select **Add Organization**.
+1.  Navigate to [Your organizations](https://tower.nf/orgs) and select **Add Organization**.
 
-2. Enter a **Name** and **Full name** for your organization.
+1.  Enter a **Name** and **Full name** for your organization.
 
    :::caution
    The organization name must follow a specific pattern. Refer to the UI for guidance.
    :::
 
-3. Enter any other optional fields as needed: **Description**, **Location**, **Website URL** and **Logo**.
+1.  Enter any other optional fields as needed: **Description**, **Location**, **Website URL** and **Logo**.
 
-4. Select **Add**.
+1.  Select **Add**.
 
 You can view the list of all **Members**, **Teams**, and **Collaborators** in an organization on the organization's page. You can also edit any of the optional fields by selecting **Edit** from the [organizations page](https://tower.nf/orgs) or by selecting the **Settings** tab from the organization's page, provided that you are an **Owner** of the organization.
 
@@ -40,9 +40,9 @@ Tower provides access control for members of an organization by classifying them
 
 To add a new member to an organization:
 
-1. Go to the **Members** tab of the organization menu
-2. Click on **Invite member**
-3. Enter the email ID of user you'd like to add to the organization
+1.  Go to the **Members** tab of the organization menu
+1.  Click on **Invite member**
+1.  Enter the email ID of user you'd like to add to the organization
 
 An e-mail invitiation will be sent which needs to be accepted by the user. Once they accept the invitation, they can switch to the organization (or organization workspace) using their workspace dropdown.
 
@@ -64,9 +64,9 @@ New collaborators to an organization's workspace can be added using **Participan
 
 To create a new team within an organization:
 
-1. Go to the **Teams** tab of the organization menu
-2. Click on **New team**
-3. Enter the **Name** of team
-4. Optionally, add the **Description** and the team's **Avatar**
-5. For the newly created team, click on **View**
-6. Click on **Add team member** and type in the name of the organization members or collaborators
+1.  Go to the **Teams** tab of the organization menu
+1.  Click on **New team**
+1.  Enter the **Name** of team
+1.  Optionally, add the **Description** and the team's **Avatar**
+1.  For the newly created team, click on **View**
+1.  Click on **Add team member** and type in the name of the organization members or collaborators

--- a/platform_versioned_docs/version-22.4.0/orgs-and-teams/workspace-management.mdx
+++ b/platform_versioned_docs/version-22.4.0/orgs-and-teams/workspace-management.mdx
@@ -18,12 +18,12 @@ A workspace participant may be a member of the workspace organization or a colla
 
 Organization owners and admins can create a new workspace within an organization:
 
-1. Go to the **Workspaces** tab of the organization page.
-2. Select **Add Workspace**.
-3. Enter the **Name** and **Full name** for the workspace.
-4. Optionally, add a **Description** for the workspace.
-5. Under **Visibility**, select either **Private** or **Shared**. Private visibility means that workspace pipelines are only accessible to workspace participants.
-6. Select **Add**.
+1.  Go to the **Workspaces** tab of the organization page.
+1.  Select **Add Workspace**.
+1.  Enter the **Name** and **Full name** for the workspace.
+1.  Optionally, add a **Description** for the workspace.
+1.  Under **Visibility**, select either **Private** or **Shared**. Private visibility means that workspace pipelines are only accessible to workspace participants.
+1.  Select **Add**.
 
 :::tip
 Optional workspace fields can be modified after workspace creation, either by using the **Edit** option on the workspace listing for an organization or by accessing the **Settings** tab within the workspace page, provided that you are the **Owner** of the workspace.
@@ -35,10 +35,10 @@ Apart from the **Participants** tab, the organization workspace is similar to th
 
 To add a new participant to a workspace:
 
-1. Go to the **Participants** tab in the workspace menu.
-2. Select **Add participant**.
-3. Enter the **Name** of the new participant.
-4. Optionally, update the participant **role**. For more information on **roles**, see [participant roles](#participant-roles).
+1.  Go to the **Participants** tab in the workspace menu.
+1.  Select **Add participant**.
+1.  Enter the **Name** of the new participant.
+1.  Optionally, update the participant **role**. For more information on **roles**, see [participant roles](#participant-roles).
 
 :::tip
 A new workspace participant can be an existing organization member, team, or collaborator.
@@ -54,15 +54,15 @@ It is also possible to group **members** and **collaborators** into **teams** an
 
 There are five roles available for every workspace participant.
 
-1. **Owner**: The participant has full permissions for all resources within the workspace, including the workspace settings.
+1.  **Owner**: The participant has full permissions for all resources within the workspace, including the workspace settings.
 
-2. **Admin**: The participant has full permissions for resources associated with the workspace. They can create, modify, and delete pipelines, compute environments, actions, and credentials. They can add or remove users from the workspace but cannot access the workspace settings.
+1.  **Admin**: The participant has full permissions for resources associated with the workspace. They can create, modify, and delete pipelines, compute environments, actions, and credentials. They can add or remove users from the workspace but cannot access the workspace settings.
 
-3. **Maintain**: The participant can launch pipelines and modify pipeline executions (e.g., they can change the pipeline launch compute environments, parameters, pre/post-run scripts, and Nextflow configuration) and create new pipelines in the Launchpad. Users with maintain permissions cannot modify compute environments and credentials.
+1.  **Maintain**: The participant can launch pipelines and modify pipeline executions (e.g., they can change the pipeline launch compute environments, parameters, pre/post-run scripts, and Nextflow configuration) and create new pipelines in the Launchpad. Users with maintain permissions cannot modify compute environments and credentials.
 
-4. **Launch**: The participant can launch pipelines and modify the pipeline input/output parameters in the Launchpad. They cannot modify the launch configuration or other resources.
+1.  **Launch**: The participant can launch pipelines and modify the pipeline input/output parameters in the Launchpad. They cannot modify the launch configuration or other resources.
 
-5. **View**: The participant can view workspace pipelines and runs in read-only mode.
+1.  **View**: The participant can view workspace pipelines and runs in read-only mode.
 
 ### Workspace run monitoring
 

--- a/platform_versioned_docs/version-22.4.0/pipeline-actions/overview.mdx
+++ b/platform_versioned_docs/version-22.4.0/pipeline-actions/overview.mdx
@@ -15,19 +15,19 @@ A **GitHub webhook** listens for any changes made in the pipeline repository. Wh
 
 To create a new **Pipeline action**, select the **Actions** tab and select **Add Action**.
 
-1. Enter a **Name** for your Action.
+1.  Enter a **Name** for your Action.
 
-2. Select **GitHub webhook** as the **Event source**.
+1.  Select **GitHub webhook** as the **Event source**.
 
    ![](./_images/actions_githook.png)
 
-3. Select the **Compute environment** where the pipeline will be executed.
+1.  Select the **Compute environment** where the pipeline will be executed.
 
-4. Select the **Pipeline to launch** and (optionally) the **Revision number**.
+1.  Select the **Pipeline to launch** and (optionally) the **Revision number**.
 
-5. Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
+1.  Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
 
-6. Select **Add**.
+1.  Select **Add**.
 
    ![](./_images/actions_params.png)
 
@@ -41,19 +41,19 @@ A **Tower launch hook** creates a custom endpoint URL which can be used to trigg
 
 To create a new **Pipeline action**, select the **Actions** tab and select **Add Action**.
 
-1. Enter a **Name** for your Action.
+1.  Enter a **Name** for your Action.
 
-2. Select **Tower launch hook** as the event source.
+1.  Select **Tower launch hook** as the event source.
 
    ![](./_images/actions_tower_hook.png)
 
-3. Select the **Compute environment** to execute your pipeline.
+1.  Select the **Compute environment** to execute your pipeline.
 
-4. Enter the **Pipeline to launch** and (optionally) the **Revision number**.
+1.  Enter the **Pipeline to launch** and (optionally) the **Revision number**.
 
-5. Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
+1.  Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
 
-6. Select **Add**.
+1.  Select **Add**.
 
    ![](./_images/actions_tower_hook_params.png)
 

--- a/platform_versioned_docs/version-22.4.0/reports/overview.mdx
+++ b/platform_versioned_docs/version-22.4.0/reports/overview.mdx
@@ -26,8 +26,8 @@ Users can download a report directly from Tower or using the path. Download is n
 
 To render reports users need to create a Tower config file that defines the paths to a selection of output files published by the pipeline. There are 2 ways users can provide the Tower config file both of which have to be in YAML format:
 
-1. **Pipeline repository**: If a file called _tower.yml_ exists in the root of the pipeline repository then this will be fetched automatically before the pipeline execution.,
-2. **Tower UI**: Providing the YAML definition within the _Advanced options > Tower config file_ box when:
+1.  **Pipeline repository**: If a file called _tower.yml_ exists in the root of the pipeline repository then this will be fetched automatically before the pipeline execution.,
+1.  **Tower UI**: Providing the YAML definition within the _Advanced options > Tower config file_ box when:
    1.Creating a Pipeline in the Launchpad
    2.Amending the Launch settings when launching a Pipeline. Users with _Maintain_ role only.
 

--- a/platform_versioned_docs/version-22.4.0/resource-labels/overview.mdx
+++ b/platform_versioned_docs/version-22.4.0/resource-labels/overview.mdx
@@ -115,15 +115,15 @@ The [`forge-policy.json`](/docs/_templates/aws-batch/forge-policy.json) file con
 
 To view and manage the resource labels applied to AWS resources by Tower and Nextflow, navigate to the [AWS Tag Editor](https://docs.aws.amazon.com/tag-editor/latest/userguide/find-resources-to-tag.html)(as an administrative user) and follow these steps:
 
-1. Under **Find resources to tag**, search for the resource label key and value in the relevant search fields under **Tags**. Your search can be further refined by AWS region and resource type. Then select **Search resources**.
+1.  Under **Find resources to tag**, search for the resource label key and value in the relevant search fields under **Tags**. Your search can be further refined by AWS region and resource type. Then select **Search resources**.
 
-2. **Resource search results** displays all the resources tagged with your given resource label key and/or value.
+1.  **Resource search results** displays all the resources tagged with your given resource label key and/or value.
 
 To include the cost information associated with your resource labels in your AWS billing reports, follow these steps:
 
-1. You need to [activate](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activating-tags.html) the associated tags in the **AWS Billing and Cost Management console**. Note that newly-applied tags may take up to 24 hours to appear on your cost allocation tags page.
+1.  You need to [activate](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activating-tags.html) the associated tags in the **AWS Billing and Cost Management console**. Note that newly-applied tags may take up to 24 hours to appear on your cost allocation tags page.
 
-2. Once your tags are activated and displayed on your **Cost allocation tags** page in the Billing and Cost Management console, you can apply those tags when creating [cost allocation reports](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/configurecostallocreport.html#allocation-viewing).
+1.  Once your tags are activated and displayed on your **Cost allocation tags** page in the Billing and Cost Management console, you can apply those tags when creating [cost allocation reports](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/configurecostallocreport.html#allocation-viewing).
 
 #### AWS limits
 

--- a/platform_versioned_docs/version-22.4.0/secrets/overview.mdx
+++ b/platform_versioned_docs/version-22.4.0/secrets/overview.mdx
@@ -46,12 +46,12 @@ Secrets will be automatically deleted from the secret manager when the Pipeline 
 
 If you are planning to use the Pipeline Secrets feature provided by Tower with the AWS Secrets Manager, the following IAM permissions should be provided:
 
-1. Create the AWS Batch [IAM Execution role](https://docs.aws.amazon.com/batch/latest/userguide/execution-IAM-role.html#create-execution-role) as specified in the AWS documentation.
+1.  Create the AWS Batch [IAM Execution role](https://docs.aws.amazon.com/batch/latest/userguide/execution-IAM-role.html#create-execution-role) as specified in the AWS documentation.
 
-2. Add the `AmazonECSTaskExecutionRolePolicy` policy and [this custom policy](../_templates/aws-batch/secrets-policy-execution-role.json) to the execution role created above.
+1.  Add the `AmazonECSTaskExecutionRolePolicy` policy and [this custom policy](../_templates/aws-batch/secrets-policy-execution-role.json) to the execution role created above.
 
-3. Specify the execution role ARN in the **Batch execution role** option (under **Advanced options**) when creating your Compute Environment in Tower.
+1.  Specify the execution role ARN in the **Batch execution role** option (under **Advanced options**) when creating your Compute Environment in Tower.
 
-4. Add [this custom policy](../_templates/aws-batch/secrets-policy-instance-role.json) to the ECS Instance role associated with the Batch compute environment that will be used to deploy your pipelines. Replace `YOUR-ACCOUNT` and `YOUR-EXECUTION-ROLE-NAME` with the appropriate values. See [here](https://docs.aws.amazon.com/batch/latest/userguide/instance_IAM_role.html) for more details about the Instance role.
+1.  Add [this custom policy](../_templates/aws-batch/secrets-policy-instance-role.json) to the ECS Instance role associated with the Batch compute environment that will be used to deploy your pipelines. Replace `YOUR-ACCOUNT` and `YOUR-EXECUTION-ROLE-NAME` with the appropriate values. See [here](https://docs.aws.amazon.com/batch/latest/userguide/instance_IAM_role.html) for more details about the Instance role.
 
-5. Add [this custom policy](../_templates/aws-batch/secrets-policy-account.json) to your Tower IAM user (the one specified in the Tower credentials).
+1.  Add [this custom policy](../_templates/aws-batch/secrets-policy-account.json) to your Tower IAM user (the one specified in the Tower credentials).

--- a/platform_versioned_docs/version-22.4.0/supported_software/dragen/overview.mdx
+++ b/platform_versioned_docs/version-22.4.0/supported_software/dragen/overview.mdx
@@ -28,9 +28,9 @@ To deploy the pipeline on your own AWS cloud infrastructure, please follow the i
 
 DRAGEN is a commercial technology provided by Illumina, so you will need to purchase a license from them. To run on Tower, you will need to obtain the following information from Illumina:
 
-1. DRAGEN AWS private AMI ID
-2. DRAGEN license username
-3. DRAGEN license password
+1.  DRAGEN AWS private AMI ID
+1.  DRAGEN license username
+1.  DRAGEN license password
 
 Batch Forge automates most of the tasks required to set up an AWS Batch Compute Environment. Please follow [our guide](../../compute-envs/aws-batch.mdx) for more details.
 
@@ -48,7 +48,7 @@ Please ensure that the Region you select contains DRAGEN F1 instances.
 
 Please see the [dragen.nf](https://github.com/seqeralabs/nf-dragen/blob/master/modules/local/dragen.nf) module implemented in the [nf-dragen](https://github.com/seqeralabs/nf-dragen) pipeline for reference. Any Nextflow processes that run DRAGEN must:
 
-1. Define `label ‘dragen’`
+1.  Define `label ‘dragen’`
 
    The `label` directive allows you to annotate a process with mnemonic identifiers of your choice. Tower will use the `dragen` label to determine which processes need to be executed on DRAGEN F1 instances.
 
@@ -62,7 +62,7 @@ Please see the [dragen.nf](https://github.com/seqeralabs/nf-dragen/blob/master/m
 
    Please refer to the [Nextflow label docs](https://www.nextflow.io/docs/latest/process.html?highlight=label#label) for more information.
 
-2. Define Secrets
+1.  Define Secrets
 
    At Seqera, we use Secrets to safely encrypt sensitive information when running licensed software via Nextflow. This enables our team to use the DRAGEN software safely via the `nf-dragen` pipeline without having to worry about the setup or safe configuration of the license key. These Secrets will be provided securely to the `--lic-server` option when running DRAGEN on the CLI to validate the license.
 

--- a/platform_versioned_docs/version-23.1.0/README.mdx
+++ b/platform_versioned_docs/version-23.1.0/README.mdx
@@ -4,19 +4,19 @@ title: "README"
 
 As of June 2023, a new process was implemented for sourcing and publishing Nextflow Tower public documentation:
 
-1. Markdown content is stored in the `/docs` folder of the [**nf-tower-cloud**](https://github.com/seqeralabs/nf-tower-cloud) repository.
-2. New content must be created in `feature branches` generated from `master`.
-3. Content changes must be pushed to `master` via PRs with two approvers:
-   1. An engineering team member (ideally the engineer that worked on the feature being documented)
-   2. A writing team member.
-4. A GitHub Action in the nf-tower-cloud repo will automatically sync the `/docs` folder to our legacy [**nf-tower-docs**](https://github.com/seqeralabs/nf-tower-docs) repository. **DO NOT MAKE CONTENT EDITS IN nf-tower-docs DIRECTLY.**
-5. nf-tower-docs repo content will be published to the public `help.tower.nf` website manually using Mkdocs.
+1.  Markdown content is stored in the `/docs` folder of the [**nf-tower-cloud**](https://github.com/seqeralabs/nf-tower-cloud) repository.
+1.  New content must be created in `feature branches` generated from `master`.
+1.  Content changes must be pushed to `master` via PRs with two approvers:
+   1.  An engineering team member (ideally the engineer that worked on the feature being documented)
+   2.  A writing team member.
+1.  A GitHub Action in the nf-tower-cloud repo will automatically sync the `/docs` folder to our legacy [**nf-tower-docs**](https://github.com/seqeralabs/nf-tower-docs) repository. **DO NOT MAKE CONTENT EDITS IN nf-tower-docs DIRECTLY.**
+1.  nf-tower-docs repo content will be published to the public `help.tower.nf` website manually using Mkdocs.
 
 ## Render this documentation locally
 
 ### Install dependencies and preview locally
 
-1. **Generate a token on git.seqera.io**
+1.  **Generate a token on git.seqera.io**
 
    To build the docker container and serve the Mkdocs site, you must generate a token on Gitea.
 
@@ -26,7 +26,7 @@ As of June 2023, a new process was implemented for sourcing and publishing Nextf
    - Generate a new token and copy the value after form submission
    - Store the token value as a `GITEA_TOKEN` environment variable, optionally added to .bashrc/.zshrc. Run `source .bashrc` or `source .zshrc` once saved.
 
-2. **Install dependencies**
+1.  **Install dependencies**
 
    Install Mkdocs, Mkdocs plugins, and Mkdocs Material Insiders. From the root folder of your local repository clone, run:
 
@@ -34,11 +34,11 @@ As of June 2023, a new process was implemented for sourcing and publishing Nextf
    - `pip install -r requirements.txt`
    - `pip install "git+https://${GITEA_TOKEN}@git.seqera.io/seqeralabs/mkdocs-material-insiders@7.3.3-insiders-3.1.3"`
 
-3. **Run `mkdocs serve`**
+1.  **Run `mkdocs serve`**
 
 ### Generate a Mkdocs-ready container
 
-1. **Generate a token on git.seqera.io**
+1.  **Generate a token on git.seqera.io**
 
    To build the docker container and serve the Mkdocs site, you must generate a token on Gitea.
 
@@ -48,7 +48,7 @@ As of June 2023, a new process was implemented for sourcing and publishing Nextf
    - Generate a new token and copy the value after form submission
    - Store the token value as a `GITEA_TOKEN` environment variable, optionally added to .bashrc/.zshrc. Run `source .bashrc` or `source .zshrc` once saved.
 
-2. **Build docs image**
+1.  **Build docs image**
 
    ```bash
    # Build the image direclty via Docker
@@ -58,14 +58,14 @@ As of June 2023, a new process was implemented for sourcing and publishing Nextf
    make build-docker
    ```
 
-3. **Run the container**
+1.  **Run the container**
 
    ```bash
    # Navigate to the root of your local nf-tower-cloud repo and run the following
    docker run --rm -p 8000:8000 -v ${PWD}:/docs seqera-docs:latest serve --dev-addr=0.0.0.0:8000
    ```
 
-4. **Visit `0.0.0.0:8000` from your favorite browser**.
+1.  **Visit `0.0.0.0:8000` from your favorite browser**.
 
 ## Contribution guidelines
 
@@ -94,9 +94,9 @@ To update the Tower docs navigation menu, edit the `navigation` section of the `
 
   - Insert tables (CSV, YML, etc.) directly into markdown pages using a tag.
   - How it's implemented:
-    1. Activate as a `plugins` entry in `mkdocs.yml` (below `social` and `search`, but above other mkdocs plugins)
-    2. Create an external yaml file in a `tables` folder within the content subfolder (e.g., `docs/enterprise/configuration/tables/compute_env.yml`)
-    3. Add key-value pairs in groups, where each key represents a column name, and each value represents an entry in a row, e.g.:
+    1.  Activate as a `plugins` entry in `mkdocs.yml` (below `social` and `search`, but above other mkdocs plugins)
+    2.  Create an external yaml file in a `tables` folder within the content subfolder (e.g., `docs/enterprise/configuration/tables/compute_env.yml`)
+    3.  Add key-value pairs in groups, where each key represents a column name, and each value represents an entry in a row, e.g.:
 
     ```yaml
     -
@@ -114,17 +114,17 @@ To update the Tower docs navigation menu, edit the `navigation` section of the `
     -
     ```
 
-    4. Each unique column name will be rendered in the table, so ensure that all row entries have the same column name keys. The example above shows the structure for two row entries in a table with three columns.
-    5. Reference this table in other markdown files with `{{ read_yaml('./tables/compute_env.yml')}}` (relevant path to the table from the markdown file where it is being referenced).
+    4.  Each unique column name will be rendered in the table, so ensure that all row entries have the same column name keys. The example above shows the structure for two row entries in a table with three columns.
+    5.  Reference this table in other markdown files with `{{ read_yaml('./tables/compute_env.yml')}}` (relevant path to the table from the markdown file where it is being referenced).
 
 - [mkdocs-markdownextradata-plugin](https://github.com/rosscdh/mkdocs-markdownextradata-plugin)
 
   - Implement DRY-like variables for content which appears throughout the site. ( _Example: The latest Tower Enterprise container names._ )
   - How it's implemented:
-    1. Activate as a `plugins` entry in `mkdocs.yml`
-    2. Create an external yaml file in `/docs/_data/` ( _e.g. `my_dry_vars`_ )
-    3. Add key-value pairs to the external file ( _e.g. `tower_fe_image: "cr.seqera.io/private/nf-tower-enterprise/frontend:v23.1.3"`_ ).
-    4. Update the `plugins` entry with a path to the file:
+    1.  Activate as a `plugins` entry in `mkdocs.yml`
+    2.  Create an external yaml file in `/docs/_data/` ( _e.g. `my_dry_vars`_ )
+    3.  Add key-value pairs to the external file ( _e.g. `tower_fe_image: "cr.seqera.io/private/nf-tower-enterprise/frontend:v23.1.3"`_ ).
+    4.  Update the `plugins` entry with a path to the file:
 
        ```yaml
        plugins:
@@ -132,7 +132,7 @@ To update the Tower docs navigation menu, edit the `navigation` section of the `
              data: _data/YOUR_FILE
        ```
 
-    5. Reference this variable in other markdown files with `{{ my_dry_vars.tower_fe_image }}`.
+    5.  Reference this variable in other markdown files with `{{ my_dry_vars.tower_fe_image }}`.
 
 - [mkdocs-same-dir](https://github.com/oprypin/mkdocs-same-dir)
   - Enable Mkdocs to build with `mkdocs.yml` inside the `/docs` folder. Once listed as a `plugins` entry in the `mkdocs.yml`, no further action is needed.

--- a/platform_versioned_docs/version-23.1.0/agent.mdx
+++ b/platform_versioned_docs/version-23.1.0/agent.mdx
@@ -16,27 +16,27 @@ jobs. The jobs are submitted on behalf of the user running the agent.
 
 Tower Agent is distributed as a single executable file to simply download and execute.
 
-1. Download the latest release from [Github](https://github.com/seqeralabs/tower-agent):
+1.  Download the latest release from [Github](https://github.com/seqeralabs/tower-agent):
 
    ```bash
    curl -fSL https://github.com/seqeralabs/tower-agent/releases/latest/download/tw-agent-linux-x86_64 > tw-agent
    ```
 
-2. Make it executable:
+1.  Make it executable:
 
    ```bash
    chmod +x ./tw-agent
    ```
 
-3. (Optional) Move it into a folder that is in your path.
+1.  (Optional) Move it into a folder that is in your path.
 
 ### Quickstart
 
 Before running the Agent:
 
-1. Create a [**personal access token**](api/overview.mdx#authentication) in Tower.
+1.  Create a [**personal access token**](api/overview.mdx#authentication) in Tower.
 
-2. Create **Tower Agent** credentials in a Tower workspace. See [here](credentials/overview.mdx) for more instructions.
+1.  Create **Tower Agent** credentials in a Tower workspace. See [here](credentials/overview.mdx) for more instructions.
 
 :::note
 To share a single Tower Agent instance with all members of a workspace, create a Tower Agent credential with **Shared agent** enabled.

--- a/platform_versioned_docs/version-23.1.0/compute-envs/altair-grid-engine.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/altair-grid-engine.mdx
@@ -23,35 +23,35 @@ To create a new compute environment for **Grid Engine** in Tower:
 
 1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2.  Enter a descriptive name for this environment, e.g., "Grid Engine".
+1.  Enter a descriptive name for this environment, e.g., "Grid Engine".
 
-3.  Select **Altair Grid Engine** as the target platform.
+1.  Select **Altair Grid Engine** as the target platform.
 
-4.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5.  Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6.  Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
 
-9.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
 
     :::tip
     The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [documentation](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
     :::
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.1.0/compute-envs/altair-pbs-pro.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/altair-pbs-pro.mdx
@@ -23,35 +23,35 @@ To create a new compute environment for **PBS Pro** in Tower:
 
 1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2.  Enter a descriptive name for this environment, e.g., "PBS Pro cluster".
+1.  Enter a descriptive name for this environment, e.g., "PBS Pro cluster".
 
-3.  Select **Altair PBS Pro** as the target platform.
+1.  Select **Altair PBS Pro** as the target platform.
 
-4.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5.  Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6.  Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
 
-9.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
 
     :::tip
     The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [documentation](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
     :::
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.1.0/compute-envs/aws-batch.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/aws-batch.mdx
@@ -11,9 +11,9 @@ This guide assumes you have an existing [Amazon Web Service (AWS)](https://aws.a
 
 There are two ways to create a **compute environment** for **AWS Batch** with Tower:
 
-1. [**Batch Forge**](#tower-forge): This option automatically creates the AWS Batch resources in your AWS account. This eliminates the need to set up your AWS Batch infrastructure manually.
+1.  [**Batch Forge**](#tower-forge): This option automatically creates the AWS Batch resources in your AWS account. This eliminates the need to set up your AWS Batch infrastructure manually.
 
-2. [**Manual**](#manual): This option allows Tower to use existing AWS Batch resources.
+1.  [**Manual**](#manual): This option allows Tower to use existing AWS Batch resources.
 
 ## Batch Forge
 
@@ -27,69 +27,69 @@ We recommend creating separate IAM policies for Batch Forge and Tower launch per
 
 #### Create Tower IAM policies
 
-1. Open the [AWS IAM console](https://console.aws.amazon.com/iam).
+1.  Open the [AWS IAM console](https://console.aws.amazon.com/iam).
 
-2. From the left navigation menu, select **Policies** under **Access management**.
+1.  From the left navigation menu, select **Policies** under **Access management**.
 
-3. Select **Create policy**.
+1.  Select **Create policy**.
 
-4. On the **Create policy** page, select the **JSON** tab.
+1.  On the **Create policy** page, select the **JSON** tab.
 
-5. Copy the contents of your policy JSON file ([Forge](https://github.com/seqeralabs/nf-tower-aws/blob/master/forge/forge-policy.json) or [Launch](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/launch-policy.json), depending on the policy being created) and replace the default text in the policy editor area under the JSON tab. To create a Launch user, you must also create the [S3 bucket write policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) separately to attach to your Launch user.
+1.  Copy the contents of your policy JSON file ([Forge](https://github.com/seqeralabs/nf-tower-aws/blob/master/forge/forge-policy.json) or [Launch](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/launch-policy.json), depending on the policy being created) and replace the default text in the policy editor area under the JSON tab. To create a Launch user, you must also create the [S3 bucket write policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) separately to attach to your Launch user.
 
-6. Select **Next: Tags**.
+1.  Select **Next: Tags**.
 
-7. Select **Next: Review**.
+1.  Select **Next: Review**.
 
-8. Enter a name and description for the policy on the Review policy page, then select **Create policy**.
+1.  Enter a name and description for the policy on the Review policy page, then select **Create policy**.
 
-9. Repeat these steps for both the `forge-policy.json` and `launch-policy.json` files. For a Launch user, also create the `s3-bucket-write-policy.json` listed in step 5 above.
+1.  Repeat these steps for both the `forge-policy.json` and `launch-policy.json` files. For a Launch user, also create the `s3-bucket-write-policy.json` listed in step 5 above.
 
 #### Create an IAM user
 
-1. From the [AWS IAM console](https://console.aws.amazon.com/iam), select **Users** in the left navigation menu, then select **Add User** at the top rigt of the page.
+1.  From the [AWS IAM console](https://console.aws.amazon.com/iam), select **Users** in the left navigation menu, then select **Add User** at the top rigt of the page.
 
-2. Enter a name for your user (e.g. `tower`) and select the **Programmatic access** type.
+1.  Enter a name for your user (e.g. `tower`) and select the **Programmatic access** type.
 
-3. Select **Next: Permissions**.
+1.  Select **Next: Permissions**.
 
-4. Select **Next: Tags**, then **Next: Review** and **Create User**.
+1.  Select **Next: Tags**, then **Next: Review** and **Create User**.
 
    :::caution
    For the time being, you can ignore the warning. Permissions will be applied using the **IAM Policy**.
    :::
 
-5. Save the **Access key ID** and **Secret access key** in a secure location as we will use these in the next section.
+1.  Save the **Access key ID** and **Secret access key** in a secure location as we will use these in the next section.
 
-6. Once you have saved the keys, select **Close**.
+1.  Once you have saved the keys, select **Close**.
 
-7. Back in the users table, select the newly created user,then select **Add permissions** under the Permissions tab.
+1.  Back in the users table, select the newly created user,then select **Add permissions** under the Permissions tab.
 
-8. Select **Attach existing policies**, search for the policies created [previously](./aws-batch.mdx#create-tower-iam-policies), and select each one.
+1.  Select **Attach existing policies**, search for the policies created [previously](./aws-batch.mdx#create-tower-iam-policies), and select each one.
 
-9. Select **Next: Review**.
+1.  Select **Next: Review**.
 
-10. Select **Add permissions**.
+1.  Select **Add permissions**.
 
 ### S3 Bucket
 
 S3 (Simple Storage Service) is a type of **object storage**. To access files and store the results for our pipelines, we have to create an **S3 bucket** and grant our new Tower IAM user access to it.
 
-1. Navigate to the [S3 service](https://console.aws.amazon.com/s3/home).
+1.  Navigate to the [S3 service](https://console.aws.amazon.com/s3/home).
 
-2. Select **Create New Bucket**.
+1.  Select **Create New Bucket**.
 
-3. Enter a unique name for your bucket and select a region.
+1.  Enter a unique name for your bucket and select a region.
 
    :::caution
    To maximize data transfer resilience and minimize cost, storage should be in the same region as compute.
    :::
 
-4. Select the default options for **Configure options**.
+1.  Select the default options for **Configure options**.
 
-5. Select the default options for **Set permissions**.
+1.  Select the default options for **Set permissions**.
 
-6. Review and select **Create bucket**.
+1.  Review and select **Create bucket**.
 
    :::caution
    S3 is used by Nextflow for the storage of intermediate files. In production pipelines, this can amount to a large quantity of data. To reduce costs, consider using a retention policy when creating a bucket, such as automatically deleting intermediate files after 30 days. See [here](https://aws.amazon.com/premiumsupport/knowledge-center/s3-empty-bucket-lifecycle-rule/) for more information.
@@ -103,31 +103,31 @@ Once the AWS resources are set up, we can add a new **AWS Batch** environment in
 
 1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2.  Enter a descriptive name for this environment, e.g., "AWS Batch Spot (eu-west-1)".
+1.  Enter a descriptive name for this environment, e.g., "AWS Batch Spot (eu-west-1)".
 
-3.  Select **Amazon Batch** as the target platform.
+1.  Select **Amazon Batch** as the target platform.
 
-4.  From the **Credentials** drop-down, select existing AWS credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing AWS credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
 
-5.  Enter a name, e.g. "AWS Credentials".
+1.  Enter a name, e.g. "AWS Credentials".
 
-6.  Add the **Access key** and **Secret key**. These are the keys you saved previously when you created the AWS [IAM user](#iam).
+1.  Add the **Access key** and **Secret key**. These are the keys you saved previously when you created the AWS [IAM user](#iam).
 
     :::tip
     You can create multiple credentials in your Tower environment.
     :::
 
-7.  Select a **Region**, e.g., "eu-west-1 - Europe (Ireland)".
+1.  Select a **Region**, e.g., "eu-west-1 - Europe (Ireland)".
 
-8.  Enter the S3 bucket path created in the previous section to the **Pipeline work directory** field, e.g. `s3://unique-tower-bucket`.
+1.  Enter the S3 bucket path created in the previous section to the **Pipeline work directory** field, e.g. `s3://unique-tower-bucket`.
 
     :::caution
     The bucket should be in the same region selected in the previous step.
     :::
 
-9.  Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
+1.  Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
 
-10. Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
+1.  Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
 
     :::note
     When using Fusion v2 without fast instance storage (see below), the following EBS settings are applied to optimize file system performance:
@@ -140,15 +140,15 @@ Once the AWS resources are set up, we can add a new **AWS Batch** environment in
     Extensive benchmarking of Fusion v2 has demonstrated that the increased cost associated with these settings are generally outweighed by the costs saved due to decreased run time.
     :::
 
-11. Select **Enable fast instance storage** to allow the use of NVMe instance storage to speed up I/O and disk access operations. NVMe instance storage requires Fusion v2 to be enabled (see above).
+1.  Select **Enable fast instance storage** to allow the use of NVMe instance storage to speed up I/O and disk access operations. NVMe instance storage requires Fusion v2 to be enabled (see above).
 
     :::note
     Fast instance storage requires an EC2 instance type that uses NVMe disks. Tower validates any instance types you specify (from **Advanced options > Instance types**) during compute environment creation. If you do not specify an instance type, a standard EC2 instance with NVMe disks will be used (`'c5ad', 'c5d', 'c6id', 'i3', 'i4i', 'm5ad', 'm5d', 'm6id', 'r5ad', 'r5d', 'r6id'` EC2 instance families) for fast storage.
     :::
 
-12. Set the **Config mode** to **Batch Forge**.
+1.  Set the **Config mode** to **Batch Forge**.
 
-13. Select a **Provisioning model**. In most cases this will be **Spot**.
+1.  Select a **Provisioning model**. In most cases this will be **Spot**.
 
     :::tip
     You can choose to create a compute environment that launches either Spot or On-demand instances. Spot instances can cost as little as 20% of on-demand instances, and with Nextflow's ability to automatically relaunch failed tasks, Spot is almost always the recommended provisioning model.
@@ -156,49 +156,49 @@ Once the AWS resources are set up, we can add a new **AWS Batch** environment in
     Note, however, that when choosing Spot instances, Tower will also create a dedicated queue for running the main Nextflow job using a single on-demand instance in order to prevent any execution interruptions.
     :::
 
-14. Enter the **Max CPUs** e.g. `64`. This is the maximum number of combined CPUs (the sum of all instances CPUs) AWS Batch will provision at any time.
+1.  Enter the **Max CPUs** e.g. `64`. This is the maximum number of combined CPUs (the sum of all instances CPUs) AWS Batch will provision at any time.
 
-15. Select **EBS Auto scale** to allow the EC2 virtual machines to dynamically expand the amount of available disk space during task execution.
+1.  Select **EBS Auto scale** to allow the EC2 virtual machines to dynamically expand the amount of available disk space during task execution.
 
     :::caution
     When running large AWS Batch clusters (hundreds of compute nodes or more), EC2 API rate limits may cause the deletion of unattached EBS volumes to fail. Volumes that remain active after Nextflow jobs have completed will incur additional costs, and should be manually deleted. Monitor your AWS account for any orphaned EBS volumes via the EC2 console, or with a Lambda function. See [here](https://aws.amazon.com/blogs/mt/controlling-your-aws-costs-by-deleting-unused-amazon-ebs-volumes/) for more information.
     :::
 
-16. With the optional **Enable Fusion mounts (deprecated)** feature enabled, S3 buckets specified in **Pipeline work directory** and **Allowed S3 Buckets** are mounted as file system volumes in the EC2 instances carrying out the Batch job execution. These buckets can then be accessed at `/fusion/s3/<bucket-name>`. For example, if the bucket name is `s3://imputation-gp2`, your pipeline will access it using the file system path `/fusion/s3/imputation-gp2`. **Note:** This feature has been deprecated. Consider using Fusion v2 (see above) for enhanced performance and stability.
+1.  With the optional **Enable Fusion mounts (deprecated)** feature enabled, S3 buckets specified in **Pipeline work directory** and **Allowed S3 Buckets** are mounted as file system volumes in the EC2 instances carrying out the Batch job execution. These buckets can then be accessed at `/fusion/s3/<bucket-name>`. For example, if the bucket name is `s3://imputation-gp2`, your pipeline will access it using the file system path `/fusion/s3/imputation-gp2`. **Note:** This feature has been deprecated. Consider using Fusion v2 (see above) for enhanced performance and stability.
 
     :::tip
     You do not need to modify your pipeline or files to take advantage of this feature. Nextflow will automatically recognize and replace any reference to files prefixed with `s3://` with the corresponding Fusion mount paths.
     :::
 
-17. Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. See [GPU usage](./overview.mdx#aws-batch) for more information.
+1.  Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. See [GPU usage](./overview.mdx#aws-batch) for more information.
 
-18. Select **Use Graviton CPU architecture** to deploy the pipeline execution on Graviton-based Ec2 instances (i.e. ARM64 CPU architecture). When enabling Tower automatically selects the following instance types for compute jobs: `m6g`, `r6g` and `c6g`. You can override them using the **Instance types** in the Advanced settings. Note: this feature requires Fargate, Wave service and Fusion v2 file system to be enabled; also it's not compatible with GPU-based architecture.
+1.  Select **Use Graviton CPU architecture** to deploy the pipeline execution on Graviton-based Ec2 instances (i.e. ARM64 CPU architecture). When enabling Tower automatically selects the following instance types for compute jobs: `m6g`, `r6g` and `c6g`. You can override them using the **Instance types** in the Advanced settings. Note: this feature requires Fargate, Wave service and Fusion v2 file system to be enabled; also it's not compatible with GPU-based architecture.
 
-19. Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.
+1.  Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.
 
-20. To use **EFS**, you can either select **Use existing EFS file system** and specify an existing EFS instance, or select **Create new EFS file system** to create one. If you intend to use the EFS file system as your work directory, you will need to specify `<your_EFS_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
+1.  To use **EFS**, you can either select **Use existing EFS file system** and specify an existing EFS instance, or select **Create new EFS file system** to create one. If you intend to use the EFS file system as your work directory, you will need to specify `<your_EFS_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
 
     - To use an existing EFS file system, enter the **EFS file system id** and **EFS mount path**. This is the path where the EFS volume is accessible to the compute environment. For simplicity, we advise that you use `/mnt/efs` as the EFS mount path.
     - To create a new EFS file system, enter the **EFS mount path**. We advise that you specify `/mnt/efs` as the EFS mount path.
     - EFS file systems created by Batch Forge are automatically tagged in AWS with `Name=TowerForge-<id>`, with `<id>` being the compute environment ID. Any manually added Tower resource label with the key `Name` (capital N) will override the automatically-assigned `TowerForge-<id>` label.
 
-21. To use **FSx for Lustre**, you can either select **Use existing FSx file system** and specify an existing FSx instance, or select **Create new FSx file system** to create one. If you intend to use the FSx file system as your work directory, you will need to specify `<your_FSx_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
+1.  To use **FSx for Lustre**, you can either select **Use existing FSx file system** and specify an existing FSx instance, or select **Create new FSx file system** to create one. If you intend to use the FSx file system as your work directory, you will need to specify `<your_FSx_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
 
     - To use an existing FSx file system, enter the **FSx DNS name** and **FSx mount path**. The FSx mount path is the path where the FSx volume is accessible to the compute environment. For simplicity, we advise that you use `/mnt/fsx` as the FSx mount path.
     - To create a new FSx file system, enter the **FSx size** (in GB) and the **FSx mount path**. We advise that you specify `/mnt/fsx` as the FSx mount path.
     - FSx file systems created by Batch Forge are automatically tagged in AWS with `Name=TowerForge-<id>`, with `<id>` being the compute environment ID. Any manually added Tower resource label with the key `Name` (capital N) will override the automatically-assigned `TowerForge-<id>` label.
 
-22. Select **Dispose resources** if you want Tower to automatically delete these AWS resources if you delete the compute environment in Tower.
+1.  Select **Dispose resources** if you want Tower to automatically delete these AWS resources if you delete the compute environment in Tower.
 
-23. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-24. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-25. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-26. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-27. Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
+1.  Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 
@@ -266,51 +266,51 @@ With these permissions set, we can add a new **AWS Batch** compute environment i
 
 Tower can use S3 to store intermediate and output data generated by pipelines. You need to create a policy for your Tower IAM user that grants access to specific buckets.
 
-1. Go to the IAM User table in the [IAM service](https://console.aws.amazon.com/iam/home)
+1.  Go to the IAM User table in the [IAM service](https://console.aws.amazon.com/iam/home)
 
-2. Select the IAM user.
+1.  Select the IAM user.
 
-3. Select **Add inline policy**.
+1.  Select **Add inline policy**.
 
-4. Copy the contents of [this policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) into the **JSON** tab. Replace `YOUR-BUCKET-NAME` (lines 10 and 21) with your bucket name.
+1.  Copy the contents of [this policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) into the **JSON** tab. Replace `YOUR-BUCKET-NAME` (lines 10 and 21) with your bucket name.
 
-5. Name your policy and select **Create policy**.
+1.  Name your policy and select **Create policy**.
 
 ### Compute environment
 
 To create a new compute environment for AWS Batch (without Forge):
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "AWS Batch Manual (eu-west-1)".
+1.  Enter a descriptive name for this environment, e.g., "AWS Batch Manual (eu-west-1)".
 
-3. Select **Amazon Batch** as the target platform.
+1.  Select **Amazon Batch** as the target platform.
 
-4. Add new credentials by selecting the **+** button.
+1.  Add new credentials by selecting the **+** button.
 
-5. Enter a name for the credentials, e.g., "AWS Credentials".
+1.  Enter a name for the credentials, e.g., "AWS Credentials".
 
-6. Enter the **Access key** and **Secret key** for your IAM user.
+1.  Enter the **Access key** and **Secret key** for your IAM user.
 
    :::tip
    You can create multiple credentials in your Tower environment. See the [Credentials](../credentials/overview.mdx) section.
    :::
 
-7. Select a **Region**, e.g., "eu-west-1 - Europe (Ireland)".
+1.  Select a **Region**, e.g., "eu-west-1 - Europe (Ireland)".
 
-8. Enter an S3 bucket path for the **Pipeline work directory**, e.g., `s3://tower-bucket`.
+1.  Enter an S3 bucket path for the **Pipeline work directory**, e.g., `s3://tower-bucket`.
 
-9. Set the **Config mode** to **Manual**.
+1.  Set the **Config mode** to **Manual**.
 
-10. Enter the **Head queue**, which is the name of the AWS Batch queue that the Nextflow driver job will run.
+1.  Enter the **Head queue**, which is the name of the AWS Batch queue that the Nextflow driver job will run.
 
-11. Enter the **Compute queue**, which is the name of the AWS Batch queue that tasks will be submitted to.
+1.  Enter the **Compute queue**, which is the name of the AWS Batch queue that tasks will be submitted to.
 
-12. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.1.0/compute-envs/azure-batch.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/azure-batch.mdx
@@ -32,13 +32,13 @@ To create Azure Batch and Azure Storage accounts, first create a **resource grou
 
 If you are logged in to your Azure account, select **Create new resource group** on [this page](https://portal.azure.com/#create/Microsoft.ResourceGroup).
 
-1. Enter a name for the resource group (e.g. `towerrg`).
+1.  Enter a name for the resource group (e.g. `towerrg`).
 
-2. Select the preferred region for this resource group.
+1.  Select the preferred region for this resource group.
 
-3. Select **Review and Create** to proceed to the review screen.
+1.  Select **Review and Create** to proceed to the review screen.
 
-4. Select **Create** to create the resources.
+1.  Select **Create** to create the resources.
 
 ### Storage account
 
@@ -46,23 +46,23 @@ The next step is to create the necessary Azure Storage.
 
 If you are logged in to your Azure account, select **Create a storage account** on [this page](https://portal.azure.com/#blade/HubsExtension/BrowseResource/resourceType/Microsoft.Storage%2FStorageAccounts).
 
-1. Enter a name for the storage account (e.g., `towerrgstorage`).
+1.  Enter a name for the storage account (e.g., `towerrgstorage`).
 
-2. Select the preferred region for this storage account.
+1.  Select the preferred region for this storage account.
 
-3. Select **Review and Create** to proceed to the review screen.
+1.  Select **Review and Create** to proceed to the review screen.
 
-4. Select **Create** to create the Azure Storage account.
+1.  Select **Create** to create the Azure Storage account.
 
-5. Navigate to your new storage account and select **Container**.
+1.  Navigate to your new storage account and select **Container**.
 
-6. Create a new Blob container by selecting **+ Container**.
+1.  Create a new Blob container by selecting **+ Container**.
 
    A new container dialogue will open. Enter a suitable name (e.g. `towerrgstorage-container`).
 
-7. Once the new Blob container is created, navigate to the **Access Keys** section of the storage account (`towerrgstorage` in this example).
+1.  Once the new Blob container is created, navigate to the **Access Keys** section of the storage account (`towerrgstorage` in this example).
 
-8. Store the access keys for the newly created Azure Storage account.
+1.  Store the access keys for the newly created Azure Storage account.
 
    :::note
    Blob container storage credentials are associated with the Batch pool configuration when it is created. Once your compute environment has been created with Batch Forge, these credentials should not be changed in Tower.
@@ -74,13 +74,13 @@ The next step is to create the necessary Batch account.
 
 If you are logged in to your Azure account, select **Create a batch account** on [this page](https://portal.azure.com/#blade/HubsExtension/BrowseResource/resourceType/Microsoft.Batch%2FbatchAccounts).
 
-1. Enter a name for the Batch account (e.g. `towerrgbatch`).
+1.  Enter a name for the Batch account (e.g. `towerrgbatch`).
 
-2. Select the preferred region for this Batch account.
+1.  Select the preferred region for this Batch account.
 
-3. Select **Review and Create** to proceed to the review screen.
+1.  Select **Review and Create** to proceed to the review screen.
 
-4. Select **Create** to create the Azure Batch account.
+1.  Select **Create** to create the Azure Batch account.
 
 ### Compute environment
 
@@ -88,51 +88,51 @@ Batch Forge automates the configuration of an [Azure Batch](https://azure.micros
 
 Once the Azure resources are set up, add a new compute environment in Tower:
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g. "Azure Batch (east-us)"
+1.  Enter a descriptive name for this environment, e.g. "Azure Batch (east-us)"
 
-3. Select **Azure Batch** as the target platform.
+1.  Select **Azure Batch** as the target platform.
 
-4. From the **Credentials** drop-down, select existing Azure credentials, or select **+** to add new credentials. If you have existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing Azure credentials, or select **+** to add new credentials. If you have existing credentials, skip to step 7.
 
-5. Enter a name, e.g. "Azure Credentials".
+1.  Enter a name, e.g. "Azure Credentials".
 
-6. Add the **Batch account** and **Blob Storage** credentials that we created previously.
+1.  Add the **Batch account** and **Blob Storage** credentials that we created previously.
 
    :::tip
    You can create multiple credentials in your Tower environment.
    :::
 
-7. Select a **Region**, for example "eastus (East US)".
+1.  Select a **Region**, for example "eastus (East US)".
 
-8. In the **Pipeline work directory** field, enter the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
+1.  In the **Pipeline work directory** field, enter the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
 
    :::caution
    The blob container must be in the same **Region** from step 7.
    :::
 
-9. Set the **Config mode** to **Batch Forge**.
+1.  Set the **Config mode** to **Batch Forge**.
 
-10. Enter the default VM type, depending on your quota limits. The default is `Standard_D4_v3`.
+1.  Enter the default VM type, depending on your quota limits. The default is `Standard_D4_v3`.
 
-11. Enter the **VMs count**. This is the number of VMs you wish to deploy.
+1.  Enter the **VMs count**. This is the number of VMs you wish to deploy.
 
-12. Enable **Autoscale** if you'd like to scale up and down automatically based on the number of pipeline tasks. The number of VMs will vary from **0** to **VMs count**.
+1.  Enable **Autoscale** if you'd like to scale up and down automatically based on the number of pipeline tasks. The number of VMs will vary from **0** to **VMs count**.
 
-13. Enable **Dispose resources** if you'd like Tower to automatically delete the Batch pool once the workflow is complete.
+1.  Enable **Dispose resources** if you'd like Tower to automatically delete the Batch pool once the workflow is complete.
 
-14. Select or create a [**Container registry credential**](../credentials/azure_registry_credentials.mdx) to authenticate to an Azure registry (used by the [Wave containers](https://www.nextflow.io/docs/latest/wave.html) service).
+1.  Select or create a [**Container registry credential**](../credentials/azure_registry_credentials.mdx) to authenticate to an Azure registry (used by the [Wave containers](https://www.nextflow.io/docs/latest/wave.html) service).
 
-15. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-16. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-17. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-18. Configure any advanced options (see below), as needed.
+1.  Configure any advanced options (see below), as needed.
 
-19. Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before the compute environment is ready to launch pipelines.
+1.  Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before the compute environment is ready to launch pipelines.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 
@@ -148,39 +148,39 @@ This section is for users with a pre-configured Azure environment. You will need
 
 To create a new compute environment for AWS Batch (without Forge):
 
-1. In a workspace, select **Compute Environments**, then **New Environment**.
+1.  In a workspace, select **Compute Environments**, then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g. "Azure Batch (east-us)".
+1.  Enter a descriptive name for this environment, e.g. "Azure Batch (east-us)".
 
-3. Select **Azure Batch** as the target platform.
+1.  Select **Azure Batch** as the target platform.
 
-4. Select your existing Azure credentials or add new credentials by selecting the **+** button. If you are using existing credentials, skip to step 7.
+1.  Select your existing Azure credentials or add new credentials by selecting the **+** button. If you are using existing credentials, skip to step 7.
 
-5. Enter a name, e.g. "Azure Credentials".
+1.  Enter a name, e.g. "Azure Credentials".
 
-6. Add the **Batch account** and **Blob Storage** credentials that we created previously.
+1.  Add the **Batch account** and **Blob Storage** credentials that we created previously.
 
    :::tip
    You can create multiple credentials in your Tower environment.
    :::
 
-7. Select a **Region**, for example "eastus (East US)".
+1.  Select a **Region**, for example "eastus (East US)".
 
-8. In the **Pipeline work directory** field, add the Azure blob container created previously, e.g. `az://towerrgstorage-container/work`.
+1.  In the **Pipeline work directory** field, add the Azure blob container created previously, e.g. `az://towerrgstorage-container/work`.
 
    :::caution
    The Blob container must be in the same **Region** specified in step 7 above.
    :::
 
-9. Set the **Config mode** to **Manual**.
+1.  Set the **Config mode** to **Manual**.
 
-10. Enter the **Compute Pool name**. This is the name of the Azure Batch pool provided to you by your Azure administrator.
+1.  Enter the **Compute Pool name**. This is the name of the Azure Batch pool provided to you by your Azure administrator.
 
-11. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-12. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-13. Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
+1.  Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.1.0/compute-envs/eks.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/eks.mdx
@@ -56,37 +56,37 @@ See the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/add
 
 ## Compute environment
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "Amazon EKS (eu-west-1)".
+1.  Enter a descriptive name for this environment, e.g., "Amazon EKS (eu-west-1)".
 
-3. Select **Amazon EKS** as the target platform.
+1.  Select **Amazon EKS** as the target platform.
 
-4. From the **Credentials** drop-down, select existing AWS credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing AWS credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
 
    :::note
    The user must have the IAM permissions required to describe and list EKS clusters as explained [here](#requirements).
    :::
 
-5. Select a **Region**, e.g., "eu-west-1 - Europe (Ireland)".
+1.  Select a **Region**, e.g., "eu-west-1 - Europe (Ireland)".
 
-6. Select a **Cluster name** from the list of available EKS clusters in the selected region.
+1.  Select a **Cluster name** from the list of available EKS clusters in the selected region.
 
-7. Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is `tower-nf` by default.
+1.  Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is `tower-nf` by default.
 
-8. Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
+1.  Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
 
-9. Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called `tower-scratch` in each of the provided examples.
+1.  Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called `tower-scratch` in each of the provided examples.
 
-10. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.1.0/compute-envs/gke.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/gke.mdx
@@ -44,23 +44,23 @@ For more details, refer to the [Google documentation](https://cloud.google.com/k
 
 ## Compute Environment
 
-1. In a Tower workspace, select **Compute environments** and then **New environment**.
+1.  In a Tower workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "Google GKE (europe-west1)".
+1.  Enter a descriptive name for this environment, e.g., "Google GKE (europe-west1)".
 
-3. From the **Provider** drop-down, select **Google GKE**.
+1.  From the **Provider** drop-down, select **Google GKE**.
 
-4. From the **Credentials** drop-down, select existing GKE credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing GKE credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
 
-5. Enter a name for the credentials, e.g., "GKE Credentials".
+1.  Enter a name for the credentials, e.g., "GKE Credentials".
 
-6. Enter the **Service account key** for your Google Service account.
+1.  Enter the **Service account key** for your Google Service account.
 
    :::tip
    You can create multiple credentials in your Tower environment.
    :::
 
-7. Select the **Location** of your GKE cluster.
+1.  Select the **Location** of your GKE cluster.
 
    :::caution
    GKE clusters can be either _regional_ or _zonal_. For example, `us-west1` identifies the United States West-Coast region, which has three zones: `us-west1-a`, `us-west1-b`, and `us-west1-c`.
@@ -69,23 +69,23 @@ For more details, refer to the [Google documentation](https://cloud.google.com/k
    ![](./_images/gke_regions.png)
    :::
 
-8. Select or enter the **Cluster name** of your GKE cluster.
+1.  Select or enter the **Cluster name** of your GKE cluster.
 
-9. Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is `tower-nf` by default.
+1.  Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is `tower-nf` by default.
 
-10. Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is `tower-launcher-sa` by default.
+1.  Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is `tower-launcher-sa` by default.
 
-11. Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This serves as a scratch filesystem for Nextflow pipelines. The storage claim is called `tower-scratch` in each of the provided examples.
+1.  Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This serves as a scratch filesystem for Nextflow pipelines. The storage claim is called `tower-scratch` in each of the provided examples.
 
-12. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-13. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-14. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-15. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-16. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.1.0/compute-envs/google-cloud-batch.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/google-cloud-batch.mdx
@@ -11,9 +11,9 @@ Tower provides integration to Google Cloud via the [Batch API](https://cloud.goo
 
 The guide is split into two parts:
 
-1. How to configure your Google Cloud account to use the Batch API.
+1.  How to configure your Google Cloud account to use the Batch API.
 
-2. How to create a Google Cloud Batch compute environment in Tower.
+1.  How to create a Google Cloud Batch compute environment in Tower.
 
 ## Configure Google Cloud
 
@@ -49,15 +49,15 @@ Alternatively, you can enable each API manually by selecting your project in the
 
 ### Create a service account key
 
-1. In the navigation menu, select **IAM & Admin**, then **Service Accounts**.
+1.  In the navigation menu, select **IAM & Admin**, then **Service Accounts**.
 
-2. Select the email address of the **Compute Engine default service account**.
+1.  Select the email address of the **Compute Engine default service account**.
 
-3. Select **Keys**, then **Add key**, then **Create new key**.
+1.  Select **Keys**, then **Add key**, then **Create new key**.
 
-4. Select **JSON** as the key type.
+1.  Select **JSON** as the key type.
 
-5. Select **Create**.
+1.  Select **Create**.
 
 A JSON file will be downloaded to your computer. This file contains the credential needed to configure the compute environment in Tower.
 
@@ -65,33 +65,33 @@ You can manage your key from the **Service Accounts** page.
 
 ### Create a Cloud Storage bucket
 
-1. In the navigation menu (**≡**), select **Cloud Storage**, then **Create bucket**.
+1.  In the navigation menu (**≡**), select **Cloud Storage**, then **Create bucket**.
 
-2. Enter a name for your bucket. You will reference this name when creating the compute environment in Tower.
+1.  Enter a name for your bucket. You will reference this name when creating the compute environment in Tower.
 
    :::caution
    Do not use underscores (`_`) in your bucket name. Use hyphens (`-`) instead.
    :::
 
-3. Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Tower.
+1.  Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Tower.
 
-4. Select **Standard** for the default storage class.
+1.  Select **Standard** for the default storage class.
 
-5. Select **Uniform** for the **Access control**.
+1.  Select **Uniform** for the **Access control**.
 
    :::note
    The Batch API is available in a limited number of [locations](https://cloud.google.com/batch/docs/locations). These locations are only used to store metadata about the pipeline operations. The storage bucket and compute resources can be in any region.
    :::
 
-6. Select **Create**.
+1.  Select **Create**.
 
-7. Once the bucket is created, you will be redirected to the **Bucket details** page.
+1.  Once the bucket is created, you will be redirected to the **Bucket details** page.
 
-8. Select **Permissions**, then **+ Add**.
+1.  Select **Permissions**, then **+ Add**.
 
-9. Copy the email address of the Compute Engine default service account into **New principals**.
+1.  Copy the email address of the Compute Engine default service account into **New principals**.
 
-10. Select the following roles:
+1.  Select the following roles:
 
 - Storage Admin
 - Storage Legacy Bucket Owner
@@ -110,37 +110,37 @@ The following guide to configure Tower assumes you have (1) a service account ke
 
 To create a new compute environment for Google Cloud in Tower:
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g., "Google Cloud Batch (europe-north1)".
+1.  Enter a descriptive name for this environment, e.g., "Google Cloud Batch (europe-north1)".
 
-3. Select **Google Cloud Batch** as the target platform.
+1.  Select **Google Cloud Batch** as the target platform.
 
-4. From the **Credentials** drop-down, select existing Google credentials, or select **+** to add new credentials. If you have existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing Google credentials, or select **+** to add new credentials. If you have existing credentials, skip to step 7.
 
-5. Enter a name for the credentials, e.g. "Google Cloud Credentials".
+1.  Enter a name for the credentials, e.g. "Google Cloud Credentials".
 
-6. Enter the **Service account key** [created previously](#create-a-service-account-key).
+1.  Enter the **Service account key** [created previously](#create-a-service-account-key).
 
-7. Select the [**Location**](https://cloud.google.com/compute/docs/regions-zones#available) where you wish to execute pipelines.
+1.  Select the [**Location**](https://cloud.google.com/compute/docs/regions-zones#available) where you wish to execute pipelines.
 
-8. In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket should be accessible in the location selected in the previous step.
+1.  In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket should be accessible in the location selected in the previous step.
 
-9. Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
+1.  Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
 
-10. Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). <!--(re-added once we have GCP Fusion instructions) See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.-->
+1.  Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). <!--(re-added once we have GCP Fusion instructions) See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.-->
 
-11. Enable **Spot** to use spot instances, which have significantly reduced cost compared to on-demand instances.
+1.  Enable **Spot** to use spot instances, which have significantly reduced cost compared to on-demand instances.
 
-12. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-13. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-14. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-15. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-16. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.1.0/compute-envs/google-cloud-lifesciences.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/google-cloud-lifesciences.mdx
@@ -11,9 +11,9 @@ Tower provides integration to Google Cloud via the [Cloud Life Sciences API](htt
 
 This guide is split into two parts:
 
-1. How to configure your Google Cloud account to use the Cloud Life Sciences API.
+1.  How to configure your Google Cloud account to use the Cloud Life Sciences API.
 
-2. How to create a Google Life Sciences compute environment in Tower.
+1.  How to create a Google Life Sciences compute environment in Tower.
 
 ## Configure Google Cloud
 
@@ -49,15 +49,15 @@ Alternatively, select your project in the navigation bar and enable each API man
 
 ### Create a service account key
 
-1. In the navigation menu, select **IAM & Admin**, then **Service Accounts**.
+1.  In the navigation menu, select **IAM & Admin**, then **Service Accounts**.
 
-2. Select the email address of the **Compute Engine default service account**.
+1.  Select the email address of the **Compute Engine default service account**.
 
-3. Select **Keys**, then **Add key**, then **Create new key**.
+1.  Select **Keys**, then **Add key**, then **Create new key**.
 
-4. Select **JSON** as the key type.
+1.  Select **JSON** as the key type.
 
-5. Select **Create**.
+1.  Select **Create**.
 
 A JSON file will be downloaded to your computer. This file contains the credential needed to configure the compute environment in Tower.
 
@@ -65,33 +65,33 @@ You can manage your key from the **Service Accounts** page.
 
 ### Create a Cloud Storage bucket
 
-1. In the navigation menu (**≡**), select **Cloud Storage**, then **Create bucket**.
+1.  In the navigation menu (**≡**), select **Cloud Storage**, then **Create bucket**.
 
-2. Enter a name for your bucket. You will reference this name when creating the compute environment in Tower.
+1.  Enter a name for your bucket. You will reference this name when creating the compute environment in Tower.
 
    :::caution
    Do not use underscores (`_`) in your bucket name. Use hyphens (`-`) instead.
    :::
 
-3. Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Tower.
+1.  Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Tower.
 
-4. Select **Standard** for the default storage class.
+1.  Select **Standard** for the default storage class.
 
-5. Select **Uniform** for the **Access control**.
+1.  Select **Uniform** for the **Access control**.
 
    :::note
    The Cloud Life Sciences API is available in a limited number of [locations](https://cloud.google.com/life-sciences/docs/concepts/locations). These locations are only used to store metadata about the pipeline operations. The storage bucket and compute resources can be in any region.
    :::
 
-6. Select **Create**.
+1.  Select **Create**.
 
-7. Once the bucket is created, you will be redirected to the **Bucket details** page.
+1.  Once the bucket is created, you will be redirected to the **Bucket details** page.
 
-8. Select **Permissions**, then **+ Add**.
+1.  Select **Permissions**, then **+ Add**.
 
-9. Copy the email address of the Compute Engine default service account into **New principals**.
+1.  Copy the email address of the Compute Engine default service account into **New principals**.
 
-10. Select the following roles:
+1.  Select the following roles:
 
 - Storage Admin
 - Storage Legacy Bucket Owner
@@ -106,39 +106,39 @@ The following guide to configure Tower assumes you have (1) a service account ke
 
 To create a new compute environment for Google Cloud in Tower:
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g., "Google Life Sciences (europe-west2)".
+1.  Enter a descriptive name for this environment, e.g., "Google Life Sciences (europe-west2)".
 
-3. Select **Google Life Sciences** as the target platform.
+1.  Select **Google Life Sciences** as the target platform.
 
-4. From the **Credentials** drop-down, select existing Google Cloud credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing Google Cloud credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
 
-5. Enter a name for the credentials, e.g. "Google Cloud Credentials".
+1.  Enter a name for the credentials, e.g. "Google Cloud Credentials".
 
-6. Enter the **Service account key** [created previously](#create-a-service-account-key).
+1.  Enter the **Service account key** [created previously](#create-a-service-account-key).
 
    :::tip
    You can create multiple credentials in your Tower workspace.
    :::
 
-7. Select the [**Region** and **Zones**](https://cloud.google.com/compute/docs/regions-zones#available) where you wish to execute pipelines. Leave the **Location** empty for the Cloud Life Sciences API to use the closest available location.
+1.  Select the [**Region** and **Zones**](https://cloud.google.com/compute/docs/regions-zones#available) where you wish to execute pipelines. Leave the **Location** empty for the Cloud Life Sciences API to use the closest available location.
 
-8. In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket should be accessible in the region selected in the previous step.
+1.  In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket should be accessible in the region selected in the previous step.
 
-9. You can enable **Preemptible** to use preemptible instances, which have significantly reduced cost compared to on-demand instances.
+1.  You can enable **Preemptible** to use preemptible instances, which have significantly reduced cost compared to on-demand instances.
 
-10. You can use a **Filestore file system** to automatically mount a Google Filestore volume in your pipelines.
+1.  You can use a **Filestore file system** to automatically mount a Google Filestore volume in your pipelines.
 
-11. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-12. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-13. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-14. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-15. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.1.0/compute-envs/hpc.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/hpc.mdx
@@ -25,33 +25,33 @@ To launch pipelines into an **HPC** cluster from Tower, the following requiremen
 
 To create a new **HPC** compute environment in Tower:
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment.
+1.  Enter a descriptive name for this environment.
 
-3. Select your HPC environment from the **Platform** dropdown menu.
+1.  Select your HPC environment from the **Platform** dropdown menu.
 
-4. Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5. Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6. Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7. Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8. Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
 
-9. Enter the **Head queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will submit tasks.
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.1.0/compute-envs/k8s.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/k8s.mdx
@@ -15,13 +15,13 @@ The following instructions create a Tower compute environment for a **generic Ku
 
 To prepare your Kubernetes cluster for the deployment of Nextflow pipelines using Tower, this guide assumes that you have already created the cluster and that you have administrative privileges.
 
-1. Verify the connection to your Kubernetes cluster:
+1.  Verify the connection to your Kubernetes cluster:
 
    ```bash
    kubectl cluster-info
    ```
 
-2. Create the Tower launcher:
+1.  Create the Tower launcher:
 
    ```bash
    kubectl apply -f https://help.tower.nf/latest/_templates/k8s/tower-launcher.yml
@@ -29,7 +29,7 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
    This command creates a service account called `tower-launcher-sa` and the associated role bindings, all contained in a namespace called `tower-nf`. Tower uses the service account to launch Nextflow pipelines. Use this service account name when setting up the compute environment for this Kubernetes cluster in Tower.
 
-3. Create persistent storage. Tower requires a `ReadWriteMany` persistent volume claim (PVC) mounted to all nodes where workflow pods will be dispatched.
+1.  Create persistent storage. Tower requires a `ReadWriteMany` persistent volume claim (PVC) mounted to all nodes where workflow pods will be dispatched.
 
    You can use any storage solution that supports the `ReadWriteMany` [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes). The setup of this storage is beyond the scope of these instructions — the right solution for you will depend on what is available for your infrastructure or cloud vendor (NFS, GlusterFS, CephFS, Amazon FSx). Ask your cluster administrator for more information.
 
@@ -45,17 +45,17 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
 ## Compute environment
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "K8s cluster".
+1.  Enter a descriptive name for this environment, e.g., "K8s cluster".
 
-3. Select **Kubernetes** as the target platform.
+1.  Select **Kubernetes** as the target platform.
 
-4. From the **Credentials** drop-down, select existing Kubernetes credentials, or select **+** to add new credentials. If you have existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing Kubernetes credentials, or select **+** to add new credentials. If you have existing credentials, skip to step 7.
 
-5. Enter a name, e.g., "K8s Credentials".
+1.  Enter a name, e.g., "K8s Credentials".
 
-6. Enter the **Service account token**.
+1.  Enter the **Service account token**.
 
    Obtain the token with the following command:
 
@@ -66,7 +66,7 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
    Replace `<SERVICE-ACCOUNT-NAME>` with the name of the service account created in the [cluster preparation](#cluster-preparation) instructions (default: `tower-launcher-sa`).
 
-7. Enter the **Master server** URL.
+1.  Enter the **Master server** URL.
 
    Obtain the master server URL with the following command:
 
@@ -76,25 +76,25 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
    It can also be found in your `~/.kube/config` file under the `server` field corresponding to your cluster.
 
-8. Specify the **SSL certificate** to authenticate your connection.
+1.  Specify the **SSL certificate** to authenticate your connection.
 
    Find the certificate data in your `~/.kube/config` file. It is the `certificate-authority-data` field corresponding to your cluster.
 
-9. Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-nf` by default.
+1.  Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-nf` by default.
 
-10. Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
+1.  Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
 
-11. Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called `tower-scratch` in each of the provided examples.
+1.  Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called `tower-scratch` in each of the provided examples.
 
-12. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-13. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-14. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-15. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-16. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.1.0/compute-envs/lsf.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/lsf.mdx
@@ -23,35 +23,35 @@ To create a new compute environment for **LSF** in Tower:
 
 1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2.  Enter a descriptive name for this environment, e.g., "LSF".
+1.  Enter a descriptive name for this environment, e.g., "LSF".
 
-3.  Select **IBM LSF** as the target platform.
+1.  Select **IBM LSF** as the target platform.
 
-4.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5.  Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6.  Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
 
-9.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
 
     :::tip
     The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [documentation](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
     :::
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.1.0/compute-envs/moab.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/moab.mdx
@@ -23,35 +23,35 @@ To create a new compute environment for **Moab** in Tower:
 
 1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2.  Enter a descriptive name for this environment, e.g., "Moab cluster".
+1.  Enter a descriptive name for this environment, e.g., "Moab cluster".
 
-3.  Select **Moab Workload Manager** as the target platform.
+1.  Select **Moab Workload Manager** as the target platform.
 
-4.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5.  Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6.  Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8.  If using SSH credentials, enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  If using SSH credentials, enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
 
-9.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
 
     :::tip
     The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [documentation](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
     :::
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.1.0/compute-envs/overview.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/overview.mdx
@@ -30,9 +30,9 @@ Each compute environment must be configured to enable Tower to submit tasks. See
 
 If you have more than one compute environment, you can select which one will be used by default when launching a pipeline.
 
-1. In a workspace, select **Compute Environments**.
+1.  In a workspace, select **Compute Environments**.
 
-2. Select **Make primary** for a particular compute environment to make it your default.
+1.  Select **Make primary** for a particular compute environment to make it your default.
 
 ### GPU usage
 

--- a/platform_versioned_docs/version-23.1.0/compute-envs/slurm.mdx
+++ b/platform_versioned_docs/version-23.1.0/compute-envs/slurm.mdx
@@ -23,35 +23,35 @@ To create a new compute environment for **Slurm** in Tower:
 
 1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2.  Enter a descriptive name for this environment, e.g., "Slurm cluster".
+1.  Enter a descriptive name for this environment, e.g., "Slurm cluster".
 
-3.  Select **Slurm Workload Manager** as the target platform.
+1.  Select **Slurm Workload Manager** as the target platform.
 
-4.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5.  Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6.  Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
 
-9.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
 
     :::tip
     The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [documentation](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
     :::
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.1.0/credentials/aws_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.1.0/credentials/aws_registry_credentials.mdx
@@ -19,13 +19,13 @@ Wave requires programmatic access to your private registry via [long-term access
 
 An IAM administrator can create and manage access keys from the AWS management console:
 
-1. Open the [IAM console](https://console.aws.amazon.com/iam/).
-2. Select **Users** from the navigation pane.
-3. Select the name of the user whose keys you want to manage, then select the **Security credentials** tab. We recommend creating an IAM user specifically for Wave authentication instead of using existing credentials with broader permissions.
-4. In the **Access keys** section, select **Create access key**. Each IAM user can have only two access keys at a time, so if the Create option is deactivated, delete an existing access key first.
-5. On the **Access key best practices & alternatives** page, select **Other** and then **Next**.
-6. On the **Retrieve access key** page, you can either **Show** the user's secret access key details, or store them by selecting **Download .csv file**.
-7. The newly created access key pair is active by default and can be stored as a container registry credential in Tower.
+1.  Open the [IAM console](https://console.aws.amazon.com/iam/).
+1.  Select **Users** from the navigation pane.
+1.  Select the name of the user whose keys you want to manage, then select the **Security credentials** tab. We recommend creating an IAM user specifically for Wave authentication instead of using existing credentials with broader permissions.
+1.  In the **Access keys** section, select **Create access key**. Each IAM user can have only two access keys at a time, so if the Create option is deactivated, delete an existing access key first.
+1.  On the **Access key best practices & alternatives** page, select **Other** and then **Next**.
+1.  On the **Retrieve access key** page, you can either **Show** the user's secret access key details, or store them by selecting **Download .csv file**.
+1.  The newly created access key pair is active by default and can be stored as a container registry credential in Tower.
 
 :::note
 Your credential must be stored in Tower as a **container registry** credential, even if the same access keys already exist in Tower as a workspace credential.

--- a/platform_versioned_docs/version-23.1.0/credentials/azure_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.1.0/credentials/azure_registry_credentials.mdx
@@ -19,18 +19,18 @@ Azure container registry makes use of Azure RBAC (Role-Based Access Control) to 
 
 You must use Azure credentials with long-term registry read (**content/read**) access to authenticate Tower to your registry. We recommend a [token with repository-scoped permissions](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions) that is used only by Tower.
 
-1. In the Azure portal, navigate to your container registry.
-2. Under **Repository permissions**, select **Tokens -> +Add**.
-3. Enter a token name.
-4. Under **Scope map**, select **Create new**.
-5. In the **Create scope map** section, enter a name and description for the new scope map.
-6. Select your **Repository** from the drop-down menu.
-7. Select **content/read** from the **Permissions** drop-down menu, then select **Add** to create the scope map.
-8. In the **Create token** section, ensure the **Status** is **Enabled** (default), then select **Create**.
-9. Return to **Repository permissions -> Tokens** for your registry, then select the token you just created.
-10. On the token details page, select **password1** or **password2**.
-11. In the password details section, uncheck the **Set expiration date?** checkbox, then select **Generate**.
-12. Copy and save the password after it is generated. The password will be displayed only once.
+1.  In the Azure portal, navigate to your container registry.
+1.  Under **Repository permissions**, select **Tokens -> +Add**.
+1.  Enter a token name.
+1.  Under **Scope map**, select **Create new**.
+1.  In the **Create scope map** section, enter a name and description for the new scope map.
+1.  Select your **Repository** from the drop-down menu.
+1.  Select **content/read** from the **Permissions** drop-down menu, then select **Add** to create the scope map.
+1.  In the **Create token** section, ensure the **Status** is **Enabled** (default), then select **Create**.
+1.  Return to **Repository permissions -> Tokens** for your registry, then select the token you just created.
+1.  On the token details page, select **password1** or **password2**.
+1.  In the password details section, uncheck the **Set expiration date?** checkbox, then select **Generate**.
+1.  Copy and save the password after it is generated. The password will be displayed only once.
 
 ### Add credentials to Tower
 

--- a/platform_versioned_docs/version-23.1.0/credentials/docker_hub_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.1.0/credentials/docker_hub_registry_credentials.mdx
@@ -19,11 +19,11 @@ You must use Docker Hub credentials with **Read-only** access to authenticate To
 
 To create your access token in Docker Hub:
 
-1. Log in to [Docker Hub](https://hub.docker.com/).
-2. Select your username in the top right corner and select **Account Settings**.
-3. Select **Security -> New Access Token**.
-4. Enter a token description and select **Read-only** from the Access permissions drop-down menu, then select **Generate**.
-5. Copy and save the generated access token (this is only displayed once).
+1.  Log in to [Docker Hub](https://hub.docker.com/).
+1.  Select your username in the top right corner and select **Account Settings**.
+1.  Select **Security -> New Access Token**.
+1.  Enter a token description and select **Read-only** from the Access permissions drop-down menu, then select **Generate**.
+1.  Copy and save the generated access token (this is only displayed once).
 
 ### Add credentials to Tower
 

--- a/platform_versioned_docs/version-23.1.0/credentials/quay_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.1.0/credentials/quay_registry_credentials.mdx
@@ -17,12 +17,12 @@ Container registry credentials are only leveraged by the Wave containers service
 
 For Quay repositories, we recommend using [robot accounts](https://docs.quay.io/glossary/robot-accounts.html) with **Read** access permissions for authentication:
 
-1. Sign in to [quay.io](https://quay.io/).
-2. From the user or organization view, select the **Robot Accounts** tab.
-3. Select **Create Robot Account**.
-4. Enter a robot account name. The username for robot accounts have the format `namespace+accountname`, where `namespace` is the user or organization name and `accountname` is your chosen robot account name.
-5. Grant the robot account repository **Read** permissions from **Settings -> User and Robot Permissions** in the repository view.
-6. Select the robot account in your admin panel to retrieve the token value.
+1.  Sign in to [quay.io](https://quay.io/).
+1.  From the user or organization view, select the **Robot Accounts** tab.
+1.  Select **Create Robot Account**.
+1.  Enter a robot account name. The username for robot accounts have the format `namespace+accountname`, where `namespace` is the user or organization name and `accountname` is your chosen robot account name.
+1.  Grant the robot account repository **Read** permissions from **Settings -> User and Robot Permissions** in the repository view.
+1.  Select the robot account in your admin panel to retrieve the token value.
 
 ### Add credentials to Tower
 

--- a/platform_versioned_docs/version-23.1.0/credentials/ssh_credentials.mdx
+++ b/platform_versioned_docs/version-23.1.0/credentials/ssh_credentials.mdx
@@ -20,12 +20,12 @@ To use SSH public key authentication:
 
 To generate an SSH key pair:
 
-1. From the target machine, open a terminal and run `ssh-keygen`.
-2. Follow the prompts to:
+1.  From the target machine, open a terminal and run `ssh-keygen`.
+1.  Follow the prompts to:
    - specify a file path and name (or keep the default)
    - specify a passphrase (recommended)
-3. Navigate to the target folder (default `/home/user/.ssh/id_rsa`) and open the private key file with a plain text editor.
-4. Copy the private key file contents before navigating to Tower.
+1.  Navigate to the target folder (default `/home/user/.ssh/id_rsa`) and open the private key file with a plain text editor.
+1.  Copy the private key file contents before navigating to Tower.
 
 ### Create an SSH credential in Tower
 

--- a/platform_versioned_docs/version-23.1.0/datasets/overview.mdx
+++ b/platform_versioned_docs/version-23.1.0/datasets/overview.mdx
@@ -48,11 +48,11 @@ All Tower users have access to the datasets feature in organization workspaces.
 
 To create a new dataset, follow these steps:
 
-1. Open the **Datasets** tab in your organization workspace.
-2. Select **New dataset**.
-3. Complete the **Name** and **Description** fields using information relevant to your dataset.
-4. Add the dataset file to your workspace with drag-and-drop or the system file explorer dialog.
-5. For dataset files that use the first row for column names, customize the dataset view with the **First row as header** option.
+1.  Open the **Datasets** tab in your organization workspace.
+1.  Select **New dataset**.
+1.  Complete the **Name** and **Description** fields using information relevant to your dataset.
+1.  Add the dataset file to your workspace with drag-and-drop or the system file explorer dialog.
+1.  For dataset files that use the first row for column names, customize the dataset view with the **First row as header** option.
 
 :::note
 The size of the dataset file cannot exceed 10MB.
@@ -62,9 +62,9 @@ The size of the dataset file cannot exceed 10MB.
 
 Tower can accommodate multiple versions of a dataset. To add a new version for an existing dataset, follow these steps:
 
-1. Select **Edit** next to the dataset you wish to update.
-2. In the Edit dialog, select **Add a new version**.
-3. Upload the newer version of the dataset and select **Update**.
+1.  Select **Edit** next to the dataset you wish to update.
+1.  In the Edit dialog, select **Add a new version**.
+1.  Upload the newer version of the dataset and select **Update**.
 
 :::caution
 All subsequent versions of a dataset must be the same format (.csv or .tsv) as the initial version.
@@ -74,9 +74,9 @@ All subsequent versions of a dataset must be the same format (.csv or .tsv) as t
 
 To use a dataset with the saved pipelines in your workspace, follow these steps:
 
-1. Open any pipeline that contains a pipeline-schema from the Launchpad.
-2. Select the input field for the pipeline, removing any default value.
-3. Pick the dataset to use as input to your pipeline.
+1.  Open any pipeline that contains a pipeline-schema from the Launchpad.
+1.  Select the input field for the pipeline, removing any default value.
+1.  Pick the dataset to use as input to your pipeline.
 
 :::note
 The input field drop-down menu will only display datasets that match the file type specified in the `nextflow_schema.json` of the chosen pipeline. If the schema specifies `"mimetype": "text/csv"`, no TSV datasets will be available for use with that pipeline, and vice versa.

--- a/platform_versioned_docs/version-23.1.0/enterprise/_templates/nginx/cert_on_frontend.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/_templates/nginx/cert_on_frontend.mdx
@@ -1,7 +1,7 @@
 title: "cert_on_frontend"
 This example assumes deployment on an Amazon Linux 2 AMI.
 
-1. Install nginx and other required packages:
+1.  Install nginx and other required packages:
 
    ```yml
    sudo amazon-linux-extras install nginx1.12
@@ -12,9 +12,9 @@ This example assumes deployment on an Amazon Linux 2 AMI.
    sudo amazon-linux-extras install epel -y
    ```
 
-2. Generate a [private certificate and key](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs).
+1.  Generate a [private certificate and key](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs).
 
-3. Create a `ssl.conf` file.
+1.  Create a `ssl.conf` file.
 
    ```conf
 
@@ -52,15 +52,15 @@ This example assumes deployment on an Amazon Linux 2 AMI.
 
    ```
 
-4. Make a local copy of the `frontend` container's `/etc/nginx/nginx.conf` file.
+1.  Make a local copy of the `frontend` container's `/etc/nginx/nginx.conf` file.
 
-5. Add the following to the `server` block of your local `nginx.conf` file:
+1.  Add the following to the `server` block of your local `nginx.conf` file:
 
    ```conf
    include /etc/nginx/ssl.conf;
    ```
 
-6. Modify the `frontend` container definition in your `docker-compose.yml` file:
+1.  Modify the `frontend` container definition in your `docker-compose.yml` file:
 
    ```yml
    frontend:

--- a/platform_versioned_docs/version-23.1.0/enterprise/advanced-topics/cloudformation.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/advanced-topics/cloudformation.mdx
@@ -14,11 +14,11 @@ This guide assumes that all [prerequisites](../prerequisites/aws.mdx) have been 
 
 ## Setup ECS cluster
 
-1. Navigate to the ECS console in AWS.
+1.  Navigate to the ECS console in AWS.
 
-2. Select **Create cluster**.
+1.  Select **Create cluster**.
 
-3. Select **Amazon ECS** -> **Clusters** -> **EC2 Linux + Networking**.
+1.  Select **Amazon ECS** -> **Clusters** -> **EC2 Linux + Networking**.
 
 ### ECS Cluster Configuration
 
@@ -62,13 +62,13 @@ Obtain Instance `ServerURL`
 
 </details>
 
-1. Download [aws-ecs-cloudformation.json](../_templates/cloudformation/aws-ecs-cloudformation.json) and [params.json.template](../_templates/cloudformation/params.json.template).
+1.  Download [aws-ecs-cloudformation.json](../_templates/cloudformation/aws-ecs-cloudformation.json) and [params.json.template](../_templates/cloudformation/params.json.template).
 
-2. Rename `params.template.json` to `params.json` and configure for your environment.
+1.  Rename `params.template.json` to `params.json` and configure for your environment.
 
    For more information on configuration, visit the [Configuration](../configuration/overview.mdx) section.
 
-3. Deploy the Tower stack to your ECS cluster:
+1.  Deploy the Tower stack to your ECS cluster:
 
    ```bash
    aws cloudformation create-stack \

--- a/platform_versioned_docs/version-23.1.0/enterprise/advanced-topics/db-docker-to-RDS.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/advanced-topics/db-docker-to-RDS.mdx
@@ -9,23 +9,23 @@ While [Docker Compose](../docker-compose.mdx) is a fast and convenient way to de
 
 ## Points to consider before migration
 
-1. **Target Database**
+1.  **Target Database**
 
    You have options when choosing your new MySQL-compliant database. While the process is mostly the same, some of the commands will be different (example: [MariaDB on RDS](../configuration/database_and_redis.mdx#generate-user-and-schema)).
 
-2. **How much data must be moved?**
+1.  **How much data must be moved?**
 
    The data in your database must be exported from the MySQL container and imported to the new instance. Depending on the amount of data in your database and the amount of remaining EC2 EBS capacity, you may be able to save your data directly onto the instance, or be forced to make use of a service with more capacity (such as S3).
 
-3. **Testing**
+1.  **Testing**
 
    What level of testing is required to determine the data has been properly migrated?
 
-4. **Maintenance window**
+1.  **Maintenance window**
 
    It is much simpler to initiate a migration once all transactions to the database cease than to do so while jobs are still running. Perform the migration at a time when an outage can occur and notify your users in advance.
 
-5. **MySQL container volume retention**
+1.  **MySQL container volume retention**
 
    Seqera highly suggests retaining your original volume until you are 100% satisfied that the migration occurred without error. So long as the volume is kept, you can fall back to the MySQL container and ensure that Kinnate does not lose any of the material generated thus far.
 
@@ -33,9 +33,9 @@ While [Docker Compose](../docker-compose.mdx) is a fast and convenient way to de
 
 Before starting your migration, do the following:
 
-1. Create an RDS MySQL-compliant instance and populate it with a [**tower user** and **tower database**](../configuration/database_and_redis.mdx#generate-user-and-schema).
+1.  Create an RDS MySQL-compliant instance and populate it with a [**tower user** and **tower database**](../configuration/database_and_redis.mdx#generate-user-and-schema).
 
-2. Ensure your EC2 instance and database instance's Security Group(s) have been configured to allow MySQL traffic (default: Port 3306).
+1.  Ensure your EC2 instance and database instance's Security Group(s) have been configured to allow MySQL traffic (default: Port 3306).
 
 ## Steps
 
@@ -47,88 +47,88 @@ These steps assume the following:
 
 :::
 
-1. Connect to to the EC2 instance using **SSH** and navigate to Tower's **docker-compose** folder.
+1.  Connect to to the EC2 instance using **SSH** and navigate to Tower's **docker-compose** folder.
 
-2. Shut down Tower:
+1.  Shut down Tower:
 
    ```bash
    docker-compose down
    ```
 
-3. Mount a new folder into the MySQL container for migration activities:
+1.  Mount a new folder into the MySQL container for migration activities:
 
-   1. Create a new folder to hold migration artefacts.
+   1.  Create a new folder to hold migration artefacts.
 
       ```bash
       mkdir ~/tower_migration
       ```
 
-   2. Backup the database.
+   2.  Backup the database.
 
       ```bash
       sudo tar -zcvf ~/tower_migration/tower_backup.tar.gz ~/.tower/db/mysql
       ```
 
-4. Modify the Tower **docker-compose.yml**:
+1.  Modify the Tower **docker-compose.yml**:
 
-   1. Add new volume entry for the db container.
+   1.  Add new volume entry for the db container.
 
    ```
    $HOME/tower_migration:/tower_migration
    ```
 
-5. Restart Tower to ensure your changes were successful.
+1.  Restart Tower to ensure your changes were successful.
 
    ```bash
    docker-compose down
    ```
 
-6. Stop all the non-MySQL containers.
+1.  Stop all the non-MySQL containers.
 
    ```bash
    docker container stop <CONTAINER ID>
    ```
 
-7. Exec onto the MySQL ontainer.
+1.  Exec onto the MySQL ontainer.
 
    ```bash
    docker exec -it <CONTAINER ID> /bin/bash
    ```
 
-   1. Dump your data to disk.
+   1.  Dump your data to disk.
 
       ```bash
       mysqldump -u tower -p --databases tower --no-tablespaces --set-gtid-purged=OFF > /tower_migration/tower_dumpfile.sql
       ```
 
-   2. Exit the container.
+   2.  Exit the container.
 
-8. Stop the MySQL container.
+1.  Stop the MySQL container.
 
    ```bash
    docker container stop <CONTAINER ID>
    ```
 
-9. Import the dump file into your new RDS instance.
+1.  Import the dump file into your new RDS instance.
 
    ```bash
    mysql --host <DB-HOST> --port 3306 -u tower -p tower < ~/tower_migration/tower_dumpfile.sql
    ```
 
-10. Log on to the RDS instance and ensure that the tower database is populated with tables prefixed by 'tw\_'.
+1.  Log on to the RDS instance and ensure that the tower database is populated with tables prefixed by 'tw\_'.
 
-11. Modify the **tower.env** in the Tower docker folder:
+1.  Modify the **tower.env** in the Tower docker folder:
 
-    1. Comment out the existing TOWER_DB-\* variables.
-    2. Add new entries [relevant to your database choice](../configuration/database_and_redis.mdx#configure-towerenv_1).
-    3. Save and exit.
+    1.  Comment out the existing TOWER_DB-\* variables.
+    2.  Add new entries [relevant to your database choice](../configuration/database_and_redis.mdx#configure-towerenv_1).
+    3.  Save and exit.
 
-12. Restart Tower.
+1.  Restart Tower.
 
     ```bash
     docker-compose up
     ```
 
-13. Confirm that Tower starts and that your data is available when you log in.
+1.  Confirm that Tower starts and that your data is available when you log in.
 
 Congratulations! Your migration is complete and your testing can begin.

--- a/platform_versioned_docs/version-23.1.0/enterprise/advanced-topics/tower-container-images.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/advanced-topics/tower-container-images.mdx
@@ -118,8 +118,8 @@ The Seqera Labs container registry `cr.seqera.io` is the default Tower container
 :::caution
 If you are unable to pull container images due to a `denied: Permission "artifactregistry.repositories.downloadArtifacts" denied on resouce "projects/nf-tower-enterprise/locations/eurpoe-west2/repositories/containers" (or it may not exist)` error, try the following:
 
-1. If your Docker requires sudo, [add sudo](https://cloud.google.com/artifact-registry/docs/docker/authentication#gcloud-helper) to the `gcloud auth configure-docker europe-west2-docker.pkg.dev` command.
+1.  If your Docker requires sudo, [add sudo](https://cloud.google.com/artifact-registry/docs/docker/authentication#gcloud-helper) to the `gcloud auth configure-docker europe-west2-docker.pkg.dev` command.
 
-2. If you installed Docker onto Ubuntu using `snap`, ensure your [containerd config](https://jhartman.pl/2022/03/23/how-to-fix-permission-artifactregistry-repositories-downloadartifacts-denied-on-resource-on-ubuntu-when-pulling-from-google-artifact-repository/) is properly updated.
+1.  If you installed Docker onto Ubuntu using `snap`, ensure your [containerd config](https://jhartman.pl/2022/03/23/how-to-fix-permission-artifactregistry-repositories-downloadartifacts-denied-on-resource-on-ubuntu-when-pulling-from-google-artifact-repository/) is properly updated.
 
    :::

--- a/platform_versioned_docs/version-23.1.0/enterprise/advanced-topics/use-iam-role.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/advanced-topics/use-iam-role.mdx
@@ -32,8 +32,8 @@ Create a custom IAM Policy ([Tower-Role-Policy.json](../_templates/Tower-Role-Po
 
 </details>
 
-1. Modify `BucketPolicy01` and `BucketPolicy02` with the name(s) of the your S3 Buckets.
-2. Revise (if necessary) the scope of access to a specific prefix in the S3 bucket(s).
+1.  Modify `BucketPolicy01` and `BucketPolicy02` with the name(s) of the your S3 Buckets.
+1.  Revise (if necessary) the scope of access to a specific prefix in the S3 bucket(s).
 
 ## Modify the Tower IAM Role Trust Policy (optional)
 
@@ -46,39 +46,39 @@ Review and modify the Role Trust Policy ([Tower-Role-Trust-Policy.json](../_temp
     ```
 </details>
 
-1. Replace `YOUR-AWS-ACCOUNT` with your own AWS Account Id.
+1.  Replace `YOUR-AWS-ACCOUNT` with your own AWS Account Id.
 
-2. Specify the Users and/or Roles able to assume the Tower IAM Role.
+1.  Specify the Users and/or Roles able to assume the Tower IAM Role.
 
 ## Create the IAM artefacts
 
 [Create the IAM Artefacts](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html) in your AWS Account.
 
-1. Navigate to the folder containing your configured IAM documents:
+1.  Navigate to the folder containing your configured IAM documents:
 
    ```bash
    cd <FOLDER_WITH_YOUR_CONFIGURED_IAM_DOCUMENTS>
    ```
 
-2. Create the **Role**:
+1.  Create the **Role**:
 
    ```bash
    aws iam create-role --role-name Tower-Role --assume-role-policy-document file://Tower-Role-Trust-Policy.json
    ```
 
-3. Create an **inline policy** for the Role:
+1.  Create an **inline policy** for the Role:
 
    ```bash
    aws iam put-role-policy --role-name Tower-Role --policy-name Tower-Role-Policy --policy-document file://Tower-Role-Policy.json
    ```
 
-4. Create an **instance profile**:
+1.  Create an **instance profile**:
 
    ```bash
    aws iam create-instance-profile --instance-profile-name Tower-Instance
    ```
 
-5. **Bind** the Role to the instance profile:
+1.  **Bind** the Role to the instance profile:
 
    ```bash
    aws iam add-role-to-instance-profile --instance-profile-name Tower-Instance --role-name Tower-Role
@@ -88,21 +88,21 @@ Review and modify the Role Trust Policy ([Tower-Role-Trust-Policy.json](../_temp
 
 With the IAM artefacts complete, update your Tower application configuration:
 
-1. Add the following entry to your `tower.env`
+1.  Add the following entry to your `tower.env`
 
    ```env
    TOWER_ALLOW_INSTANCE_CREDENTIALS=true
    ```
 
-2. Restart the Tower application.
+1.  Restart the Tower application.
 
-3. Verify that the change took effect by querying the Tower instance `service-info` endpoint:
+1.  Verify that the change took effect by querying the Tower instance `service-info` endpoint:
 
    ```bash
    curl -X GET "https://YOUR-TOWER-DOMAIN/api/service-info" -H "Accept: application/json" | jq ".serviceInfo.allowInstanceCredentials"
    ```
 
-4. Log in to Tower and create a new AWS credential. You are now prompted for an AWS `arn` instead of access keys.
+1.  Log in to Tower and create a new AWS credential. You are now prompted for an AWS `arn` instead of access keys.
 
    **Before Change**:
    ![](./_images/tower_credentials_aws_keys.png)

--- a/platform_versioned_docs/version-23.1.0/enterprise/configuration/authentication.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/configuration/authentication.mdx
@@ -102,30 +102,30 @@ Complete the setup on Tower side adding the following environment variables to y
 
 To make use of [Azure AD for the OIDC](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc) as identity provider for Tower, configure a new client in your Azure AD service:
 
-1. Log in to the [Azure portal](https://portal.azure.com/).
-2. Navigate to the **Azure Active Directory** service.
-3. Select **Manage Tenants**.
-4. Create a new **Tenant** (e.g. `NextflowTowerOrg`).
-5. Navigate to the newly-created Tenant.
-6. Go to **App Registrations**.
-7. Click **New Registration**.
+1.  Log in to the [Azure portal](https://portal.azure.com/).
+1.  Navigate to the **Azure Active Directory** service.
+1.  Select **Manage Tenants**.
+1.  Create a new **Tenant** (e.g. `NextflowTowerOrg`).
+1.  Navigate to the newly-created Tenant.
+1.  Go to **App Registrations**.
+1.  Click **New Registration**.
 
-   1. Enter a name for the application.
-   2. Specify the scope of user verification (e.g. single tenant, multi-tenant, personal MSFT accounts, etc).
+   1.  Enter a name for the application.
+   2.  Specify the scope of user verification (e.g. single tenant, multi-tenant, personal MSFT accounts, etc).
 
    :::note
    The Azure AD app must have user consent settings configured to "Allow user consent for apps" to ensure that admin approval is not required for each application login. See [User consent settings](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/configure-user-consent?pivots=portal#configure-user-consent-settings).
    :::
 
-8. Specify the **Redirect** (callback) URI (NOTE: Microsoft requires that this URI uses `HTTPS`)
+1.  Specify the **Redirect** (callback) URI (NOTE: Microsoft requires that this URI uses `HTTPS`)
 
-9. Open the newly-created app:
-   1. Note the Application (client) ID under the Essentials table
-   2. Generate Client credentials under the Essentials table
-   3. Click Endpoints and note the OpenID Connect metadata document URI
-10. Add users to your tenant as required.
+1.  Open the newly-created app:
+   1.  Note the Application (client) ID under the Essentials table
+   2.  Generate Client credentials under the Essentials table
+   3.  Click Endpoints and note the OpenID Connect metadata document URI
+1.  Add users to your tenant as required.
 
-11. Complete the setup on Tower side adding the following environment variables to your configuration:
+1.  Complete the setup on Tower side adding the following environment variables to your configuration:
 
     ```bash
     TOWER_OIDC_CLIENT=<YOUR_APPLICATION_ID>
@@ -133,7 +133,7 @@ To make use of [Azure AD for the OIDC](https://docs.microsoft.com/en-us/azure/ac
     TOWER_OIDC_ISSUER=<YOUR_OIDC_METADATA_URL_UP_TO_"v2.0">   (e.g. https://login.microsoftonline.com/000000-0000-0000-00-0000000000000/v2.0)
     ```
 
-12. Add `auth-oidc` to the end of the `MICRONAUT_ENVIRONMENTS` value for both the `cron` and `backend` services.
+1.  Add `auth-oidc` to the end of the `MICRONAUT_ENVIRONMENTS` value for both the `cron` and `backend` services.
 
 ## Configure user access allow list
 

--- a/platform_versioned_docs/version-23.1.0/enterprise/docker-compose.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/docker-compose.mdx
@@ -35,17 +35,17 @@ In order for your DB or Redis volume to persist after a `docker restart`, uncomm
     ```
 </details>
 
-1. Download and configure [tower.env](_templates/docker/tower.env).
+1.  Download and configure [tower.env](_templates/docker/tower.env).
 
-2. Download and configure [tower.yml](_templates/docker/tower.yml), update values for allowed emails.
+1.  Download and configure [tower.yml](_templates/docker/tower.yml), update values for allowed emails.
 
-3. Download and configure [docker-compose.yml](_templates/docker/docker-compose.yml).
+1.  Download and configure [docker-compose.yml](_templates/docker/docker-compose.yml).
 
    The `db` and `mail` containers should only be used for local testing; you may remove them if you have configured these services elsewhere.
 
    Make sure to customize the `TOWER_ENABLE_PLATFORMS` variable to include the execution platform(s) you will use.
 
-4. Deploy Tower and wait for it to initialize (takes a few minutes):
+1.  Deploy Tower and wait for it to initialize (takes a few minutes):
 
    ```bash
    docker-compose up
@@ -59,21 +59,21 @@ For more information on configuration, see [Configuration options](./configurati
 
 To make sure that Tower is properly configured, follow these steps:
 
-1. Login to Tower.
+1.  Login to Tower.
 
-2. Create an **organization**.
+1.  Create an **organization**.
 
-3. Create a **workspace** within that organization.
+1.  Create a **workspace** within that organization.
 
-4. Create a new **Compute Environment**. Refer to [Compute Environments](https://help.tower.nf/compute-envs/overview/) for detailed instructions.
+1.  Create a new **Compute Environment**. Refer to [Compute Environments](https://help.tower.nf/compute-envs/overview/) for detailed instructions.
 
-5. Select **Quick Launch** from the **Launchpad** tab in your workspace.
+1.  Select **Quick Launch** from the **Launchpad** tab in your workspace.
 
-6. Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
+1.  Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
 
-7. In the **Config profiles** dropdown, select the `test` profile.
+1.  In the **Config profiles** dropdown, select the `test` profile.
 
-8. In the **Pipeline parameters** text area, change the output directory to a sensible location based on your Compute Environment:
+1.  In the **Pipeline parameters** text area, change the output directory to a sensible location based on your Compute Environment:
 
    ```yaml
    # save to S3 bucket
@@ -83,7 +83,7 @@ To make sure that Tower is properly configured, follow these steps:
    outdir: /scratch/results
    ```
 
-9. Select **Launch**.
+1.  Select **Launch**.
 
    You'll be transitioned to the **Runs** tab for the workflow. After a few minutes, you'll see the progress logs in the **Execution log** tab for that workflow.
 

--- a/platform_versioned_docs/version-23.1.0/enterprise/general_troubleshooting.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/general_troubleshooting.mdx
@@ -273,9 +273,9 @@ The secret used to generate the login JWT token that is appended to user sign-in
 
 This error points to an issue with the SSH credentials used to authenticate Tower to your HPC cluster (LSF, Slurm, etc.), such as an invalid SSH key or inappropriate permissions on the user directory. Check the following:
 
-1. Test the SSH key to ensure it is still valid. If not, create new SSH keys and [re-create the compute environment](https://help.tower.nf/latest/compute-envs/lsf/) in Tower using the updated credentials.
+1.  Test the SSH key to ensure it is still valid. If not, create new SSH keys and [re-create the compute environment](https://help.tower.nf/latest/compute-envs/lsf/) in Tower using the updated credentials.
 
-2. Check the backend logs for a stack trace similar to the following:
+1.  Check the backend logs for a stack trace similar to the following:
 
    ```
    [io-executor-thread-2] 10.42.0.1 ERROR i.s.t.c.GlobalErrorController - Oops... Unable to process request - Error ID: 5d7rDpS8pByF8YqfUVPvB4
@@ -298,13 +298,13 @@ This error points to an issue with the SSH credentials used to authenticate Towe
        at net.schmizz.sshj.userauth.keyprovider.PKCS5KeyFile$ASN1Data.<init>(PKCS5KeyFile.java:248)
    ```
 
-3. Enable SSH library log tracing with the following environbment variable in your `tower.env` file for verbose debug logging of the SSH connection:
+1.  Enable SSH library log tracing with the following environbment variable in your `tower.env` file for verbose debug logging of the SSH connection:
 
 ```env
 TOWER_SSH_LOGLEVEL=TRACE
 ```
 
-4. Check the permissions of the `/home` directory of the user tied to the cluster's SSH credentials. `/home/[user]` should be `chmod 755`, whereas `/home/[user]/ssh` requires `chmod 700`.
+1.  Check the permissions of the `/home` directory of the user tied to the cluster's SSH credentials. `/home/[user]` should be `chmod 755`, whereas `/home/[user]/ssh` requires `chmod 700`.
 
 ```bash
 $ pwd ; ls -ld .

--- a/platform_versioned_docs/version-23.1.0/enterprise/index.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/index.mdx
@@ -77,15 +77,15 @@ _Reference architecture diagram of Tower on AWS using Elastic Kubernetes Service
 Nextflow Tower is distributed as a collection of Docker containers available through the Seqera Labs
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. Once you have received your credentials, log in to the registry using these steps:
 
-1. Retrieve the **name** and **secret** values from the JSON file you received from Seqera Labs support.
+1.  Retrieve the **name** and **secret** values from the JSON file you received from Seqera Labs support.
 
-2. Authenticate to the registry (using the `name` and `secret` values copied in step 1):
+1.  Authenticate to the registry (using the `name` and `secret` values copied in step 1):
 
    ```bash
    docker login -u '<NAME>' -p '<SECRET>' cr.seqera.io
    ```
 
-3. Pull the Nextflow Tower container images:
+1.  Pull the Nextflow Tower container images:
 
    ```bash
    docker pull {{ images.tower_be_image }}

--- a/platform_versioned_docs/version-23.1.0/enterprise/kubernetes.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/kubernetes.mdx
@@ -17,13 +17,13 @@ You may also use this guide for deployments to other cloud platforms (e.g. Oracl
 
 Create a namespace to group the Tower resources within your K8s cluster.
 
-1. Create the namespace (e.g. `tower-nf`):
+1.  Create the namespace (e.g. `tower-nf`):
 
    ```bash
    kubectl create namespace tower-nf
    ```
 
-2. Switch to the namespace:
+1.  Switch to the namespace:
 
    ```bash
    kubectl config set-context --current --namespace=tower-nf
@@ -34,9 +34,9 @@ Create a namespace to group the Tower resources within your K8s cluster.
 Nextflow Tower is distributed as a collection of Docker containers available through the Seqera Labs
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. Once you have received your credentials, grant your cluster access to the registry using these steps:
 
-1. Retrieve the `name` and `secret` values from the JSON file you received from Seqera Labs support.
+1.  Retrieve the `name` and `secret` values from the JSON file you received from Seqera Labs support.
 
-2. Create a Kubernetes [Secret](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/), using the `name` and `secret` retrieved in step 1, with this command:
+1.  Create a Kubernetes [Secret](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/), using the `name` and `secret` retrieved in step 1, with this command:
 
    ```bash
    kubectl create secret docker-registry cr.seqera.io \
@@ -47,7 +47,7 @@ container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](htt
 
    Note: The credential `name` contains a dollar `$` character. To prevent the Linux shell from interpreting this value as an environment variable, wrap it in single quotes.
 
-3. The following snippet configures the Tower cron service and the Tower frontend and backend to use the Secret created in step 2 (see [tower-cron.yml](./_templates/k8s/tower-cron.yml) and [tower-svc.yml](./_templates/k8s/tower-svc.yml)):
+1.  The following snippet configures the Tower cron service and the Tower frontend and backend to use the Secret created in step 2 (see [tower-cron.yml](./_templates/k8s/tower-cron.yml) and [tower-svc.yml](./_templates/k8s/tower-svc.yml)):
 
 ```yml
 imagePullSecrets:
@@ -65,9 +65,9 @@ This parameter is already included in the templates linked above — if you use 
   ```
 </details>
 
-1. Download and configure [configmap.yml](_templates/k8s/configmap.yml) as per the [configuration](configuration/overview.mdx) page.
+1.  Download and configure [configmap.yml](_templates/k8s/configmap.yml) as per the [configuration](configuration/overview.mdx) page.
 
-2. Deploy the configmap to your cluster:
+1.  Deploy the configmap to your cluster:
 
    ```bash
    kubectl apply -f configmap.yml
@@ -134,11 +134,11 @@ You may also be able to use a managed Redis service such as [Amazon Elasticache]
     ```
 </details>
 
-1. Download the manifest:
+1.  Download the manifest:
 
 - [tower-cron.yml](_templates/k8s/tower-cron.yml)
 
-2. Deploy to your cluster:
+1.  Deploy to your cluster:
 
 ```bash
 kubectl apply -f tower-cron.yml
@@ -226,21 +226,21 @@ kubectl get pods
 
 To make sure that Tower is properly configured, follow these steps:
 
-1. Log in to Tower.
+1.  Log in to Tower.
 
-2. Create an **organization**.
+1.  Create an **organization**.
 
-3. Create a **workspace** within that organization.
+1.  Create a **workspace** within that organization.
 
-4. Create a new **Compute Environment**. Refer to [Compute Environments](https://help.tower.nf/compute-envs/overview/) for detailed instructions.
+1.  Create a new **Compute Environment**. Refer to [Compute Environments](https://help.tower.nf/compute-envs/overview/) for detailed instructions.
 
-5. Select **Quick Launch** from the **Launchpad** tab in your workspace.
+1.  Select **Quick Launch** from the **Launchpad** tab in your workspace.
 
-6. Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
+1.  Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
 
-7. In the **Config profiles** dropdown, select the `test` profile.
+1.  In the **Config profiles** dropdown, select the `test` profile.
 
-8. In the **Pipeline parameters** textarea, change the output directory to a sensible location based on your Compute Environment:
+1.  In the **Pipeline parameters** textarea, change the output directory to a sensible location based on your Compute Environment:
 
    ```yaml
    # save to S3 bucket
@@ -250,7 +250,7 @@ To make sure that Tower is properly configured, follow these steps:
    outdir: /scratch/results
    ```
 
-9. Select **Launch**.
+1.  Select **Launch**.
 
    You'll be transitioned to the **Runs** tab for the workflow. After a few minutes, you'll see the progress logs in the **Execution log** tab for that workflow.
 
@@ -267,13 +267,13 @@ To make sure that Tower is properly configured, follow these steps:
 
 The included [dbconsole.yml](_templates/k8s/dbconsole.yml) can be used to deploy a simple web frontend to the Tower database. It is _not_ required but it can be useful for administrative purposes.
 
-1. Deploy the database console:
+1.  Deploy the database console:
 
    ```bash
    kubectl apply -f dbconsole.yml
    ```
 
-2. Port-forward the database console to your local machine:
+1.  Port-forward the database console to your local machine:
 
    ```bash
    kubectl port-forward deployment/dbconsole 8080:8080

--- a/platform_versioned_docs/version-23.1.0/enterprise/prerequisites/aws.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/prerequisites/aws.mdx
@@ -12,13 +12,13 @@ This page describes the infrastructure and other prerequisites for deploying Tow
 Nextflow Tower is distributed as a collection of Docker containers available through the Seqera Labs
 container registry ([cr.seqera.io](https://cr.seqera.io)). Contact [support](https://support.seqera.io) to get your container access credentials. Once you have received your credentials, log in to the registry using these steps:
 
-1. Retrieve the **username** and **password** you received from Seqera Labs support.
+1.  Retrieve the **username** and **password** you received from Seqera Labs support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
 
-3. Pull the Nextflow Tower container images with the following commands:
+1.  Pull the Nextflow Tower container images with the following commands:
 
 ```bash
 docker pull {{ images.tower_be_image }}
@@ -116,17 +116,17 @@ This section provides step-by-step instructions for some commonly used AWS servi
 
 From Tower version 23.1, you can retrieve Tower configuration values remotely from the AWS Parameter Store.
 
-1. Configure [AWS authentication](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html) to grant AWS Parameter Store access on your local host.
-2. Retrieve the Tower container images and install Tower per the instructions at the top of this page.
-3. The default value for `tower.application.name` is `tower-app`. This can be changed in your `tower.yml` configuration file. Note that your application name must be specified in the path to your configuration values in AWS Parameter Store (see step 5 below).
-4. Set the `TOWER_ENABLE_AWS_SSM` environment variable to `true`. Alternatively, add the value `aws-ssm` to the `TOWER_ENABLE_PLATFORMS` variable.
-5. Add configuration parameters to the AWS Parameter Store individually, using the format `/config/<application_name>/<cfg_path> : <cfg_value>`. For example:
+1.  Configure [AWS authentication](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html) to grant AWS Parameter Store access on your local host.
+1.  Retrieve the Tower container images and install Tower per the instructions at the top of this page.
+1.  The default value for `tower.application.name` is `tower-app`. This can be changed in your `tower.yml` configuration file. Note that your application name must be specified in the path to your configuration values in AWS Parameter Store (see step 5 below).
+1.  Set the `TOWER_ENABLE_AWS_SSM` environment variable to `true`. Alternatively, add the value `aws-ssm` to the `TOWER_ENABLE_PLATFORMS` variable.
+1.  Add configuration parameters to the AWS Parameter Store individually, using the format `/config/<application_name>/<cfg_path> : <cfg_value>`. For example:
 
    ```bash
    /config/tower-app/tower.logger.levels.com.amazonaws : "WARN"
    ```
 
-6. Start or restart your Tower instance to confirm that the configuration value is fetched. The following entries should appear in your backend log:
+1.  Start or restart your Tower instance to confirm that the configuration value is fetched. The following entries should appear in your backend log:
 
    ```bash
    [main] - INFO  i.m.context.DefaultBeanContext - Reading bootstrap environment configuration
@@ -139,27 +139,27 @@ From Tower version 23.1, you can retrieve Tower configuration values remotely fr
 If you're using Simple Email Service in sandbox mode, ensure that both the _sender_ and the _receiver_ email addresses are verified via AWS SES. Note that sandbox is not recommended for production use. See the [AWS docs](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) for instructions to move out of the sandbox.
 :::
 
-1. Navigate to the [**Amazon Simple Email Service**](https://us-east-2.console.aws.amazon.com/ses) console.
+1.  Navigate to the [**Amazon Simple Email Service**](https://us-east-2.console.aws.amazon.com/ses) console.
 
-2. In the navigation menu, select **SMTP Settings**.
+1.  In the navigation menu, select **SMTP Settings**.
 
-3. Select **Create my SMTP Credentials**
+1.  Select **Create my SMTP Credentials**
 
-4. Select **Create**.
+1.  Select **Create**.
 
-5. Select **Show User SMTP Credentials** to copy your credentials, or select **Download Credentials**.
+1.  Select **Show User SMTP Credentials** to copy your credentials, or select **Download Credentials**.
 
    :::caution
    The credentials (username and password) will not be shown to you again after this instance.
    :::
 
-6. You will be automatically redirected to the IAM dashboard. Log back in to the [Amazon SES Console](https://us-east-2.console.aws.amazon.com/ses).
+1.  You will be automatically redirected to the IAM dashboard. Log back in to the [Amazon SES Console](https://us-east-2.console.aws.amazon.com/ses).
 
-7. Select **Email Addresses** in the navigation menu. Then, select **Verify a new Email Address**.
+1.  Select **Email Addresses** in the navigation menu. Then, select **Verify a new Email Address**.
 
-8. A pop-up asking for your email should automatically appear. Once you type in your email address and select **Verify This Email Address**, you should receive a confirmation email from Amazon SES to confirm email address ownership.
+1.  A pop-up asking for your email should automatically appear. Once you type in your email address and select **Verify This Email Address**, you should receive a confirmation email from Amazon SES to confirm email address ownership.
 
-9. Open the verification link in the message.
+1.  Open the verification link in the message.
 
    :::caution
    The verification link is **only valid for 24 hours** after your original request for verification.
@@ -175,76 +175,76 @@ See the AWS documentation for more options, such as setting up an [Easy DKIM for
 
 ### Amazon RDS
 
-1. Open the [Amazon RDS console](https://console.aws.amazon.com/rds/).
+1.  Open the [Amazon RDS console](https://console.aws.amazon.com/rds/).
 
-2. Select **Create database** -> **Standard create** -> **MySQL**.
+1.  Select **Create database** -> **Standard create** -> **MySQL**.
 
-3. Under **Edition**, select **MySQL Community** and any version under **5.7.x**, or **8.0.x**.
+1.  Under **Edition**, select **MySQL Community** and any version under **5.7.x**, or **8.0.x**.
 
-4. Enter the **DB cluster identifier** (e.g., `nftower-db`).
+1.  Enter the **DB cluster identifier** (e.g., `nftower-db`).
 
-5. Enter the **Master username**, or keep the default.
+1.  Enter the **Master username**, or keep the default.
 
-6. Enter the **Master password**.
+1.  Enter the **Master password**.
 
    - To use an automatically generated master password, select **Auto generate a password**.
    - To use a custom master password, deselect **Auto generate a password** and enter your password in **Master password** and **Confirm password**.
 
-7. Under **Instance configuration**, select the **DB instance class** and instance type.
+1.  Under **Instance configuration**, select the **DB instance class** and instance type.
 
-8. Under **Connectivity**, select the correct **VPC security group**. Confirm this with your AWS administrator.
+1.  Under **Connectivity**, select the correct **VPC security group**. Confirm this with your AWS administrator.
 
-9. Under **Additional configuration**, enter the **Initial database name** (e.g., `tower`).
+1.  Under **Additional configuration**, enter the **Initial database name** (e.g., `tower`).
 
-10. Select **Create database**.
+1.  Select **Create database**.
 
 After your database is created:
 
-1. Update the inbound rules for the underlying EC2 instance to allow MySQL connections.
+1.  Update the inbound rules for the underlying EC2 instance to allow MySQL connections.
 
-2. Update `TOWER_DB_URL` in your configuration value with the database hostname.
+1.  Update `TOWER_DB_URL` in your configuration value with the database hostname.
 
 ### Amazon EC2
 
 If you have never set up an Amazon EC2 instance for Linux, refer to [this guide](https://aws.amazon.com/ec2/getting-started/) to get started with Amazon EC2.
 
-1. Open the [AWS Management console](https://us-east-2.console.aws.amazon.com/console/home).
+1.  Open the [AWS Management console](https://us-east-2.console.aws.amazon.com/console/home).
 
-2. Log in as an IAM user with your credentials.
+1.  Log in as an IAM user with your credentials.
 
-3. Under **AWS services**, select **All Services**.
+1.  Under **AWS services**, select **All Services**.
 
-4. Under **Compute**, select **EC2**.
+1.  Under **Compute**, select **EC2**.
 
-5. Select **Instances**, then **Launch instances**.
+1.  Select **Instances**, then **Launch instances**.
 
-6. You will be asked to choose an Amazon Machine Image (AMI). Scroll to the middle of the page and select **Amazon Linux 2**.
+1.  You will be asked to choose an Amazon Machine Image (AMI). Scroll to the middle of the page and select **Amazon Linux 2**.
 
-7. Once you click **Select**, you will be redirected to **Step 2: Choose an Instance Type**.
+1.  Once you click **Select**, you will be redirected to **Step 2: Choose an Instance Type**.
 
-8. Scroll down and select either **c5a.xlarge** or **c5.large** — these provide 4 CPUs and 8GB of RAM.
+1.  Scroll down and select either **c5a.xlarge** or **c5.large** — these provide 4 CPUs and 8GB of RAM.
 
-9. Select **Next: Configure Instance Details**.
+1.  Select **Next: Configure Instance Details**.
 
-10. If required, configure the instance details settings. Then, select **Next: Add Storage**.
+1.  If required, configure the instance details settings. Then, select **Next: Add Storage**.
 
-11. The root storage should be 20GB. Configure this under **Size (GiB)**.
+1.  The root storage should be 20GB. Configure this under **Size (GiB)**.
 
-12. Select **Add Tags** (if required) to add case-sensitive key-value pairs (e.g., `key = Name` and `value = Webserver`).
+1.  Select **Add Tags** (if required) to add case-sensitive key-value pairs (e.g., `key = Name` and `value = Webserver`).
 
-13. Select **Next: Configure Security Group**.
+1.  Select **Next: Configure Security Group**.
 
-14. Enter `nftower-sg` as the Security Group name.
+1.  Enter `nftower-sg` as the Security Group name.
 
-15. Optionally, you can enter a description for your Security Group's name.
+1.  Optionally, you can enter a description for your Security Group's name.
 
-16. Configure the type of protocol settings. Note that the security group port must be configured to 8000.
+1.  Configure the type of protocol settings. Note that the security group port must be configured to 8000.
 
-17. Select **Review and Launch**.
+1.  Select **Review and Launch**.
 
-18. Once you have reviewed your instance, select **Launch**.
+1.  Once you have reviewed your instance, select **Launch**.
 
-19. Select an existing key pair or create a new one in the pop-up that appears.
+1.  Select an existing key pair or create a new one in the pop-up that appears.
 
     If you already have an existing key pair, select **Choose an existing key pair** and choose from the available options in the drop-down menu.
 
@@ -252,11 +252,11 @@ If you have never set up an Amazon EC2 instance for Linux, refer to [this guide]
 
     **Note:** once you download the key pair, store it in a secure and accessible location. You will not be able to download the file again after it is created.
 
-20. Select **Launch Instances**.
+1.  Select **Launch Instances**.
 
-21. Use the key pair to connect to the server using SSH and its public IP address. Terminal-based SSH is easier to use than browser-based SSH for copying and pasting text.
+1.  Use the key pair to connect to the server using SSH and its public IP address. Terminal-based SSH is easier to use than browser-based SSH for copying and pasting text.
 
-22. Enter the following commands to set up `docker` and `docker-compose`.
+1.  Enter the following commands to set up `docker` and `docker-compose`.
 
 ```bash
 # Install and start the docker engine

--- a/platform_versioned_docs/version-23.1.0/enterprise/prerequisites/azure.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/prerequisites/azure.mdx
@@ -12,15 +12,15 @@ This page describes the infrastructure and other prerequisites for deploying Tow
 Nextflow Tower is distributed as a collection of Docker containers available through the Seqera Labs
 container registry ([cr.seqera.io](https://cr.seqera.io)). Contact [support](https://support.seqera.io) to get your container access credentials. Once you have received your credentials, log in to the registry using these steps:
 
-1. Retrieve the **username** and **password** you received from Seqera Labs support.
+1.  Retrieve the **username** and **password** you received from Seqera Labs support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    ```bash
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
    ```
 
-3. Pull the Nextflow Tower container images with the following commands:
+1.  Pull the Nextflow Tower container images with the following commands:
 
 ```bash
 docker pull {{ images.tower_be_image }}
@@ -102,13 +102,13 @@ This section provides step-by-step instructions for some commonly used Azure ser
 
 ### Azure Resource Group
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
+1.  Sign in to the [Azure portal](https://portal.azure.com).
 
-2. Select **Resource groups**.
+1.  Select **Resource groups**.
 
-3. Select **Add**.
+1.  Select **Add**.
 
-4. Enter the following values:
+1.  Enter the following values:
 
    - **Subscription**: Select your Azure subscription.
 
@@ -116,19 +116,19 @@ This section provides step-by-step instructions for some commonly used Azure ser
 
    - **Region**: Select the Region where your assets will exist (e.g. `East US`).
 
-5. Select **Review and Create**.
+1.  Select **Review and Create**.
 
-6. Select **Create**.
+1.  Select **Create**.
 
 ### Azure Storage Account
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
+1.  Sign in to the [Azure portal](https://portal.azure.com).
 
-2. Select **Storage accounts**.
+1.  Select **Storage accounts**.
 
-3. Select **Create**.
+1.  Select **Create**.
 
-4. Enter the following values:
+1.  Enter the following values:
 
    - **Subscription**: Select your Azure subscription.
 
@@ -142,71 +142,71 @@ This section provides step-by-step instructions for some commonly used Azure ser
 
    - **Redundancy**: Select `Geo-redundant storage (GRS)`
 
-5. Select **Review + create**. Note that the default values are used in the other tabs. See the [Azure documentation](https://docs.microsoft.com/en-ca/azure/storage/common/storage-account-create?tabs=azure-portal#create-a-storage-account-1) for further details on each setting.
+1.  Select **Review + create**. Note that the default values are used in the other tabs. See the [Azure documentation](https://docs.microsoft.com/en-ca/azure/storage/common/storage-account-create?tabs=azure-portal#create-a-storage-account-1) for further details on each setting.
 
-6. Select **Create**.
+1.  Select **Create**.
 
 ### Azure Linux VM
 
 We recommend the following VM settings:
 
-1. Use **default values** unless otherwise specified.
-2. Provision at least **2 CPUS** and **8GB RAM**.
-3. Use the **Ubuntu Server 20.04 LTS - Gen2** image.
-4. Ensure your VM is **accessible by SSH**.
-5. Do not implement DNS or Load Balancing directly against the VM (do so via Azure Application Gateway instead).
+1.  Use **default values** unless otherwise specified.
+1.  Provision at least **2 CPUS** and **8GB RAM**.
+1.  Use the **Ubuntu Server 20.04 LTS - Gen2** image.
+1.  Ensure your VM is **accessible by SSH**.
+1.  Do not implement DNS or Load Balancing directly against the VM (do so via Azure Application Gateway instead).
 
 To create a VM:
 
-1. Configure the **Basics** tab:
+1.  Configure the **Basics** tab:
 
    - Ensure your **Region** is the same as your **Resource group**.
    - Do not set the VM as an **Azure Spot instance**.
    - Ensure your Security Group allows ingress on **Port 8000**.
 
-2. Configure the **Disks** tab:
+1.  Configure the **Disks** tab:
 
    - Ensure your OS disk type is **Standard SSD**.
 
-3. Configure the **Network** tab:
+1.  Configure the **Network** tab:
 
    - Ensure that a **Public IP** is assigned to the VM.
    - Do not place the VM in the backend pool of an existing load balancing solution.
 
-4. Select **Review + create**.
+1.  Select **Review + create**.
 
-5. Select **Create**.
+1.  Select **Create**.
 
 To make the VM's IP address static:
 
-1. Enter **Public IP addresses** in the search.
+1.  Enter **Public IP addresses** in the search.
 
-2. Under **Services**, select **Public IP addresses**.
+1.  Under **Services**, select **Public IP addresses**.
 
-3. On the **Public IP addresses** page, select the entry containing your VM name. A page opens with that IP's details.
+1.  On the **Public IP addresses** page, select the entry containing your VM name. A page opens with that IP's details.
 
-4. Select **Configuration** from the left-hand navigation panel.
+1.  Select **Configuration** from the left-hand navigation panel.
 
-5. Ensure that your IP address assignment is **Static**.
+1.  Ensure that your IP address assignment is **Static**.
 
-6. Do not add a custom DNS name label to the VM.
+1.  Do not add a custom DNS name label to the VM.
 
 To allow ingress on port 8000:
 
-1. Enter **Virtual Machines** in the search bar.
+1.  Enter **Virtual Machines** in the search bar.
 
-2. Under **Services**, select **Virtual machines**.
+1.  Under **Services**, select **Virtual machines**.
 
-3. On the **Virtual machines** page, select your VM name to navigate to the VM details.
+1.  On the **Virtual machines** page, select your VM name to navigate to the VM details.
 
-4. Select **Networking** from the left-hand navigation panel.
+1.  Select **Networking** from the left-hand navigation panel.
 
-5. **Add inbound port rule** for port 8000.
+1.  **Add inbound port rule** for port 8000.
 
 To install Docker:
 
 1.  Complete the steps for the [Install using the apt repository][docker] instructions.
-2.  Confirm that Docker Compose is installed:
+1.  Confirm that Docker Compose is installed:
 
     ```bash
     docker compose version

--- a/platform_versioned_docs/version-23.1.0/enterprise/prerequisites/gcp.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/prerequisites/gcp.mdx
@@ -12,15 +12,15 @@ This page describes the infrastructure and other prerequisites for deploying Tow
 Nextflow Tower is distributed as a collection of Docker containers available through the Seqera Labs
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. Once you have received your credentials, log in to the registry using these steps:
 
-1. Retrieve the **username** and **password** you received from Seqera Labs support.
+1.  Retrieve the **username** and **password** you received from Seqera Labs support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
 ```bash
 docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
 ```
 
-3. Pull the Nextflow Tower container images with the following commands:
+1.  Pull the Nextflow Tower container images with the following commands:
 
 ```bash
 docker pull {{ images.tower_be_image }}
@@ -82,13 +82,13 @@ From Tower 22.1.1, HTTP-only implementations **must** set the `TOWER_ENABLE_UNSA
 
 A public IP address can be reserved for the Tower ingress to keep the IP address constant across restarts. If you do not reserve an IP address, the ingress will create one for you automatically, but it will be different every time you deploy the ingress. See the [detailed instructions](#detailed-instructions) to reserve a public IP address.
 
-1. Browse to **VPC network** → **External IP addresses** and select **Reserve Static Address**
+1.  Browse to **VPC network** → **External IP addresses** and select **Reserve Static Address**
 
-2. Assign a name (e.g., `tower-ip`). This name will be used later to configure the ingress.
+1.  Assign a name (e.g., `tower-ip`). This name will be used later to configure the ingress.
 
-3. Select the region where your GKE cluster is deployed.
+1.  Select the region where your GKE cluster is deployed.
 
-4. Select **Reserve**.
+1.  Select **Reserve**.
 
 ## Detailed instructions
 
@@ -96,37 +96,37 @@ This section provides step-by-step instructions for some commonly used GCP servi
 
 ### Google CloudSQL
 
-1. Browse to **Cloud SQL** and select **Create Instance**.
+1.  Browse to **Cloud SQL** and select **Create Instance**.
 
-2. Select **MySQL** (you may need to enable the API).
+1.  Select **MySQL** (you may need to enable the API).
 
-3. Change to **Single zone** availability, unless there is a need for high availability.
+1.  Change to **Single zone** availability, unless there is a need for high availability.
 
-4. Update the **Region** and **Zone** to match the location of your Tower deployment.
+1.  Update the **Region** and **Zone** to match the location of your Tower deployment.
 
-5. Expand **Show configuration options** and update the **Machine type** and **Storage** settings. The recommended machine type and disk size depends on the number of parallel pipelines you expect to run. In this guide, we use the **Standard** machine type with **1 vCPU**, and **20 GB SSD** storage.
+1.  Expand **Show configuration options** and update the **Machine type** and **Storage** settings. The recommended machine type and disk size depends on the number of parallel pipelines you expect to run. In this guide, we use the **Standard** machine type with **1 vCPU**, and **20 GB SSD** storage.
 
-6. Expand **Connections**, disable **Public IP**, and enable **Private IP**.
+1.  Expand **Connections**, disable **Public IP**, and enable **Private IP**.
 
-7. Select the **Network** (usually **default**). You may need to set up a **Private services access connection** for this VPC if you have not done so already. Enable the API and select **Use an automatically allocated IP range**. Select **Continue**, then **Create Connection**.
+1.  Select the **Network** (usually **default**). You may need to set up a **Private services access connection** for this VPC if you have not done so already. Enable the API and select **Use an automatically allocated IP range**. Select **Continue**, then **Create Connection**.
 
-8. Select **Create Instance**.
+1.  Select **Create Instance**.
 
-9. Once the database has been created, select the instance, then **Databases**. Create a new database named **tower**.
+1.  Once the database has been created, select the instance, then **Databases**. Create a new database named **tower**.
 
-10. Note the Private IP address of the instance as it must be supplied to the `TOWER_DB_URL` environment variable.
+1.  Note the Private IP address of the instance as it must be supplied to the `TOWER_DB_URL` environment variable.
 
 ### Google Compute Engine
 
-1. From the Navigation menu of the Google Cloud console, select **Compute Engine** to create a new VM instance. Select the machine name, region/zone, and machine type. In this example we have used an `e2-standard-2` instance (2 vCPUs, 8 GB memory). We recommend using the [container-optimized OS](https://cloud.google.com/community/tutorials/docker-compose-on-container-optimized-os) for the VM.
+1.  From the Navigation menu of the Google Cloud console, select **Compute Engine** to create a new VM instance. Select the machine name, region/zone, and machine type. In this example we have used an `e2-standard-2` instance (2 vCPUs, 8 GB memory). We recommend using the [container-optimized OS](https://cloud.google.com/community/tutorials/docker-compose-on-container-optimized-os) for the VM.
 
-2. Enable HTTP traffic. By default, the frontend is exposed to port 8000, so you will need to add a firewall rule to the underlying VPC network to allow port 8000 (after VM creation).
+1.  Enable HTTP traffic. By default, the frontend is exposed to port 8000, so you will need to add a firewall rule to the underlying VPC network to allow port 8000 (after VM creation).
 
-3. Connect to the machine using SSH. If you run into issues with SSH, or would like to set up IAP SSH, refer to the documentation for [TCP forward to IAP](https://cloud.google.com/iap/docs/using-tcp-forwarding).
+1.  Connect to the machine using SSH. If you run into issues with SSH, or would like to set up IAP SSH, refer to the documentation for [TCP forward to IAP](https://cloud.google.com/iap/docs/using-tcp-forwarding).
 
-4. Install [Docker](https://docs.docker.com/engine/install/debian/) if it is not already installed.
+1.  Install [Docker](https://docs.docker.com/engine/install/debian/) if it is not already installed.
 
-5. Test Docker by running the [Docker Compose](https://hub.docker.com/r/docker/compose/tags/) image. If Docker does not have sufficient permissions, use [these steps](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) to run it without root, or use `sudo`.
+1.  Test Docker by running the [Docker Compose](https://hub.docker.com/r/docker/compose/tags/) image. If Docker does not have sufficient permissions, use [these steps](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) to run it without root, or use `sudo`.
 
    ```bash
    # test docker compose
@@ -136,7 +136,7 @@ This section provides step-by-step instructions for some commonly used GCP servi
    docker images
    ```
 
-6. Create an alias for `docker-compose`:
+1.  Create an alias for `docker-compose`:
 
    ```bash
    echo alias docker-compose="'"'docker run --rm \
@@ -148,4 +148,4 @@ This section provides step-by-step instructions for some commonly used GCP servi
    source .bashrc
    ```
 
-7. Configure `gcloud` and Docker as described in [Tower container images](#tower-container-images).
+1.  Configure `gcloud` and Docker as described in [Tower container images](#tower-container-images).

--- a/platform_versioned_docs/version-23.1.0/enterprise/prerequisites/on-prem.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/prerequisites/on-prem.mdx
@@ -12,15 +12,15 @@ This page describes the prerequisites for deploying Tower to your on-premises in
 Nextflow Tower is distributed as a collection of Docker containers available through the Seqera Labs
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. Once you have received your credentials, log in to the registry using these steps:
 
-1. Retrieve the **username** and **password** you received from Seqera Labs support.
+1.  Retrieve the **username** and **password** you received from Seqera Labs support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    ```bash
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
    ```
 
-3. Pull the Nextflow Tower container images with the following commands:
+1.  Pull the Nextflow Tower container images with the following commands:
 
    ```bash
    docker pull {{ images.tower_be_image }}

--- a/platform_versioned_docs/version-23.1.0/enterprise/release_notes/22.1.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/release_notes/22.1.mdx
@@ -68,44 +68,44 @@ We have also implemented a first version of a much requested feature from HPC us
 
 ## Notes
 
-1. As of version 22.1.x, Nextflow Tower Enterprise will follow a three month release cadence, using the following version number scheme: `YY.Q.PATCH`, where `YY` represents the year, `Q` represents the quarter and `PATCH` the incremental patch number.
+1.  As of version 22.1.x, Nextflow Tower Enterprise will follow a three month release cadence, using the following version number scheme: `YY.Q.PATCH`, where `YY` represents the year, `Q` represents the quarter and `PATCH` the incremental patch number.
 
-2. As of version 21.02.x, a license key must be provided to enable the Tower deployment feature. The license key should be specified using the configuration variable `TOWER_LICENSE`. If you don't have a license key, contact sales@seqera.io.
+2.  As of version 21.02.x, a license key must be provided to enable the Tower deployment feature. The license key should be specified using the configuration variable `TOWER_LICENSE`. If you don't have a license key, contact sales@seqera.io.
 
 ## Warnings
 
-1. This version now expects the use of HTTPS by default for all browser client connections.
+1.  This version now expects the use of HTTPS by default for all browser client connections.
 
    If your Tower installation requires the use of unsecured HTTP, set the following environment variable in the infrastructure hosting the Tower application: `TOWER_ENABLE_UNSAFE_MODE=true`.
 
-2. If you are upgrading from a version of Tower prior to `21.04.x`, please update your implementation to `21.04.x` before installing this release.
+2.  If you are upgrading from a version of Tower prior to `21.04.x`, please update your implementation to `21.04.x` before installing this release.
 
 ## Database Schema
 
 This Tower version requires a database schema update. Follow these steps to update your DB instance and the Tower installation.
 
-1. Make a backup of the Tower database.
+1.  Make a backup of the Tower database.
 
-2. Download and update your container versions to:
+2.  Download and update your container versions to:
 
    - `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v22.1.5`
    - `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v22.1.5`
 
-3. Redeploy the Tower application:
+3.  Redeploy the Tower application:
 
    - **docker-compose**:
 
-     1. Restart the application with `docker-compose restart`. This will automatically migrate the database schema.
+     1.  Restart the application with `docker-compose restart`. This will automatically migrate the database schema.
 
    - **kubernetes**:
 
-     1. Update the cron service with `kubectl apply -f tower-cron.yml`. This will automatically migrate the database schema.
-     2. Update the frontend and backend services with `kubectl apply -f tower-srv.yml`.
+     1.  Update the cron service with `kubectl apply -f tower-cron.yml`. This will automatically migrate the database schema.
+     2.  Update the frontend and backend services with `kubectl apply -f tower-srv.yml`.
 
    - **custom deployment**
 
-     1. Run the `/migrate-db.sh` script provided in the `backend` container. This will migrate the database schema.
-     2. Deploy Tower following your usual procedures.
+     1.  Run the `/migrate-db.sh` script provided in the `backend` container. This will migrate the database schema.
+     2.  Deploy Tower following your usual procedures.
 
 ## Nextflow Launcher Image
 

--- a/platform_versioned_docs/version-23.1.0/enterprise/release_notes/22.2.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/release_notes/22.2.mdx
@@ -53,9 +53,9 @@ Available reports are listed in a Reports tab on the Runs page. Users can select
 
 ## Notes
 
-1. As of version 22.1.x, Nextflow Tower Enterprise will follow a three month release cadence, using the following version number scheme: `YY.Q.PATCH`, where `YY` represents the year, `Q` represents the quarter and `PATCH` the incremental patch number.
+1.  As of version 22.1.x, Nextflow Tower Enterprise will follow a three month release cadence, using the following version number scheme: `YY.Q.PATCH`, where `YY` represents the year, `Q` represents the quarter and `PATCH` the incremental patch number.
 
-2. As of version 21.02.x, a license key must be provided to enable the Tower deployment feature. The license key should be specified using the configuration variable `TOWER_LICENSE`. If you don't have a license key, contact sales@seqera.io.
+2.  As of version 21.02.x, a license key must be provided to enable the Tower deployment feature. The license key should be specified using the configuration variable `TOWER_LICENSE`. If you don't have a license key, contact sales@seqera.io.
 
 ## Warnings
 
@@ -71,28 +71,28 @@ Available reports are listed in a Reports tab on the Runs page. Users can select
 
 This Tower version requires a database schema update. Follow these steps to update your DB instance and the Tower installation.
 
-1. Make a backup of the Tower database.
+1.  Make a backup of the Tower database.
 
-2. Download and update your container versions to:
+2.  Download and update your container versions to:
 
    - `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v22.2.1`
    - `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v22.2.1`
 
-3. Redeploy the Tower application:
+3.  Redeploy the Tower application:
 
    - **docker-compose**:
 
-     1. Restart the application with `docker-compose restart`. This will automatically migrate the database schema.
+     1.  Restart the application with `docker-compose restart`. This will automatically migrate the database schema.
 
    - **kubernetes**:
 
-     1. Update the cron service with `kubectl apply -f tower-cron.yml`. This will automatically migrate the database schema.
-     2. Update the frontend and backend services with `kubectl apply -f tower-srv.yml`.
+     1.  Update the cron service with `kubectl apply -f tower-cron.yml`. This will automatically migrate the database schema.
+     2.  Update the frontend and backend services with `kubectl apply -f tower-srv.yml`.
 
    - **custom deployment**
 
-     1. Run the `/migrate-db.sh` script provided in the `backend` container. This will migrate the database schema.
-     2. Deploy Tower following your usual procedures.
+     1.  Run the `/migrate-db.sh` script provided in the `backend` container. This will migrate the database schema.
+     2.  Deploy Tower following your usual procedures.
 
 ## Nextflow Launcher Image
 

--- a/platform_versioned_docs/version-23.1.0/enterprise/release_notes/22.3.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/release_notes/22.3.mdx
@@ -116,32 +116,32 @@ This feature is currently only available on Tower Cloud (tower.nf). For more inf
 
 This Tower version requires a database schema update. Follow these steps to update your DB instance and the Tower installation.
 
-1. Make a backup of the Tower database.
+1.  Make a backup of the Tower database.
 
-2. Download and update your container versions.
+2.  Download and update your container versions.
 
-3. Redeploy the Tower application:
+3.  Redeploy the Tower application:
 
    - **docker-compose**:
 
-     1. Restart the application with `docker-compose restart`. This will automatically migrate the database schema.
+     1.  Restart the application with `docker-compose restart`. This will automatically migrate the database schema.
 
    - **kubernetes**:
 
-     1. Update the cron service with `kubectl apply -f tower-cron.yml`. This will automatically migrate the database schema.
-     2. Update the frontend and backend services with `kubectl apply -f tower-srv.yml`.
+     1.  Update the cron service with `kubectl apply -f tower-cron.yml`. This will automatically migrate the database schema.
+     2.  Update the frontend and backend services with `kubectl apply -f tower-srv.yml`.
 
    - **custom deployment**
-     1. Run the `/migrate-db.sh` script provided in the `backend` container. This will migrate the database schema.
-     2. Deploy Tower following your usual procedures.
+     1.  Run the `/migrate-db.sh` script provided in the `backend` container. This will migrate the database schema.
+     2.  Deploy Tower following your usual procedures.
 
 ## Nextflow Launcher Image
 
 If you must host your nf-launcher container image on a private image registry:
 
-1. Copy the [nf-launcher image](https://quay.io/repository/seqeralabs/nf-launcher?tab=tags) to your private registry.
+1.  Copy the [nf-launcher image](https://quay.io/repository/seqeralabs/nf-launcher?tab=tags) to your private registry.
 
-2. Update your `tower.env` with the following environment variable:
+2.  Update your `tower.env` with the following environment variable:
 
    `TOWER_LAUNCH_CONTAINER=<FULL_PATH_TO_YOUR_PRIVATE_IMAGE>`
 

--- a/platform_versioned_docs/version-23.1.0/enterprise/release_notes/22.4.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/release_notes/22.4.mdx
@@ -82,32 +82,32 @@ This Tower version requires a database schema update. Follow these steps to upda
 To ensure no loss of data, the database volume must be persistent on the local machine. Use the `volumes` key in the `db` or `redis` section of your docker-compose.yml file to specify a local path to the DB or Redis instance.
 :::
 
-1. Make a backup of the Tower database.
+1.  Make a backup of the Tower database.
 
-2. Download and update your container versions.
+2.  Download and update your container versions.
 
-3. Redeploy the Tower application:
+3.  Redeploy the Tower application:
 
    - **docker-compose**:
 
-     1. To migrate the database schema, restart the application with `docker-compose down`, then `docker-compose up`.
+     1.  To migrate the database schema, restart the application with `docker-compose down`, then `docker-compose up`.
 
    - **kubernetes**:
 
-     1. Update the cron service with `kubectl apply -f tower-cron.yml`. This will automatically migrate the database schema.
-     2. Update the frontend and backend services with `kubectl apply -f tower-srv.yml`.
+     1.  Update the cron service with `kubectl apply -f tower-cron.yml`. This will automatically migrate the database schema.
+     2.  Update the frontend and backend services with `kubectl apply -f tower-srv.yml`.
 
    - **custom deployment**:
-     1. Run the `/migrate-db.sh` script provided in the `backend` container. This will migrate the database schema.
-     2. Deploy Tower following your usual procedures.
+     1.  Run the `/migrate-db.sh` script provided in the `backend` container. This will migrate the database schema.
+     2.  Deploy Tower following your usual procedures.
 
 ## Nextflow launcher image
 
 If you must host your nf-launcher container image on a private image registry:
 
-1. Copy the [nf-launcher image](https://quay.io/seqeralabs/nf-launcher:j17-22.10.7) to your private registry.
+1.  Copy the [nf-launcher image](https://quay.io/seqeralabs/nf-launcher:j17-22.10.7) to your private registry.
 
-2. Update your `tower.env` with the following environment variable:
+2.  Update your `tower.env` with the following environment variable:
 
    `TOWER_LAUNCH_CONTAINER=<FULL_PATH_TO_YOUR_PRIVATE_IMAGE>`
 

--- a/platform_versioned_docs/version-23.1.0/enterprise/release_notes/23.1.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/release_notes/23.1.mdx
@@ -62,32 +62,32 @@ This Tower version requires a database schema update. Follow these steps to upda
 To ensure no loss of data, the database volume must be persistent on the local machine. Use the `volumes` key in the `db` or `redis` section of your docker-compose.yml file to specify a local path to the DB or Redis instance.
 :::
 
-1. Make a backup of the Tower database.
+1.  Make a backup of the Tower database.
 
-2. Download and update your container versions.
+2.  Download and update your container versions.
 
-3. Redeploy the Tower application:
+3.  Redeploy the Tower application:
 
    - **docker-compose**:
 
-     1. To migrate the database schema, restart the application with `docker-compose down`, then `docker-compose up`.
+     1.  To migrate the database schema, restart the application with `docker-compose down`, then `docker-compose up`.
 
    - **kubernetes**:
 
-     1. Update the cron service with `kubectl apply -f tower-cron.yml`. This will automatically migrate the database schema.
-     2. Update the frontend and backend services with `kubectl apply -f tower-srv.yml`.
+     1.  Update the cron service with `kubectl apply -f tower-cron.yml`. This will automatically migrate the database schema.
+     2.  Update the frontend and backend services with `kubectl apply -f tower-srv.yml`.
 
    - **custom deployment**:
-     1. Run the `/migrate-db.sh` script provided in the `backend` container. This will migrate the database schema.
-     2. Deploy Tower following your usual procedures.
+     1.  Run the `/migrate-db.sh` script provided in the `backend` container. This will migrate the database schema.
+     2.  Deploy Tower following your usual procedures.
 
 ## Nextflow launcher image
 
 If you must host your nf-launcher container image on a private image registry:
 
-1. Copy the [nf-launcher image](https://quay.io/seqeralabs/nf-launcher:j17-23.04.1) to your private registry.
+1.  Copy the [nf-launcher image](https://quay.io/seqeralabs/nf-launcher:j17-23.04.1) to your private registry.
 
-2. Update your `tower.env` with the launch container environment variable:
+2.  Update your `tower.env` with the launch container environment variable:
 
    `TOWER_LAUNCH_CONTAINER=<FULL_PATH_TO_YOUR_PRIVATE_IMAGE>`
 

--- a/platform_versioned_docs/version-23.1.0/enterprise/release_notes/changelog.mdx
+++ b/platform_versioned_docs/version-23.1.0/enterprise/release_notes/changelog.mdx
@@ -314,7 +314,7 @@ tags: [changelog]
 - chore: Upgrade to Micronaut 3.4.x
 - chore: typography sync between tower and design
 
-* Full Changelog: v22.1.5-enterprise...v22.2.0-rc0-enterprise
+- Full Changelog: v22.1.5-enterprise...v22.2.0-rc0-enterprise
 
 #### 22.1.6 - 15 Jul 2022
 

--- a/platform_versioned_docs/version-23.1.0/faqs.mdx
+++ b/platform_versioned_docs/version-23.1.0/faqs.mdx
@@ -11,10 +11,10 @@ tags: [faq, help]
 
 The Administration Console allows Tower instance administrators to interact with all users and organizations registered with the platform. Administrators must be identified in your Tower instance configuration files prior to instantiation of the application.
 
-1. Create a `TOWER_ROOT_USERS` environment variable (e.g. via _tower.env_ or Kubernetes ConfigMap).
-2. Populate the variable with a sequence of comma-delimited email addresses (no spaces).<br/>Example: `TOWER_ROOT_USERS=foo@foo.com,bar@bar.com`
-3. If using a Tower version earlier than 21.12:
-   1. Add the following configuration to _tower.yml_:
+1.  Create a `TOWER_ROOT_USERS` environment variable (e.g. via _tower.env_ or Kubernetes ConfigMap).
+1.  Populate the variable with a sequence of comma-delimited email addresses (no spaces).<br/>Example: `TOWER_ROOT_USERS=foo@foo.com,bar@bar.com`
+1.  If using a Tower version earlier than 21.12:
+   1.  Add the following configuration to _tower.yml_:
 
    ```yml
    tower:
@@ -22,8 +22,8 @@ The Administration Console allows Tower instance administrators to interact with
        root-users: "${TOWER_ROOT_USERS:[]}"
    ```
 
-4. Restart the `cron` and `backend` containers/Deployments.
-5. The console will now be available via your Profile drop-down menu.
+1.  Restart the `cron` and `backend` containers/Deployments.
+1.  The console will now be available via your Profile drop-down menu.
 
 ## API
 
@@ -53,11 +53,11 @@ One such value is `launch.id`; attempting to launch a pipeline without specifyin
 
 If you have encountered the 403 error as a result of being a Launch user who did not provide a `launch.id`, please try resolving the problem as follows:
 
-1. Provide the launch ID to the payload sent to the tower using the same endpoint. To do this;
+1.  Provide the launch ID to the payload sent to the tower using the same endpoint. To do this;
 
-   1. Query the list of pipelines via the `/pipelines` endpoint. Find the `pipelineId` of the pipeline you intend to launch.
-   2. Once you have the `pipelineId`, call the `/pipelines/{pipelineId}/launch` API to retrieve the pipeline's `launch.id`.
-   3. Include the `launch.id` in your call to the `/workflow/launch` API endpoint (see example below).
+   1.  Query the list of pipelines via the `/pipelines` endpoint. Find the `pipelineId` of the pipeline you intend to launch.
+   2.  Once you have the `pipelineId`, call the `/pipelines/{pipelineId}/launch` API to retrieve the pipeline's `launch.id`.
+   3.  Include the `launch.id` in your call to the `/workflow/launch` API endpoint (see example below).
 
       ```
       {
@@ -72,7 +72,7 @@ If you have encountered the 403 error as a result of being a Launch user who did
       }
       ```
 
-2. If a launch id remains unavailable to you, upgrade your user role to 'Maintain' or higher. This will allow you to execute quick launch-type pipeline invocations.
+1.  If a launch id remains unavailable to you, upgrade your user role to 'Maintain' or higher. This will allow you to execute quick launch-type pipeline invocations.
 
 ## Common Errors
 
@@ -88,9 +88,9 @@ Github imposes [rate limits](https://docs.github.com/en/rest/overview/resources-
 
 To resolve the problem, please try the following:
 
-1. Ensure there is at least one Github credential in your Workspace's Credentials tab.
-2. Ensure that the **Access token** field of all Github Credential objects is populated with a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) value, NOT a user password. (_Github PATs are typically several dozen characters long and begin with a `ghp_`prefix; example:`ghp*IqIMNOZH6zOwIEB4T9A2g4EHMy8Ji42q4HA`*)
-3. Confirm that your PAT is providing the elevated threshold and transactions are being charged against it:
+1.  Ensure there is at least one Github credential in your Workspace's Credentials tab.
+1.  Ensure that the **Access token** field of all Github Credential objects is populated with a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) value, NOT a user password. (_Github PATs are typically several dozen characters long and begin with a `ghp_`prefix; example:`ghp*IqIMNOZH6zOwIEB4T9A2g4EHMy8Ji42q4HA`*)
+1.  Confirm that your PAT is providing the elevated threshold and transactions are being charged against it:
 
    `curl -H "Authorization: token ghp_LONG_ALPHANUMERIC_PAT" -H "Accept: application/vnd.github.v3+json" https://api.github.com/rate_limit`
 
@@ -100,14 +100,14 @@ This error can occur if incorrect configuration values are assigned to the `back
 
 Please verify the following:
 
-1. The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `backend` container:
+1.  The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `backend` container:
    - Contains `prod,redis,ha`
    - Does not contain `cron`
-2. The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `cron` container:
+1.  The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `cron` container:
    - Contains `prod,redis,cron`
    - Does not contain `ha`
-3. You do not have another copy of the `MICRONAUT_ENVIRONMENTS` environment variable defined elsewhere in your application (e.g. a _tower.env_ file or Kubernetes ConfigMap).
-4. If you are using a separate container/pod to execute _migrate-db.sh_, there is no `MICRONAUT_ENVIRONMENTS` environment variable assigned to it.
+1.  You do not have another copy of the `MICRONAUT_ENVIRONMENTS` environment variable defined elsewhere in your application (e.g. a _tower.env_ file or Kubernetes ConfigMap).
+1.  If you are using a separate container/pod to execute _migrate-db.sh_, there is no `MICRONAUT_ENVIRONMENTS` environment variable assigned to it.
 
 **<p data-question>Q: Why do I get a `chmod: cannot access PATH/TO/bin/*: No such file or directory` exception?</p>**
 
@@ -186,8 +186,8 @@ Clients who use Amazon Aurora as their database solution may encounter a `java.s
 
 Please modify Tower Enterprise configuration as follows to try resolving the problem:
 
-1. Ensure your `TOWER_DB_DRIVER` uses the specified MariaDB URI.
-2. Modify your `TOWER_DB_URL` to: `TOWER_DB_URL=jdbc:mysql://YOUR_DOMAIN:YOUR_PORT/YOUR_TOWER_DB?usePipelineAuth=false&useBatchMultiSend=false`
+1.  Ensure your `TOWER_DB_DRIVER` uses the specified MariaDB URI.
+1.  Modify your `TOWER_DB_URL` to: `TOWER_DB_URL=jdbc:mysql://YOUR_DOMAIN:YOUR_PORT/YOUR_TOWER_DB?usePipelineAuth=false&useBatchMultiSend=false`
 
 ## Datasets
 
@@ -195,10 +195,10 @@ Please modify Tower Enterprise configuration as follows to try resolving the pro
 
 When uploading Datasets via the Tower UI or CLI, some steps are automatically done on your behalf. To upload Datasets via the TOwer API, additional steps are required:
 
-1. Explicitly define the MIME type of the file being uploaded.
-2. Make two calls to the API:
-   1. Create a Dataset object
-   2. Upload the samplesheet to the Dataset object.
+1.  Explicitly define the MIME type of the file being uploaded.
+1.  Make two calls to the API:
+   1.  Create a Dataset object
+   2.  Upload the samplesheet to the Dataset object.
 
 Example:
 
@@ -258,13 +258,13 @@ TLS connection errors can occur due to variability in the [default TLS version s
 
 To fix the problem, you can either:
 
-1. Set a JDK environment variable to force Nextflow and/or the Tower containers to use TLSv1.2 by default:
+1.  Set a JDK environment variable to force Nextflow and/or the Tower containers to use TLSv1.2 by default:
 
 ```
 export JAVA_OPTIONS="-Dmail.smtp.ssl.protocols=TLSv1.2"
 ```
 
-2. Add the following parameter to your nextflow.config file:
+1.  Add the following parameter to your nextflow.config file:
 
 ```
 mail {
@@ -323,9 +323,9 @@ Users with email addresses other than the `trustedEmails` list will undergo an a
 
 **Note:**
 
-1. You must rebuild your containers (i.e., `docker-compose down`) to force Tower to implement this change. Ensure your database is persistent before issuing the docker-compose down command. See [here](https://help.tower.nf/latest/enterprise/docker-compose/) for more information.
-2. All login attempts are visible to the root user at **Profile -> Admin panel -> Users**.
-3. Any user logged in prior to the restriction will not be subject to the new restriction. An admin of the organization should remove users that have previously logged in via (untrusted) email from the Admin panel users list. This will restart the approval process before they can log in via email.
+1.  You must rebuild your containers (i.e., `docker-compose down`) to force Tower to implement this change. Ensure your database is persistent before issuing the docker-compose down command. See [here](https://help.tower.nf/latest/enterprise/docker-compose/) for more information.
+1.  All login attempts are visible to the root user at **Profile -> Admin panel -> Users**.
+1.  Any user logged in prior to the restriction will not be subject to the new restriction. An admin of the organization should remove users that have previously logged in via (untrusted) email from the Admin panel users list. This will restart the approval process before they can log in via email.
 
 **<p data-question>Q: Why am I receiving login errors stating that admin approval is required when using Azure AD OIDC?</p>**
 
@@ -335,17 +335,17 @@ The Azure AD app integrated with Tower must have user consent settings configure
 
 This can occur for several reasons. Please verify the following:
 
-1. Your `TOWER_SERVER_URL` environment variable uses the `https://` prefix.
-2. Your `tower.yml` has `micronaut.ssl.enabled` set to `true`.
-3. Any Load Balancer instance that sends traffic to the Tower application is configured to use HTTPS as its backend protocol rather than TCP.
+1.  Your `TOWER_SERVER_URL` environment variable uses the `https://` prefix.
+1.  Your `tower.yml` has `micronaut.ssl.enabled` set to `true`.
+1.  Any Load Balancer instance that sends traffic to the Tower application is configured to use HTTPS as its backend protocol rather than TCP.
 
 **<p data-question>Q: Why isn't my OIDC callback working?</p>**
 
 Callbacks could fail for many reasons. To more effectively investigate the problem:
 
-1. Set the Tower environment variable to `TOWER_SECURITY_LOGLEVEL=DEBUG`.
-2. Ensure your `TOWER_OIDC_CLIENT`, `TOWER_OIDC_SECRET`, and `TOWER_OIDC_ISSUER` environment variables all match the values specified in your OIDC provider's corresponding application.
-3. Ensure your network infrastructure allow necessary egress and ingress traffic.
+1.  Set the Tower environment variable to `TOWER_SECURITY_LOGLEVEL=DEBUG`.
+1.  Ensure your `TOWER_OIDC_CLIENT`, `TOWER_OIDC_SECRET`, and `TOWER_OIDC_ISSUER` environment variables all match the values specified in your OIDC provider's corresponding application.
+1.  Ensure your network infrastructure allow necessary egress and ingress traffic.
 
 **<p data-question>Q: Why did Google SMTP start returning `Username and Password not accepted` errors?</p>**
 
@@ -388,7 +388,7 @@ Yes. You can mount the APM solution's JAR file in the `backend` container and se
 **<p data-question>Q: Is it possible to retrieve the trace file for a Tower-based workflow run?</p>**
 Yes. Although it is not possible to directly download the file via Tower, you can configure your workflow to export the file to persistent storage:
 
-1. Set the following block in your `nextflow.config`:
+1.  Set the following block in your `nextflow.config`:
 
 ```nextflow
 trace {
@@ -396,7 +396,7 @@ trace {
 }
 ```
 
-2. Add a copy command to your pipeline's **Advanced options > Post-run script** field:
+1.  Add a copy command to your pipeline's **Advanced options > Post-run script** field:
 
 ```
 # Example: Export the generated trace file to an S3 bucket
@@ -600,9 +600,9 @@ Runs will fail if your Nextflow script or Nextflow config contain illegal charac
 
 The Groovy shell used by Nextflow to execute your workflow has a hard limit on string size (64KiB). Check the size of your scripts with the `ls -llh` command. If the size is greater than 65,535 bytes, consider these mitigation techniques:
 
-1. Remove any unnecessary code or comments from the script.
-2. Move long script bodies into a separate script file in the pipeline `/bin` directory.
-3. Consider using DSL2 so you can move each function, process, and workflow definition into its own script and include these scripts as [modules](https://www.nextflow.io/docs/latest/dsl2.html#modules).
+1.  Remove any unnecessary code or comments from the script.
+1.  Move long script bodies into a separate script file in the pipeline `/bin` directory.
+1.  Consider using DSL2 so you can move each function, process, and workflow definition into its own script and include these scripts as [modules](https://www.nextflow.io/docs/latest/dsl2.html#modules).
 
 ## Nextflow Launcher
 
@@ -616,8 +616,8 @@ If you are restricted from using public container registries, please see Tower E
 
 Each Nextflow Tower release uses a specific nf-launcher image by default. This image is loaded with a specific Nextflow version, meaning that any workflow run in the container uses this Nextflow version by default. You can force your jobs to use a newer/older version of Nextflow with any of the following strategies:
 
-1. Use the **Pre-run script** advanced launch option to set the desired Nextflow version. Example: `export NXF_VER=22.08.0-edge`
-2. For jobs executing in an AWS Batch compute environment, create a [custom job definition](https://install.tower.nf/22.2/advanced-topics/custom-launch-container/) which references a different nf-launcher image.
+1.  Use the **Pre-run script** advanced launch option to set the desired Nextflow version. Example: `export NXF_VER=22.08.0-edge`
+1.  For jobs executing in an AWS Batch compute environment, create a [custom job definition](https://install.tower.nf/22.2/advanced-topics/custom-launch-container/) which references a different nf-launcher image.
 
 ## OIDC
 
@@ -697,8 +697,8 @@ This error can occur if the Nextflow head job fails to retrieve the necessary re
 
 To determine if this is the case, please do the following:
 
-1. Check your Nextflow log for an entry like `DEBUG nextflow.scm.RepositoryProvider - Request [credentials -:-]`.
-2. If the above is true, please check the protocol of the string that was assigned to your Tower instance's `TOWER_SERVER_URL` configuration value. It is possible this has been erroneously set to `http` rather than `https`.
+1.  Check your Nextflow log for an entry like `DEBUG nextflow.scm.RepositoryProvider - Request [credentials -:-]`.
+1.  If the above is true, please check the protocol of the string that was assigned to your Tower instance's `TOWER_SERVER_URL` configuration value. It is possible this has been erroneously set to `http` rather than `https`.
 
 ## Secrets
 
@@ -725,8 +725,8 @@ Users may encounter a few different errors when executing pipelines that use Sec
 
   To resolve the issue, please upgrade your Nextflow version to 22.08.0-edge. If you cannot upgrade, you can use the following as workarounds:
 
-  1. Use a different container image for each process.
-  2. Define the same set of Secrets in each process that uses the same container image.
+  1.  Use a different container image for each process.
+  2.  Define the same set of Secrets in each process that uses the same container image.
 
 ## Tower Agent
 
@@ -748,8 +748,8 @@ Yes. Provide a POSIX-compliant path to the `TOWER_CONFIG_FILE` environment varia
 
 There are two reasons why configurations specified in `tower.yml` are not being expressed by your Tower instance:
 
-1. There is a typo in one of the key value pairs.
-2. There is a duplicate key present in your file.
+1.  There is a typo in one of the key value pairs.
+1.  There is a duplicate key present in your file.
 
    ```yaml
    # EXAMPLE
@@ -785,8 +785,8 @@ You can force your Nextflow head job to use DSL2 syntax via any of the following
 
 Yes. As of v22.1, Nextflow Tower Enterprise can link to workflows stored in "local" git repositories. To do so:
 
-1. Volume mount your repository folder into the Tower Enterprise `backend` container.
-2. Update your `tower.yml` with the following configuration:
+1.  Volume mount your repository folder into the Tower Enterprise `backend` container.
+1.  Update your `tower.yml` with the following configuration:
 
 ```yml
 tower:
@@ -810,9 +810,9 @@ Activating the **Enable GPU** field while creating an AWS Batch environment with
 
 Note:
 
-1. Activation does not cause GPU-enabled instances to automatically spawn in your Batch cluster. You must still specify these in the Forge screen's **Advanced options > Instance types** field.
-2. Population of the Forge screen's **Advanced options > AMI Id** field will supersede the AWS-recommended AMI.
-3. Your Nextflow script must include [accelerator directives](https://www.nextflow.io/docs/latest/process.html?highlight=accelerator) to use the provisioned GPUs.
+1.  Activation does not cause GPU-enabled instances to automatically spawn in your Batch cluster. You must still specify these in the Forge screen's **Advanced options > Instance types** field.
+1.  Population of the Forge screen's **Advanced options > AMI Id** field will supersede the AWS-recommended AMI.
+1.  Your Nextflow script must include [accelerator directives](https://www.nextflow.io/docs/latest/process.html?highlight=accelerator) to use the provisioned GPUs.
 
 ## tw CLI
 
@@ -874,8 +874,8 @@ This problem will express itself with the following entry in your Nextflow log: 
 
 This can occur due to the following reasons:
 
-1. An access token value has been hardcoded in the `tower.accessToken` block of your `nextflow.config` (either via the git repository itself or override value in the launch form).
-2. In cases where your compute environment is an HPC cluster, the credentialized user's home directory contains a stateful `nextflow.config` with a hardcoded token (e.g. `~/.nextflow/config).
+1.  An access token value has been hardcoded in the `tower.accessToken` block of your `nextflow.config` (either via the git repository itself or override value in the launch form).
+1.  In cases where your compute environment is an HPC cluster, the credentialized user's home directory contains a stateful `nextflow.config` with a hardcoded token (e.g. `~/.nextflow/config).
 
 **<p data-question>Q: What privilege level is granted to a user assigned to a Workspace both as a Participant and Team member?</p>**
 
@@ -932,9 +932,9 @@ There are multiple reasons why your pipeline could fail with an `Essential conta
 
 Please try the following:
 
-1. [Upgrade your ECS Agent](https://github.com/aws/amazon-ecs-agent/releases) to [1.54.1](https://github.com/aws/amazon-ecs-agent/pull/2940) or newer ([instructions for checking your ECS Agent version](https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/ECS/latest-agent-version.html));
-2. Provision more storage space for your EC2 instance (preferably via ebs-autoscaling to ensure scalability).
-3. If the error is accompanied by `command exit status: 123` and a `permissions denied` error tied to a system command, please ensure that the binary is set to be executable (i.e. `chmod u+x`).
+1.  [Upgrade your ECS Agent](https://github.com/aws/amazon-ecs-agent/releases) to [1.54.1](https://github.com/aws/amazon-ecs-agent/pull/2940) or newer ([instructions for checking your ECS Agent version](https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/ECS/latest-agent-version.html));
+1.  Provision more storage space for your EC2 instance (preferably via ebs-autoscaling to ensure scalability).
+1.  If the error is accompanied by `command exit status: 123` and a `permissions denied` error tied to a system command, please ensure that the binary is set to be executable (i.e. `chmod u+x`).
 
 ### Queues
 
@@ -980,7 +980,7 @@ As of Nextflow Tower v21.12, you can specify an Amazon FSX for Lustre instance a
 
 If you need to save files to an S3 bucket protected by a [bucket policy which enforces AES256 server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html), additional configuration settings must be provided to the [nf-launcher](https://quay.io/repository/seqeralabs/nf-launcher?tab=tags) script which invokes the Nextflow head job:
 
-1. Add the following configuration to the **Advanced options > Nextflow config file** textbox of the **Launch Pipeline** screen:
+1.  Add the following configuration to the **Advanced options > Nextflow config file** textbox of the **Launch Pipeline** screen:
 
    ```
    aws {
@@ -990,7 +990,7 @@ If you need to save files to an S3 bucket protected by a [bucket policy which en
    }
    ```
 
-2. Add the following configuration to the **Advanced options > Pre-run script** textbox of the **Launch Pipeline** screen:
+1.  Add the following configuration to the **Advanced options > Pre-run script** textbox of the **Launch Pipeline** screen:
 
    ```bash
    export TOWER_AWS_SSE=AES256
@@ -1031,7 +1031,7 @@ This can occur if a tool/library in your task container requires SSL certificate
 
 You may be able to solve the issue by:
 
-1. Mounting host certificates into the container ([example](https://github.com/nextflow-io/nextflow/blob/v21.10.6/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy#L348-L351)).
+1.  Mounting host certificates into the container ([example](https://github.com/nextflow-io/nextflow/blob/v21.10.6/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy#L348-L351)).
 
 **<p data-question>Q: Why is my deployment using Azure SQL database returning an error about `Connections using insecure transport are prohibited while --require_secure_transport=ON.`</p>**
 
@@ -1059,10 +1059,10 @@ process {
 
 The following roles are needed to be granted to the `nextflow-service-account`.
 
-1. Cloud Life Sciences Workflows Runner
-2. Service Account User
-3. Service Usage Consumer
-4. Storage Object Admin
+1.  Cloud Life Sciences Workflows Runner
+1.  Service Account User
+1.  Service Usage Consumer
+1.  Storage Object Admin
 
 For detailed information, please refer to this [guide.](https://cloud.google.com/life-sciences/docs/tutorials/nextflow#create_a_service_account_and_add_roles)
 
@@ -1108,24 +1108,24 @@ Nextflow is trying to use the Java VM defined for the following environment vari
 
 Possible reasons for this error:
 
-1. The queue where the Nextflow head job runs in a different environment/node than your login node userspace.
-2. If your HPC cluster uses modules, the Java module may not be loaded by default.
+1.  The queue where the Nextflow head job runs in a different environment/node than your login node userspace.
+1.  If your HPC cluster uses modules, the Java module may not be loaded by default.
 
 To troubleshoot:
 
-1. Open an interactive session with the head job queue.
-2. Launch the Nextflow job from the interactive session.
-3. If you cluster used modules:
-   1. Add `module load <your_java_module>` in the **Advanced Features > Pre-run script** field when creating your HPC Compute Environment within Nextflow Tower.
-4. If you cluster does not use modules:
-   1. Source an environment with java and Nextflow using the **Advanced Features > Pre-run script** field when creating your HPC Compute Environment within Nextflow Tower.
+1.  Open an interactive session with the head job queue.
+1.  Launch the Nextflow job from the interactive session.
+1.  If you cluster used modules:
+   1.  Add `module load <your_java_module>` in the **Advanced Features > Pre-run script** field when creating your HPC Compute Environment within Nextflow Tower.
+1.  If you cluster does not use modules:
+   1.  Source an environment with java and Nextflow using the **Advanced Features > Pre-run script** field when creating your HPC Compute Environment within Nextflow Tower.
 
 **<p data-question>Q: Why do pipelines I submit to my HPC cluster fail, but those submitted by another user succeed?</p>**
 
 Nextflow launcher scripts will fail if processed by a non-Bash shell (e.g., `zsh`, `tcsh`). This problem can be identified from certain error entries:
 
-1. Your _.nextflow.log_ contains an error like `Invalid workflow status - expected: SUBMITTED; current: FAILED`.
-2. Your Tower **Error report** tab contains an error like:
+1.  Your _.nextflow.log_ contains an error like `Invalid workflow status - expected: SUBMITTED; current: FAILED`.
+1.  Your Tower **Error report** tab contains an error like:
 
 ```yaml
 Slurm job submission failed
@@ -1136,6 +1136,6 @@ Slurm job submission failed
 
 Connect to the head node via SSH and run `ps -p $$` to verify your default shell. If you see an entry other than Bash, fix as follows:
 
-1. Check which shells are available to you: `cat /etc/shells`
-2. Change your shell: `chsh -s /usr/bin/bash` (note: the path to the binary may differ, depending on your HPC configuration)
-3. If submissions continue to fail after this shell change, ask your Tower admin to restart the **backend** and **cron** containers, and submit from Tower again.
+1.  Check which shells are available to you: `cat /etc/shells`
+1.  Change your shell: `chsh -s /usr/bin/bash` (note: the path to the binary may differ, depending on your HPC configuration)
+1.  If submissions continue to fail after this shell change, ask your Tower admin to restart the **backend** and **cron** containers, and submit from Tower again.

--- a/platform_versioned_docs/version-23.1.0/getting-started/community-showcase.mdx
+++ b/platform_versioned_docs/version-23.1.0/getting-started/community-showcase.mdx
@@ -29,15 +29,15 @@ The community showcase includes [pipeline secrets](../secrets/overview.mdx) that
 
 ## Run pipeline with sample data
 
-1. From the [Launchpad](../launch/launchpad.mdx), select the pipeline of your choice to view the pipeline detail page. nf-core-rnaseq is a good first pipeline example.
-2. (Optional) Select the URL under **Workflow repository** to view the pipeline code repository in another tab.
-3. In Tower Cloud, select **Launch** from the pipeline detail page.
-4. On the **Launch pipeline** page, enter a unique **Workflow run name** or accept the pre-filled random name.
-5. (Optional) Enter labels to be assigned to the run in the **Labels** field.
-6. Under **Input/output options**, select the dataset named after your chosen pipeline from the drop-down menu under **input**.
-7. Under **outdir**, specify an output directory where run results will be saved. This must be an absolute path to storage on cloud infrastructure and defaults to `./results`.
-8. Under **email**, enter an email address where you wish to receive the run completion summary.
-9. Under **multiqc_title**, enter a title for the MultiQC report. This is used as both the report page header and filename.
+1.  From the [Launchpad](../launch/launchpad.mdx), select the pipeline of your choice to view the pipeline detail page. nf-core-rnaseq is a good first pipeline example.
+1.  (Optional) Select the URL under **Workflow repository** to view the pipeline code repository in another tab.
+1.  In Tower Cloud, select **Launch** from the pipeline detail page.
+1.  On the **Launch pipeline** page, enter a unique **Workflow run name** or accept the pre-filled random name.
+1.  (Optional) Enter labels to be assigned to the run in the **Labels** field.
+1.  Under **Input/output options**, select the dataset named after your chosen pipeline from the drop-down menu under **input**.
+1.  Under **outdir**, specify an output directory where run results will be saved. This must be an absolute path to storage on cloud infrastructure and defaults to `./results`.
+1.  Under **email**, enter an email address where you wish to receive the run completion summary.
+1.  Under **multiqc_title**, enter a title for the MultiQC report. This is used as both the report page header and filename.
 
 The remaining launch form fields will vary depending on the pipeline you have selected. Parameters required for the pipeline to run are pre-filled by default, and empty fields are optional.
 

--- a/platform_versioned_docs/version-23.1.0/getting-started/deployment-options.mdx
+++ b/platform_versioned_docs/version-23.1.0/getting-started/deployment-options.mdx
@@ -40,11 +40,11 @@ You can access Tower through the web user interface, the [API](../api/overview.m
 
 ### Tower UI
 
-1. Create an account and log in to Tower, available free of charge at [cloud.tower.nf](https://cloud.tower.nf).
+1.  Create an account and log in to Tower, available free of charge at [cloud.tower.nf](https://cloud.tower.nf).
 
-2. Create and configure a new [compute environment](../compute-envs/overview.mdx).
+1.  Create and configure a new [compute environment](../compute-envs/overview.mdx).
 
-3. Start [launching pipelines](../launch/launchpad.mdx).
+1.  Start [launching pipelines](../launch/launchpad.mdx).
 
 ### Tower API
 
@@ -58,30 +58,30 @@ See [CLI](../cli/cli.mdx).
 
 If you have an existing environment where you run Nextflow directly, you can still leverage Tower capabilities by executing your Nextflow run with a `with-tower` flag.
 
-1. Create an account and log in to Tower.
-2. From your personal workspace, select **Your tokens** from **Settings** in the user top-right menu.
-3. Select **Add token**.
-4. Enter a unique name for your token, then select **Add**.
-5. Copy and store your token securely.
+1.  Create an account and log in to Tower.
+1.  From your personal workspace, select **Your tokens** from **Settings** in the user top-right menu.
+1.  Select **Add token**.
+1.  Enter a unique name for your token, then select **Add**.
+1.  Copy and store your token securely.
 
 :::caution
 The access token will be displayed only once. Save the token value before closing the **Personal Access Token** window.
 :::
 
-6. Open a terminal and create environment variables to store the Tower access token and Nextflow version:
+1.  Open a terminal and create environment variables to store the Tower access token and Nextflow version:
 
    ```bash
    export TOWER_ACCESS_TOKEN=eyxxxxxxxxxxxxxxxQ1ZTE=
    export NXF_VER=23.1.3
    ```
 
-7. Replace `eyxxxxxxxxxxxxxxxQ1ZTE=` with your newly-created token.
+1.  Replace `eyxxxxxxxxxxxxxxxQ1ZTE=` with your newly-created token.
 
 :::note
 Bearer token support requires Nextflow version 20.10.0 or later. Set with the `NXF_VER` environment variable.
 :::
 
-8. To submit a pipeline to a [workspace](./workspace.mdx) using Nextflow, add the workspace ID to your environment:
+1.  To submit a pipeline to a [workspace](./workspace.mdx) using Nextflow, add the workspace ID to your environment:
 
    ```bash
    export TOWER_WORKSPACE_ID=000000000000000
@@ -89,7 +89,7 @@ Bearer token support requires Nextflow version 20.10.0 or later. Set with the `N
 
    To find your workspace ID, select your organization in Tower and navigate to the **Workspaces** tab.
 
-9. Run your Nextflow pipeline with the `-with-tower` flag:
+1.  Run your Nextflow pipeline with the `-with-tower` flag:
 
    ```bash
    nextflow run main.nf -with-tower

--- a/platform_versioned_docs/version-23.1.0/getting-started/usage.mdx
+++ b/platform_versioned_docs/version-23.1.0/getting-started/usage.mdx
@@ -9,11 +9,11 @@ You can use Tower through the web interface, the API, the CLI, or in Nextflow di
 
 ### Tower web interface
 
-1. Create an account and log in to Tower, available free of charge at [tower.nf](https://cloud.tower.nf).
+1.  Create an account and log in to Tower, available free of charge at [tower.nf](https://cloud.tower.nf).
 
-2. Create and configure a new [compute environment](../compute-envs/overview.mdx).
+1.  Create and configure a new [compute environment](../compute-envs/overview.mdx).
 
-3. Start [launching pipelines](../launch/launchpad.mdx).
+1.  Start [launching pipelines](../launch/launchpad.mdx).
 
 ### Tower API
 
@@ -25,17 +25,17 @@ See [CLI](../cli.mdx).
 
 ### Nextflow `-with-tower`
 
-1. Create an account and log in to Tower.
+1.  Create an account and log in to Tower.
 
-2. Create a new token. You can access your tokens from the **Settings** drop-down menu:
+1.  Create a new token. You can access your tokens from the **Settings** drop-down menu:
 
    ![](./_images/usage_create_token.png)
 
-3. Name your token.
+1.  Name your token.
 
    ![](./_images/usage_name_token.png)
 
-4. Store your token securely.
+1.  Store your token securely.
 
    ![](./_images/usage_token.png)
 
@@ -43,7 +43,7 @@ See [CLI](../cli.mdx).
 The token will only be displayed once. You must copy and save the token before closing the Personal Access Token window.
 :::
 
-5. Open a terminal and enter the following commands:
+1.  Open a terminal and enter the following commands:
 
    ```bash
    export TOWER_ACCESS_TOKEN=eyxxxxxxxxxxxxxxxQ1ZTE=
@@ -64,7 +64,7 @@ export TOWER_WORKSPACE_ID=000000000000000
 
 The workspace ID can be found on the organization workspaces overview page.
 
-6. Run your Nextflow pipeline with the `-with-tower` flag:
+1.  Run your Nextflow pipeline with the `-with-tower` flag:
 
    ```bash
    nextflow run hello.nf -with-tower

--- a/platform_versioned_docs/version-23.1.0/git/overview.mdx
+++ b/platform_versioned_docs/version-23.1.0/git/overview.mdx
@@ -39,13 +39,13 @@ All credentials are (AES-256) encrypted before secure storage and are not expose
 
 When your Tower instance has multiple stored credentials, selection of the most relevant credential for your repository takes precedence in the following order:
 
-1. Tower evaluates all the stored credentials available to the current Workspace.
+1.  Tower evaluates all the stored credentials available to the current Workspace.
 
-2. Credentials are filtered by Git provider (GitHub, GitLab, Bitbucket, etc.)
+1.  Credentials are filtered by Git provider (GitHub, GitLab, Bitbucket, etc.)
 
-3. Tower selects the credential with a **Repository base URL** most similar to the target repository.
+1.  Tower selects the credential with a **Repository base URL** most similar to the target repository.
 
-4. If no **Repository base URL** values are specified in the Workspace credentials, the the most long-lived credential is selected.
+1.  If no **Repository base URL** values are specified in the Workspace credentials, the the most long-lived credential is selected.
 
 **Example**:
 
@@ -91,17 +91,17 @@ You can authenticate to Azure Devops repositories using a [personal access token
 
 Once you have created and copied your access token, create a new credential in Tower using these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "Azure DevOps" as the **Provider**.
+1.  Select "Azure DevOps" as the **Provider**.
 
-5. Enter your **Username** and **Access token**.
+1.  Enter your **Username** and **Access token**.
 
-6. Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://dev.azure.com/{your organization}/{your project}`.
+1.  Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://dev.azure.com/{your organization}/{your project}`.
 
 ### GitHub
 
@@ -117,17 +117,17 @@ For **fine-grained** tokens, the repository's organization must [opt in](https:/
 
 Once you have created and copied your access token, create a new credential in Tower using these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "GitHub" as the **Provider**.
+1.  Select "GitHub" as the **Provider**.
 
-5. Enter your **Username** and **Access token**.
+1.  Enter your **Username** and **Access token**.
 
-6. Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://github.com/seqeralabs`.
+1.  Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://github.com/seqeralabs`.
 
 ### GitLab
 
@@ -135,19 +135,19 @@ GitLab supports [Personal](https://docs.gitlab.com/ee/user/profile/personal_acce
 
 To connect Tower to a private [GitLab](https://gitlab.com/) repository:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "GitLab" as the **Provider**.
+1.  Select "GitLab" as the **Provider**.
 
-5. Enter your **Username**. For Group and Project access tokens, the username can be any non-empty value.
+1.  Enter your **Username**. For Group and Project access tokens, the username can be any non-empty value.
 
-6. Enter your token value in the **Password** and **Access token** fields.
+1.  Enter your token value in the **Password** and **Access token** fields.
 
-7. Enter the **Repository base URL** (recommended). This option is used to apply the credentials to a specific repository, e.g. `https://gitlab.com/seqeralabs`.
+1.  Enter the **Repository base URL** (recommended). This option is used to apply the credentials to a specific repository, e.g. `https://gitlab.com/seqeralabs`.
 
 ### Gitea
 
@@ -155,51 +155,51 @@ To connect Tower to a private [GitLab](https://gitlab.com/) repository:
 
 To connect to a private [Gitea](https://gitea.io/) repository, supply your Gitea user credentials to create a new credential in Tower with these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "Gitea" as the **Provider**.
+1.  Select "Gitea" as the **Provider**.
 
-5. Enter your **Username**.
+1.  Enter your **Username**.
 
-6. Enter your **Password**.
+1.  Enter your **Password**.
 
-7. Enter your **Repository base URL** (required).
+1.  Enter your **Repository base URL** (required).
 
 ### Bitbucket
 
 To connect to a private BitBucket repository, refer to the [BitBucket documentation](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) to learn how to create a BitBucket App password. Then, create a new credential in Tower using these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "BitBucket" as the **Provider**.
+1.  Select "BitBucket" as the **Provider**.
 
-5. Enter your **Username** and **Password**.
+1.  Enter your **Username** and **Password**.
 
-6. Enter the **Repository base URL** (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://bitbucket.org/seqeralabs`.
+1.  Enter the **Repository base URL** (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://bitbucket.org/seqeralabs`.
 
 ### AWS CodeCommit
 
 To connect to a private AWS CodeCommit repository, refer to the [AWS documentation](https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-iam-identity-based-access-control.html) to learn more about IAM permissions for CodeCommit. Then, supply the IAM account access key and secret key to create a credential in Tower using these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "CodeCommit" as the **Provider**.
+1.  Select "CodeCommit" as the **Provider**.
 
-5. Enter the **Access key** and **Secret key** of the AWS IAM account that will be used to access the desired CodeCommit repository.
+1.  Enter the **Access key** and **Secret key** of the AWS IAM account that will be used to access the desired CodeCommit repository.
 
-6. Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific region, e.g. `https://git-codecommit.eu-west-1.amazonaws.com`.
+1.  Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific region, e.g. `https://git-codecommit.eu-west-1.amazonaws.com`.
 
 ### Self-hosted Git
 

--- a/platform_versioned_docs/version-23.1.0/labels/overview.mdx
+++ b/platform_versioned_docs/version-23.1.0/labels/overview.mdx
@@ -49,6 +49,7 @@ Apply a label to a workflow run when launching a workflow run, on the workflow r
 ![](./_images/launch_labels.png)
 
 ### Search and filter with labels
+
 Search and filter pipelines and workflow runs using one or more labels.
 Filter and search are complementary.
 

--- a/platform_versioned_docs/version-23.1.0/launch/launch.mdx
+++ b/platform_versioned_docs/version-23.1.0/launch/launch.mdx
@@ -11,23 +11,23 @@ The **Launch Form** can be used for launching pipelines and for adding pipelines
 
 To launch a pipeline:
 
-1. Select **Start Quick Launch** in the navigation bar. The Launch Form will appear.
+1.  Select **Start Quick Launch** in the navigation bar. The Launch Form will appear.
 
-2. Select a **Compute Environment** from the available options.
+1.  Select a **Compute Environment** from the available options.
 
    Visit the [Compute Environment](../compute-envs/overview.mdx) documentation to learn how to create an environment for your preferred execution platform.
 
-3. Enter a repository URL for the **Pipeline to launch** (e.g. `https://github.com/nf-core/rnaseq.git`).
+1.  Enter a repository URL for the **Pipeline to launch** (e.g. `https://github.com/nf-core/rnaseq.git`).
 
 :::tip
 Nextflow pipelines are just Git repositories and they can reside on any public or private Git-hosting platform. See [Git Integration](../git/overview.mdx) in the Tower docs and [Pipeline Sharing](https://www.nextflow.io/docs/latest/sharing.html) in the Nextflow docs for more details.
 :::
 
-4. You can select a **Revision number** to use a specific version of the pipeline.
+1.  You can select a **Revision number** to use a specific version of the pipeline.
 
    The Git default branch (e.g. `main` or `master`) or `manifest.defaultBranch` in the Nextflow configuration will be used by default.
 
-5. Enter the **Work directory**, which corresponds to the Nextflow work directory.
+1.  Enter the **Work directory**, which corresponds to the Nextflow work directory.
 
    The default work directory of the compute environment will be used by default.
 
@@ -35,11 +35,11 @@ Nextflow pipelines are just Git repositories and they can reside on any public o
 The credentials associated with the compute environment must be able to access the work directory (e.g. an S3 bucket).
 :::
 
-6.  Select any **Config profiles** you would like to use.
+1.  Select any **Config profiles** you would like to use.
 
     Visit the Nextflow [Config profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) documentation for more details.
 
-7.  Enter any **Pipeline parameters** in YAML or JSON format.
+1.  Enter any **Pipeline parameters** in YAML or JSON format.
 
         YAML example:
         ```yaml
@@ -51,4 +51,4 @@ The credentials associated with the compute environment must be able to access t
 In YAML, quotes should be used for paths but not for numbers or Booleans.
 :::
 
-8.  Select **Launch** to launch the pipeline.
+1.  Select **Launch** to launch the pipeline.

--- a/platform_versioned_docs/version-23.1.0/orgs-and-teams/organizations.mdx
+++ b/platform_versioned_docs/version-23.1.0/orgs-and-teams/organizations.mdx
@@ -13,17 +13,17 @@ Organizations are the top-level structure and contain Workspaces, Members, Teams
 
 To create a new organization:
 
-1. Navigate to [Your organizations](https://tower.nf/orgs) and select **Add Organization**.
+1.  Navigate to [Your organizations](https://tower.nf/orgs) and select **Add Organization**.
 
-2. Enter a **Name** and **Full name** for your organization.
+1.  Enter a **Name** and **Full name** for your organization.
 
    :::caution
    The organization name must follow a specific pattern. Refer to the UI for guidance.
    :::
 
-3. Enter any other optional fields as needed: **Description**, **Location**, **Website URL** and **Logo**.
+1.  Enter any other optional fields as needed: **Description**, **Location**, **Website URL** and **Logo**.
 
-4. Select **Add**.
+1.  Select **Add**.
 
 You can view the list of all **Members**, **Teams**, and **Collaborators** in an organization on the organization's page. You can also edit any of the optional fields by selecting **Edit** from the [organizations page](https://tower.nf/orgs) or by selecting the **Settings** tab from the organization's page, provided that you are an **Owner** of the organization.
 
@@ -41,9 +41,9 @@ Tower provides access control for members of an organization by classifying them
 
 To add a new member to an organization:
 
-1. Go to the **Members** tab of the organization menu
-2. Click on **Invite member**
-3. Enter the email ID of user you'd like to add to the organization
+1.  Go to the **Members** tab of the organization menu
+1.  Click on **Invite member**
+1.  Enter the email ID of user you'd like to add to the organization
 
 An e-mail invitiation will be sent which needs to be accepted by the user. Once they accept the invitation, they can switch to the organization (or organization workspace) using their workspace dropdown.
 
@@ -65,9 +65,9 @@ New collaborators to an organization's workspace can be added using **Participan
 
 To create a new team within an organization:
 
-1. Go to the **Teams** tab of the organization menu
-2. Click on **New team**
-3. Enter the **Name** of team
-4. Optionally, add the **Description** and the team's **Avatar**
-5. For the newly created team, click on **View**
-6. Click on **Add team member** and type in the name of the organization members or collaborators
+1.  Go to the **Teams** tab of the organization menu
+1.  Click on **New team**
+1.  Enter the **Name** of team
+1.  Optionally, add the **Description** and the team's **Avatar**
+1.  For the newly created team, click on **View**
+1.  Click on **Add team member** and type in the name of the organization members or collaborators

--- a/platform_versioned_docs/version-23.1.0/orgs-and-teams/workspace-management.mdx
+++ b/platform_versioned_docs/version-23.1.0/orgs-and-teams/workspace-management.mdx
@@ -19,12 +19,12 @@ A workspace participant may be a member of the workspace organization or a colla
 
 Organization owners and admins can create a new workspace within an organization:
 
-1. Go to the **Workspaces** tab of the organization page.
-2. Select **Add Workspace**.
-3. Enter the **Name** and **Full name** for the workspace.
-4. Optionally, add a **Description** for the workspace.
-5. Under **Visibility**, select either **Private** or **Shared**. Private visibility means that workspace pipelines are only accessible to workspace participants.
-6. Select **Add**.
+1.  Go to the **Workspaces** tab of the organization page.
+1.  Select **Add Workspace**.
+1.  Enter the **Name** and **Full name** for the workspace.
+1.  Optionally, add a **Description** for the workspace.
+1.  Under **Visibility**, select either **Private** or **Shared**. Private visibility means that workspace pipelines are only accessible to workspace participants.
+1.  Select **Add**.
 
 :::tip
 Optional workspace fields can be modified after workspace creation, either by using the **Edit** option on the workspace listing for an organization or by accessing the **Settings** tab within the workspace page, provided that you are the **Owner** of the workspace.
@@ -36,10 +36,10 @@ Apart from the **Participants** tab, the organization workspace is similar to th
 
 To add a new participant to a workspace:
 
-1. Go to the **Participants** tab in the workspace menu.
-2. Select **Add participant**.
-3. Enter the **Name** of the new participant.
-4. Optionally, update the participant **role**. For more information on **roles**, see [participant roles](#participant-roles).
+1.  Go to the **Participants** tab in the workspace menu.
+1.  Select **Add participant**.
+1.  Enter the **Name** of the new participant.
+1.  Optionally, update the participant **role**. For more information on **roles**, see [participant roles](#participant-roles).
 
 :::tip
 A new workspace participant can be an existing organization member, team, or collaborator.
@@ -55,15 +55,15 @@ It is also possible to group **members** and **collaborators** into **teams** an
 
 There are five roles available for every workspace participant.
 
-1. **Owner**: The participant has full permissions for all resources within the workspace, including the workspace settings.
+1.  **Owner**: The participant has full permissions for all resources within the workspace, including the workspace settings.
 
-2. **Admin**: The participant has full permissions for resources associated with the workspace. They can create, modify, and delete pipelines, compute environments, actions, and credentials. They can add or remove users from the workspace but cannot access the workspace settings.
+1.  **Admin**: The participant has full permissions for resources associated with the workspace. They can create, modify, and delete pipelines, compute environments, actions, and credentials. They can add or remove users from the workspace but cannot access the workspace settings.
 
-3. **Maintain**: The participant can launch pipelines and modify pipeline executions (e.g., they can change the pipeline launch compute environments, parameters, pre/post-run scripts, and Nextflow configuration) and create new pipelines in the Launchpad. Users with maintain permissions cannot modify compute environments and credentials.
+1.  **Maintain**: The participant can launch pipelines and modify pipeline executions (e.g., they can change the pipeline launch compute environments, parameters, pre/post-run scripts, and Nextflow configuration) and create new pipelines in the Launchpad. Users with maintain permissions cannot modify compute environments and credentials.
 
-4. **Launch**: The participant can launch pipelines and modify the pipeline input/output parameters in the Launchpad. They cannot modify the launch configuration or other resources.
+1.  **Launch**: The participant can launch pipelines and modify the pipeline input/output parameters in the Launchpad. They cannot modify the launch configuration or other resources.
 
-5. **View**: The participant can view workspace pipelines and runs in read-only mode.
+1.  **View**: The participant can view workspace pipelines and runs in read-only mode.
 
 ### Workspace run monitoring
 

--- a/platform_versioned_docs/version-23.1.0/pipeline-actions/overview.mdx
+++ b/platform_versioned_docs/version-23.1.0/pipeline-actions/overview.mdx
@@ -17,19 +17,19 @@ A **GitHub webhook** listens for any changes made in the pipeline repository. Wh
 
 To create a new **Pipeline action**, select the **Actions** tab and select **Add Action**.
 
-1. Enter a **Name** for your Action.
+1.  Enter a **Name** for your Action.
 
-2. Select **GitHub webhook** as the **Event source**.
+1.  Select **GitHub webhook** as the **Event source**.
 
    ![](./_images/actions_githook.png)
 
-3. Select the **Compute environment** where the pipeline will be executed.
+1.  Select the **Compute environment** where the pipeline will be executed.
 
-4. Select the **Pipeline to launch** and (optionally) the **Revision number**.
+1.  Select the **Pipeline to launch** and (optionally) the **Revision number**.
 
-5. Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
+1.  Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
 
-6. Select **Add**.
+1.  Select **Add**.
 
    ![](./_images/actions_params.png)
 
@@ -43,19 +43,19 @@ A **Tower launch hook** creates a custom endpoint URL which can be used to trigg
 
 To create a new **Pipeline action**, select the **Actions** tab and select **Add Action**.
 
-1. Enter a **Name** for your Action.
+1.  Enter a **Name** for your Action.
 
-2. Select **Tower launch hook** as the event source.
+1.  Select **Tower launch hook** as the event source.
 
    ![](./_images/actions_tower_hook.png)
 
-3. Select the **Compute environment** to execute your pipeline.
+1.  Select the **Compute environment** to execute your pipeline.
 
-4. Enter the **Pipeline to launch** and (optionally) the **Revision number**.
+1.  Enter the **Pipeline to launch** and (optionally) the **Revision number**.
 
-5. Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
+1.  Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
 
-6. Select **Add**.
+1.  Select **Add**.
 
    ![](./_images/actions_tower_hook_params.png)
 

--- a/platform_versioned_docs/version-23.1.0/reports/overview.mdx
+++ b/platform_versioned_docs/version-23.1.0/reports/overview.mdx
@@ -27,8 +27,8 @@ Users can download a report directly from Tower or using the path. Download is n
 
 To render reports users need to create a Tower config file that defines the paths to a selection of output files published by the pipeline. There are 2 ways users can provide the Tower config file both of which have to be in YAML format:
 
-1. **Pipeline repository**: If a file called _tower.yml_ exists in the root of the pipeline repository then this will be fetched automatically before the pipeline execution.,
-2. **Tower UI**: Providing the YAML definition within the _Advanced options > Tower config file_ box when:
+1.  **Pipeline repository**: If a file called _tower.yml_ exists in the root of the pipeline repository then this will be fetched automatically before the pipeline execution.,
+1.  **Tower UI**: Providing the YAML definition within the _Advanced options > Tower config file_ box when:
    1.Creating a Pipeline in the Launchpad
    2.Amending the Launch settings when launching a Pipeline. Users with _Maintain_ role only.
 

--- a/platform_versioned_docs/version-23.1.0/resource-labels/overview.mdx
+++ b/platform_versioned_docs/version-23.1.0/resource-labels/overview.mdx
@@ -107,15 +107,15 @@ The [`forge-policy.json`](https://github.com/seqeralabs/nf-tower-aws/blob/master
 
 To view and manage the resource labels applied to AWS resources by Tower and Nextflow, navigate to the [AWS Tag Editor](https://docs.aws.amazon.com/tag-editor/latest/userguide/find-resources-to-tag.html)(as an administrative user) and follow these steps:
 
-1. Under **Find resources to tag**, search for the resource label key and value in the relevant search fields under **Tags**. Your search can be further refined by AWS region and resource type. Then select **Search resources**.
+1.  Under **Find resources to tag**, search for the resource label key and value in the relevant search fields under **Tags**. Your search can be further refined by AWS region and resource type. Then select **Search resources**.
 
-2. **Resource search results** displays all the resources tagged with your given resource label key and/or value.
+1.  **Resource search results** displays all the resources tagged with your given resource label key and/or value.
 
 To include the cost information associated with your resource labels in your AWS billing reports, follow these steps:
 
-1. You need to [activate](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activating-tags.html) the associated tags in the **AWS Billing and Cost Management console**. Note that newly-applied tags may take up to 24 hours to appear on your cost allocation tags page.
+1.  You need to [activate](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activating-tags.html) the associated tags in the **AWS Billing and Cost Management console**. Note that newly-applied tags may take up to 24 hours to appear on your cost allocation tags page.
 
-2. Once your tags are activated and displayed on your **Cost allocation tags** page in the Billing and Cost Management console, you can apply those tags when creating [cost allocation reports](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/configurecostallocreport.html#allocation-viewing).
+1.  Once your tags are activated and displayed on your **Cost allocation tags** page in the Billing and Cost Management console, you can apply those tags when creating [cost allocation reports](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/configurecostallocreport.html#allocation-viewing).
 
 #### AWS limits
 

--- a/platform_versioned_docs/version-23.1.0/secrets/overview.mdx
+++ b/platform_versioned_docs/version-23.1.0/secrets/overview.mdx
@@ -47,12 +47,12 @@ Secrets will be automatically deleted from the secret manager when the Pipeline 
 
 If you are planning to use the Pipeline Secrets feature provided by Tower with the AWS Secrets Manager, the following IAM permissions should be provided:
 
-1. Create the AWS Batch [IAM Execution role](https://docs.aws.amazon.com/batch/latest/userguide/execution-IAM-role.html#create-execution-role) as specified in the AWS documentation.
+1.  Create the AWS Batch [IAM Execution role](https://docs.aws.amazon.com/batch/latest/userguide/execution-IAM-role.html#create-execution-role) as specified in the AWS documentation.
 
-2. Add the `AmazonECSTaskExecutionRolePolicy` policy and [this custom policy](../_templates/aws-batch/secrets-policy-execution-role.json) to the execution role created above.
+1.  Add the `AmazonECSTaskExecutionRolePolicy` policy and [this custom policy](../_templates/aws-batch/secrets-policy-execution-role.json) to the execution role created above.
 
-3. Specify the execution role ARN in the **Batch execution role** option (under **Advanced options**) when creating your Compute Environment in Tower.
+1.  Specify the execution role ARN in the **Batch execution role** option (under **Advanced options**) when creating your Compute Environment in Tower.
 
-4. Add [this custom policy](../_templates/aws-batch/secrets-policy-instance-role.json) to the ECS Instance role associated with the Batch compute environment that will be used to deploy your pipelines. Replace `YOUR-ACCOUNT` and `YOUR-EXECUTION-ROLE-NAME` with the appropriate values. See [here](https://docs.aws.amazon.com/batch/latest/userguide/instance_IAM_role.html) for more details about the Instance role.
+1.  Add [this custom policy](../_templates/aws-batch/secrets-policy-instance-role.json) to the ECS Instance role associated with the Batch compute environment that will be used to deploy your pipelines. Replace `YOUR-ACCOUNT` and `YOUR-EXECUTION-ROLE-NAME` with the appropriate values. See [here](https://docs.aws.amazon.com/batch/latest/userguide/instance_IAM_role.html) for more details about the Instance role.
 
-5. Add [this custom policy](../_templates/aws-batch/secrets-policy-account.json) to your Tower IAM user (the one specified in the Tower credentials).
+1.  Add [this custom policy](../_templates/aws-batch/secrets-policy-account.json) to your Tower IAM user (the one specified in the Tower credentials).

--- a/platform_versioned_docs/version-23.1.0/supported_software/dragen/overview.mdx
+++ b/platform_versioned_docs/version-23.1.0/supported_software/dragen/overview.mdx
@@ -29,9 +29,9 @@ To deploy the pipeline on your own AWS cloud infrastructure, please follow the i
 
 DRAGEN is a commercial technology provided by Illumina, so you will need to purchase a license from them. To run on Tower, you will need to obtain the following information from Illumina:
 
-1. DRAGEN AWS private AMI ID
-2. DRAGEN license username
-3. DRAGEN license password
+1.  DRAGEN AWS private AMI ID
+1.  DRAGEN license username
+1.  DRAGEN license password
 
 Batch Forge automates most of the tasks required to set up an AWS Batch Compute Environment. Please follow [our guide](../../compute-envs/aws-batch.mdx) for more details.
 
@@ -49,7 +49,7 @@ Please ensure that the Region you select contains DRAGEN F1 instances.
 
 Please see the [dragen.nf](https://github.com/seqeralabs/nf-dragen/blob/master/modules/local/dragen.nf) module implemented in the [nf-dragen](https://github.com/seqeralabs/nf-dragen) pipeline for reference. Any Nextflow processes that run DRAGEN must:
 
-1. Define `label ‘dragen’`
+1.  Define `label ‘dragen’`
 
    The `label` directive allows you to annotate a process with mnemonic identifiers of your choice. Tower will use the `dragen` label to determine which processes need to be executed on DRAGEN F1 instances.
 
@@ -63,7 +63,7 @@ Please see the [dragen.nf](https://github.com/seqeralabs/nf-dragen/blob/master/m
 
    Please refer to the [Nextflow label docs](https://www.nextflow.io/docs/latest/process.html?highlight=label#label) for more information.
 
-2. Define Secrets
+1.  Define Secrets
 
    At Seqera, we use Secrets to safely encrypt sensitive information when running licensed software via Nextflow. This enables our team to use the DRAGEN software safely via the `nf-dragen` pipeline without having to worry about the setup or safe configuration of the license key. These Secrets will be provided securely to the `--lic-server` option when running DRAGEN on the CLI to validate the license.
 

--- a/platform_versioned_docs/version-23.1.0/supported_software/fusion/fusion.mdx
+++ b/platform_versioned_docs/version-23.1.0/supported_software/fusion/fusion.mdx
@@ -31,11 +31,11 @@ Fusion v2 improves pipeline throughput for containerized tasks by simplifying di
 
 We recommend using Fusion with AWS NVMe instances (fast instance storage) as this delivers the fastest performance when compared to environments using only AWS EBS (Elastic Block Store).
 
-1. For this configuration, use Tower version 23.1 or later.
-2. Create an [AWS Batch compute environment](https://help.tower.nf/latest/compute-envs/aws-batch/#tower-forge).
-3. Enable Wave containers, Fusion v2, and fast instance storage.
-4. Select the **Batch Forge** config mode.
-5. Select your **Instance types** under Advanced options:
+1.  For this configuration, use Tower version 23.1 or later.
+1.  Create an [AWS Batch compute environment](https://help.tower.nf/latest/compute-envs/aws-batch/#tower-forge).
+1.  Enable Wave containers, Fusion v2, and fast instance storage.
+1.  Select the **Batch Forge** config mode.
+1.  Select your **Instance types** under Advanced options:
 
    - If left unspecified, Tower will select the following NVMe-based instance type families: `'c5ad', 'c5d', 'c6id', 'i3', 'i4i', 'm5ad', 'm5d', 'm6id', 'r5ad', 'r5d', 'r6id'`
    - To specify an NVMe instance family type, select from the following:
@@ -50,17 +50,17 @@ We recommend using Fusion with AWS NVMe instances (fast instance storage) as thi
    We recommend selecting 8xlarge or above for large and long-lived production pipelines. Dedicated networking ensures a guaranteed network speed service level compared with "burstable" instances. See [Instance network bandwidth](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-network-bandwidth.html) for more information.
    :::
 
-6. Use an S3 bucket as the pipeline work directory.
+1.  Use an S3 bucket as the pipeline work directory.
 
 #### Batch Forge AWS compute environments with Fusion only
 
 To use Fusion in AWS environments without NVMe instances, enable Wave containers and Fusion v2 when creating a new compute environment without enabling fast instance storage. This option configures an AWS EBS (Elastic Bucket Store) disk with settings optimized for the Fusion file system.
 
-1. For this configuration, use Tower version 23.1 or later.
-2. Create an [AWS Batch compute environment](https://help.tower.nf/latest/compute-envs/aws-batch/#tower-forge).
-3. Enable Wave containers and Fusion v2.
-4. Select the **Batch Forge** config mode.
-5. When you enable Fusion v2 without fast instance storage, the following settings are applied:
+1.  For this configuration, use Tower version 23.1 or later.
+1.  Create an [AWS Batch compute environment](https://help.tower.nf/latest/compute-envs/aws-batch/#tower-forge).
+1.  Enable Wave containers and Fusion v2.
+1.  Select the **Batch Forge** config mode.
+1.  When you enable Fusion v2 without fast instance storage, the following settings are applied:
 
    - `process.scratch = false` is added to the Nextflow configuration file
    - EBS autoscaling is disabled
@@ -68,7 +68,7 @@ To use Fusion in AWS environments without NVMe instances, enable Wave containers
    - EBS boot disk type is changed to GP3
    - EBS boot disk throughput is increased to 325MB/s
 
-6. Use an S3 bucket as the pipeline work directory.
+1.  Use an S3 bucket as the pipeline work directory.
 
 #### Fusion in manual compute environments
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/altair-grid-engine.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/altair-grid-engine.mdx
@@ -21,37 +21,37 @@ To launch pipelines into a **Grid Engine** cluster from Tower, the following req
 
 To create a new compute environment for **Grid Engine** in Tower:
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "Grid Engine".
+1.  Enter a descriptive name for this environment, e.g., "Grid Engine".
 
-3. Select **Altair Grid Engine** as the target platform.
+1.  Select **Altair Grid Engine** as the target platform.
 
-4. Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5. Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6. Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7. Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8. Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
 
-9. Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
 
 :::tip
 The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [documentation](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
 :::
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/altair-pbs-pro.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/altair-pbs-pro.mdx
@@ -21,37 +21,37 @@ To launch pipelines into a **PBS Pro** cluster from Tower, the following require
 
 To create a new compute environment for **PBS Pro** in Tower:
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "PBS Pro cluster".
+1.  Enter a descriptive name for this environment, e.g., "PBS Pro cluster".
 
-3. Select **Altair PBS Pro** as the target platform.
+1.  Select **Altair PBS Pro** as the target platform.
 
-4. Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5. Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6. Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7. Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8. Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
 
-9. Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
 
 :::tip
 The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [documentation](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
 :::
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/aws-batch.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/aws-batch.mdx
@@ -11,9 +11,9 @@ This guide assumes you have an existing [Amazon Web Service (AWS)](https://aws.a
 
 There are two ways to create a **compute environment** for **AWS Batch** with Tower:
 
-1. [**Batch Forge**](#tower-forge): This option automatically creates the AWS Batch resources in your AWS account. This eliminates the need to set up your AWS Batch infrastructure manually.
+1.  [**Batch Forge**](#tower-forge): This option automatically creates the AWS Batch resources in your AWS account. This eliminates the need to set up your AWS Batch infrastructure manually.
 
-2. [**Manual**](#manual): This option allows Tower to use existing AWS Batch resources.
+1.  [**Manual**](#manual): This option allows Tower to use existing AWS Batch resources.
 
 ## Batch Forge
 
@@ -27,69 +27,69 @@ We recommend creating separate IAM policies for Batch Forge and Tower launch per
 
 #### Create Tower IAM policies
 
-1. Open the [AWS IAM console](https://console.aws.amazon.com/iam).
+1.  Open the [AWS IAM console](https://console.aws.amazon.com/iam).
 
-2. From the left navigation menu, select **Policies** under **Access management**.
+1.  From the left navigation menu, select **Policies** under **Access management**.
 
-3. Select **Create policy**.
+1.  Select **Create policy**.
 
-4. On the **Create policy** page, select the **JSON** tab.
+1.  On the **Create policy** page, select the **JSON** tab.
 
-5. Copy the contents of your policy JSON file ([Forge](https://github.com/seqeralabs/nf-tower-aws/blob/master/forge/forge-policy.json) or [Launch](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/launch-policy.json), depending on the policy being created) and replace the default text in the policy editor area under the JSON tab. To create a Launch user, you must also create the [S3 bucket write policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) separately to attach to your Launch user.
+1.  Copy the contents of your policy JSON file ([Forge](https://github.com/seqeralabs/nf-tower-aws/blob/master/forge/forge-policy.json) or [Launch](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/launch-policy.json), depending on the policy being created) and replace the default text in the policy editor area under the JSON tab. To create a Launch user, you must also create the [S3 bucket write policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) separately to attach to your Launch user.
 
-6. Select **Next: Tags**.
+1.  Select **Next: Tags**.
 
-7. Select **Next: Review**.
+1.  Select **Next: Review**.
 
-8. Enter a name and description for the policy on the Review policy page, then select **Create policy**.
+1.  Enter a name and description for the policy on the Review policy page, then select **Create policy**.
 
-9. Repeat these steps for both the `forge-policy.json` and `launch-policy.json` files. For a Launch user, also create the `s3-bucket-write-policy.json` listed in step 5 above.
+1.  Repeat these steps for both the `forge-policy.json` and `launch-policy.json` files. For a Launch user, also create the `s3-bucket-write-policy.json` listed in step 5 above.
 
 #### Create an IAM user
 
-1. From the [AWS IAM console](https://console.aws.amazon.com/iam), select **Users** in the left navigation menu, then select **Add User** at the top rigt of the page.
+1.  From the [AWS IAM console](https://console.aws.amazon.com/iam), select **Users** in the left navigation menu, then select **Add User** at the top rigt of the page.
 
-2. Enter a name for your user (e.g. `tower`) and select the **Programmatic access** type.
+1.  Enter a name for your user (e.g. `tower`) and select the **Programmatic access** type.
 
-3. Select **Next: Permissions**.
+1.  Select **Next: Permissions**.
 
-4. Select **Next: Tags**, then **Next: Review** and **Create User**.
+1.  Select **Next: Tags**, then **Next: Review** and **Create User**.
 
 :::caution
 For the time being, you can ignore the "user has no permissions" warning. Permissions will be applied using the **IAM Policy**.
 :::
 
-5. Save the **Access key ID** and **Secret access key** in a secure location as we will use these in the next section.
+1.  Save the **Access key ID** and **Secret access key** in a secure location as we will use these in the next section.
 
-6. Once you have saved the keys, select **Close**.
+1.  Once you have saved the keys, select **Close**.
 
-7. Back in the users table, select the newly created user,then select **Add permissions** under the Permissions tab.
+1.  Back in the users table, select the newly created user,then select **Add permissions** under the Permissions tab.
 
-8. Select **Attach existing policies**, search for the policies created [previously](./aws-batch.mdx#create-tower-iam-policies), and select each one.
+1.  Select **Attach existing policies**, search for the policies created [previously](./aws-batch.mdx#create-tower-iam-policies), and select each one.
 
-9. Select **Next: Review**.
+1.  Select **Next: Review**.
 
-10. Select **Add permissions**.
+1.  Select **Add permissions**.
 
 ### S3 Bucket
 
 S3 (Simple Storage Service) is a type of **object storage**. To access files and store the results for our pipelines, we have to create an **S3 bucket** and grant our new Tower IAM user access to it.
 
-1. Navigate to the [S3 service](https://console.aws.amazon.com/s3/home).
+1.  Navigate to the [S3 service](https://console.aws.amazon.com/s3/home).
 
-2. Select **Create New Bucket**.
+1.  Select **Create New Bucket**.
 
-3. Enter a unique name for your bucket and select a region.
+1.  Enter a unique name for your bucket and select a region.
 
 :::caution
 To maximize data transfer resilience and minimize cost, storage should be in the same region as compute.
 :::
 
-4. Select the default options for **Configure options**.
+1.  Select the default options for **Configure options**.
 
-5. Select the default options for **Set permissions**.
+1.  Select the default options for **Set permissions**.
 
-6. Review and select **Create bucket**.
+1.  Review and select **Create bucket**.
 
 :::caution
 S3 is used by Nextflow for the storage of intermediate files. In production pipelines, this can amount to a large quantity of data. To reduce costs, consider using a retention policy when creating a bucket, such as automatically deleting intermediate files after 30 days. See [here](https://aws.amazon.com/premiumsupport/knowledge-center/s3-empty-bucket-lifecycle-rule/) for more information.
@@ -101,33 +101,33 @@ Batch Forge automates the configuration of an [AWS Batch](https://aws.amazon.com
 
 Once the AWS resources are set up, we can add a new **AWS Batch** environment in Tower. To create a new compute environment:
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "AWS Batch Spot (eu-west-1)".
+1.  Enter a descriptive name for this environment, e.g., "AWS Batch Spot (eu-west-1)".
 
-3. Select **Amazon Batch** as the target platform.
+1.  Select **Amazon Batch** as the target platform.
 
-4. From the **Credentials** drop-down, select existing AWS credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing AWS credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
 
-5. Enter a name, e.g. "AWS Credentials".
+1.  Enter a name, e.g. "AWS Credentials".
 
-6. Add the **Access key** and **Secret key**. These are the keys you saved previously when you created the AWS [IAM user](#iam).
+1.  Add the **Access key** and **Secret key**. These are the keys you saved previously when you created the AWS [IAM user](#iam).
 
 :::tip
 You can create multiple credentials in your Tower environment.
 :::
 
-7. Select a **Region**, e.g., "eu-west-1 - Europe (Ireland)".
+1.  Select a **Region**, e.g., "eu-west-1 - Europe (Ireland)".
 
-8. Enter the S3 bucket path created in the previous section to the **Pipeline work directory** field, e.g. `s3://unique-tower-bucket`.
+1.  Enter the S3 bucket path created in the previous section to the **Pipeline work directory** field, e.g. `s3://unique-tower-bucket`.
 
 :::caution
 The bucket should be in the same region selected in the previous step.
 :::
 
-9. Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
+1.  Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
 
-10. Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
+1.  Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
 
     :::note
     When using Fusion v2 without fast instance storage (see below), the following EBS settings are applied to optimize file system performance:
@@ -140,15 +140,15 @@ The bucket should be in the same region selected in the previous step.
     Extensive benchmarking of Fusion v2 has demonstrated that the increased cost associated with these settings are generally outweighed by the costs saved due to decreased run time.
     :::
 
-11. Select **Enable fast instance storage** to allow the use of NVMe instance storage to speed up I/O and disk access operations. NVMe instance storage requires Fusion v2 to be enabled (see above).
+1.  Select **Enable fast instance storage** to allow the use of NVMe instance storage to speed up I/O and disk access operations. NVMe instance storage requires Fusion v2 to be enabled (see above).
 
     :::note
     Fast instance storage requires an EC2 instance type that uses NVMe disks. Tower validates any instance types you specify (from **Advanced options > Instance types**) during compute environment creation. If you do not specify an instance type, a standard EC2 instance with NVMe disks will be used (`'c5ad', 'c5d', 'c6id', 'i3', 'i4i', 'm5ad', 'm5d', 'm6id', 'r5ad', 'r5d', 'r6id'` EC2 instance families) for fast storage.
     :::
 
-12. Set the **Config mode** to **Batch Forge**.
+1.  Set the **Config mode** to **Batch Forge**.
 
-13. Select a **Provisioning model**. In most cases this will be **Spot**.
+1.  Select a **Provisioning model**. In most cases this will be **Spot**.
 
     :::tip
     You can choose to create a compute environment that launches either Spot or On-demand instances. Spot instances can cost as little as 20% of on-demand instances, and with Nextflow's ability to automatically relaunch failed tasks, Spot is almost always the recommended provisioning model.
@@ -156,23 +156,23 @@ The bucket should be in the same region selected in the previous step.
     Note, however, that when choosing Spot instances, Tower will also create a dedicated queue for running the main Nextflow job using a single on-demand instance in order to prevent any execution interruptions.
     :::
 
-14. Enter the **Max CPUs** e.g. `64`. This is the maximum number of combined CPUs (the sum of all instances CPUs) AWS Batch will provision at any time.
+1.  Enter the **Max CPUs** e.g. `64`. This is the maximum number of combined CPUs (the sum of all instances CPUs) AWS Batch will provision at any time.
 
-15. Select **EBS Auto scale** to allow the EC2 virtual machines to dynamically expand the amount of available disk space during task execution.
+1.  Select **EBS Auto scale** to allow the EC2 virtual machines to dynamically expand the amount of available disk space during task execution.
 
     :::caution
     When running large AWS Batch clusters (hundreds of compute nodes or more), EC2 API rate limits may cause the deletion of unattached EBS volumes to fail. Volumes that remain active after Nextflow jobs have completed will incur additional costs, and should be manually deleted. Monitor your AWS account for any orphaned EBS volumes via the EC2 console, or with a Lambda function. See [here](https://aws.amazon.com/blogs/mt/controlling-your-aws-costs-by-deleting-unused-amazon-ebs-volumes/) for more information.
     :::
 
-16. With the optional **Enable Fusion mounts (deprecated)** feature enabled, S3 buckets specified in **Pipeline work directory** and **Allowed S3 Buckets** are mounted as file system volumes in the EC2 instances carrying out the Batch job execution. These buckets can then be accessed at `/fusion/s3/<bucket-name>`. For example, if the bucket name is `s3://imputation-gp2`, your pipeline will access it using the file system path `/fusion/s3/imputation-gp2`. **Note:** This feature has been deprecated. Consider using Fusion v2 (see above) for enhanced performance and stability.
+1.  With the optional **Enable Fusion mounts (deprecated)** feature enabled, S3 buckets specified in **Pipeline work directory** and **Allowed S3 Buckets** are mounted as file system volumes in the EC2 instances carrying out the Batch job execution. These buckets can then be accessed at `/fusion/s3/<bucket-name>`. For example, if the bucket name is `s3://imputation-gp2`, your pipeline will access it using the file system path `/fusion/s3/imputation-gp2`. **Note:** This feature has been deprecated. Consider using Fusion v2 (see above) for enhanced performance and stability.
 
     :::tip
     You do not need to modify your pipeline or files to take advantage of this feature. Nextflow will automatically recognize and replace any reference to files prefixed with `s3://` with the corresponding Fusion mount paths.
     :::
 
-17. Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. See [GPU usage](./overview.mdx#aws-batch) for more information.
+1.  Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. See [GPU usage](./overview.mdx#aws-batch) for more information.
 
-18. Select **Use Graviton CPU architecture** to execute the pipeline on Graviton-based EC2 instances (i.e., ARM64 CPU architecture). When enabled, Tower automatically selects `m6g`, `r6g` and `c6g` instance types for compute jobs. You can override this selection in the **Instance types** field under **Advanced settings**.
+1.  Select **Use Graviton CPU architecture** to execute the pipeline on Graviton-based EC2 instances (i.e., ARM64 CPU architecture). When enabled, Tower automatically selects `m6g`, `r6g` and `c6g` instance types for compute jobs. You can override this selection in the **Instance types** field under **Advanced settings**.
 
 :::note
 Requires Fargate, Wave containers, and Fusion v2 file system to be enabled. This feature is not compatible with GPU-based architecture.
@@ -181,31 +181,31 @@ Requires Fargate, Wave containers, and Fusion v2 file system to be enabled. This
 
 :::
 
-19. Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.
+1.  Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.
 
-20. To use **EFS**, you can either select **Use existing EFS file system** and specify an existing EFS instance, or select **Create new EFS file system** to create one. If you intend to use the EFS file system as your work directory, you will need to specify `<your_EFS_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
+1.  To use **EFS**, you can either select **Use existing EFS file system** and specify an existing EFS instance, or select **Create new EFS file system** to create one. If you intend to use the EFS file system as your work directory, you will need to specify `<your_EFS_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
 
     - To use an existing EFS file system, enter the **EFS file system id** and **EFS mount path**. This is the path where the EFS volume is accessible to the compute environment. For simplicity, we advise that you use `/mnt/efs` as the EFS mount path.
     - To create a new EFS file system, enter the **EFS mount path**. We advise that you specify `/mnt/efs` as the EFS mount path.
     - EFS file systems created by Batch Forge are automatically tagged in AWS with `Name=TowerForge-<id>`, with `<id>` being the compute environment ID. Any manually added Tower resource label with the key `Name` (capital N) will override the automatically-assigned `TowerForge-<id>` label.
 
-21. To use **FSx for Lustre**, you can either select **Use existing FSx file system** and specify an existing FSx instance, or select **Create new FSx file system** to create one. If you intend to use the FSx file system as your work directory, you will need to specify `<your_FSx_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
+1.  To use **FSx for Lustre**, you can either select **Use existing FSx file system** and specify an existing FSx instance, or select **Create new FSx file system** to create one. If you intend to use the FSx file system as your work directory, you will need to specify `<your_FSx_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
 
     - To use an existing FSx file system, enter the **FSx DNS name** and **FSx mount path**. The FSx mount path is the path where the FSx volume is accessible to the compute environment. For simplicity, we advise that you use `/mnt/fsx` as the FSx mount path.
     - To create a new FSx file system, enter the **FSx size** (in GB) and the **FSx mount path**. We advise that you specify `/mnt/fsx` as the FSx mount path.
     - FSx file systems created by Batch Forge are automatically tagged in AWS with `Name=TowerForge-<id>`, with `<id>` being the compute environment ID. Any manually added Tower resource label with the key `Name` (capital N) will override the automatically-assigned `TowerForge-<id>` label.
 
-22. Select **Dispose resources** if you want Tower to automatically delete these AWS resources if you delete the compute environment in Tower.
+1.  Select **Dispose resources** if you want Tower to automatically delete these AWS resources if you delete the compute environment in Tower.
 
-23. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-24. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-25. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-26. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-27. Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
+1.  Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 
@@ -273,51 +273,51 @@ With these permissions set, we can add a new **AWS Batch** compute environment i
 
 Tower can use S3 to store intermediate and output data generated by pipelines. You need to create a policy for your Tower IAM user that grants access to specific buckets.
 
-1. Go to the IAM User table in the [IAM service](https://console.aws.amazon.com/iam/home)
+1.  Go to the IAM User table in the [IAM service](https://console.aws.amazon.com/iam/home)
 
-2. Select the IAM user.
+1.  Select the IAM user.
 
-3. Select **Add inline policy**.
+1.  Select **Add inline policy**.
 
-4. Copy the contents of [this policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) into the **JSON** tab. Replace `YOUR-BUCKET-NAME` (lines 10 and 21) with your bucket name.
+1.  Copy the contents of [this policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) into the **JSON** tab. Replace `YOUR-BUCKET-NAME` (lines 10 and 21) with your bucket name.
 
-5. Name your policy and select **Create policy**.
+1.  Name your policy and select **Create policy**.
 
 ### Compute environment
 
 To create a new compute environment for AWS Batch (without Forge):
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "AWS Batch Manual (eu-west-1)".
+1.  Enter a descriptive name for this environment, e.g., "AWS Batch Manual (eu-west-1)".
 
-3. Select **Amazon Batch** as the target platform.
+1.  Select **Amazon Batch** as the target platform.
 
-4. Add new credentials by selecting the **+** button.
+1.  Add new credentials by selecting the **+** button.
 
-5. Enter a name for the credentials, e.g., "AWS Credentials".
+1.  Enter a name for the credentials, e.g., "AWS Credentials".
 
-6. Enter the **Access key** and **Secret key** for your IAM user.
+1.  Enter the **Access key** and **Secret key** for your IAM user.
 
 :::tip
 You can create multiple credentials in your Tower environment. See the [Credentials](../credentials/overview.mdx) section.
 :::
 
-7. Select a **Region**, e.g., "eu-west-1 - Europe (Ireland)".
+1.  Select a **Region**, e.g., "eu-west-1 - Europe (Ireland)".
 
-8. Enter an S3 bucket path for the **Pipeline work directory**, e.g., `s3://tower-bucket`.
+1.  Enter an S3 bucket path for the **Pipeline work directory**, e.g., `s3://tower-bucket`.
 
-9. Set the **Config mode** to **Manual**.
+1.  Set the **Config mode** to **Manual**.
 
-10. Enter the **Head queue**, which is the name of the AWS Batch queue that the Nextflow driver job will run.
+1.  Enter the **Head queue**, which is the name of the AWS Batch queue that the Nextflow driver job will run.
 
-11. Enter the **Compute queue**, which is the name of the AWS Batch queue that tasks will be submitted to.
+1.  Enter the **Compute queue**, which is the name of the AWS Batch queue that tasks will be submitted to.
 
-12. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/azure-batch.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/azure-batch.mdx
@@ -32,13 +32,13 @@ To create Azure Batch and Azure Storage accounts, first create a **resource grou
 
 If you are logged in to your Azure account, select **Create new resource group** on [this page](https://portal.azure.com/#create/Microsoft.ResourceGroup).
 
-1. Enter a name for the resource group (e.g. `towerrg`).
+1.  Enter a name for the resource group (e.g. `towerrg`).
 
-2. Select the preferred region for this resource group.
+1.  Select the preferred region for this resource group.
 
-3. Select **Review and Create** to proceed to the review screen.
+1.  Select **Review and Create** to proceed to the review screen.
 
-4. Select **Create** to create the resources.
+1.  Select **Create** to create the resources.
 
 ### Storage account
 
@@ -46,23 +46,23 @@ The next step is to create the necessary Azure Storage.
 
 If you are logged in to your Azure account, select **Create a storage account** on [this page](https://portal.azure.com/#blade/HubsExtension/BrowseResource/resourceType/Microsoft.Storage%2FStorageAccounts).
 
-1. Enter a name for the storage account (e.g., `towerrgstorage`).
+1.  Enter a name for the storage account (e.g., `towerrgstorage`).
 
-2. Select the preferred region for this storage account.
+1.  Select the preferred region for this storage account.
 
-3. Select **Review and Create** to proceed to the review screen.
+1.  Select **Review and Create** to proceed to the review screen.
 
-4. Select **Create** to create the Azure Storage account.
+1.  Select **Create** to create the Azure Storage account.
 
-5. Navigate to your new storage account and select **Container**.
+1.  Navigate to your new storage account and select **Container**.
 
-6. Create a new Blob container by selecting **+ Container**.
+1.  Create a new Blob container by selecting **+ Container**.
 
    A new container dialogue will open. Enter a suitable name (e.g. `towerrgstorage-container`).
 
-7. Once the new Blob container is created, navigate to the **Access Keys** section of the storage account (`towerrgstorage` in this example).
+1.  Once the new Blob container is created, navigate to the **Access Keys** section of the storage account (`towerrgstorage` in this example).
 
-8. Store the access keys for the newly created Azure Storage account.
+1.  Store the access keys for the newly created Azure Storage account.
 
 :::note
 Blob container storage credentials are associated with the Batch pool configuration when it is created. Once your compute environment has been created with Batch Forge, these credentials should not be changed in Tower.
@@ -74,13 +74,13 @@ The next step is to create the necessary Batch account.
 
 If you are logged in to your Azure account, select **Create a batch account** on [this page](https://portal.azure.com/#blade/HubsExtension/BrowseResource/resourceType/Microsoft.Batch%2FbatchAccounts).
 
-1. Enter a name for the Batch account (e.g. `towerrgbatch`).
+1.  Enter a name for the Batch account (e.g. `towerrgbatch`).
 
-2. Select the preferred region for this Batch account.
+1.  Select the preferred region for this Batch account.
 
-3. Select **Review and Create** to proceed to the review screen.
+1.  Select **Review and Create** to proceed to the review screen.
 
-4. Select **Create** to create the Azure Batch account.
+1.  Select **Create** to create the Azure Batch account.
 
 ### Compute environment
 
@@ -88,51 +88,51 @@ Batch Forge automates the configuration of an [Azure Batch](https://azure.micros
 
 Once the Azure resources are set up, add a new compute environment in Tower:
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g. "Azure Batch (east-us)"
+1.  Enter a descriptive name for this environment, e.g. "Azure Batch (east-us)"
 
-3. Select **Azure Batch** as the target platform.
+1.  Select **Azure Batch** as the target platform.
 
-4. From the **Credentials** drop-down, select existing Azure credentials, or select **+** to add new credentials. If you have existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing Azure credentials, or select **+** to add new credentials. If you have existing credentials, skip to step 7.
 
-5. Enter a name, e.g. "Azure Credentials".
+1.  Enter a name, e.g. "Azure Credentials".
 
-6. Add the **Batch account** and **Blob Storage** credentials that we created previously.
+1.  Add the **Batch account** and **Blob Storage** credentials that we created previously.
 
 :::tip
 You can create multiple credentials in your Tower environment.
 :::
 
-7. Select a **Region**, for example "eastus (East US)".
+1.  Select a **Region**, for example "eastus (East US)".
 
-8. In the **Pipeline work directory** field, enter the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
+1.  In the **Pipeline work directory** field, enter the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
 
 :::caution
 The blob container must be in the same **Region** from step 7.
 :::
 
-9. Set the **Config mode** to **Batch Forge**.
+1.  Set the **Config mode** to **Batch Forge**.
 
-10. Enter the default VM type, depending on your quota limits. The default is `Standard_D4_v3`.
+1.  Enter the default VM type, depending on your quota limits. The default is `Standard_D4_v3`.
 
-11. Enter the **VMs count**. This is the number of VMs you wish to deploy.
+1.  Enter the **VMs count**. This is the number of VMs you wish to deploy.
 
-12. Enable **Autoscale** if you'd like to scale up and down automatically based on the number of pipeline tasks. The number of VMs will vary from **0** to **VMs count**.
+1.  Enable **Autoscale** if you'd like to scale up and down automatically based on the number of pipeline tasks. The number of VMs will vary from **0** to **VMs count**.
 
-13. Enable **Dispose resources** if you'd like Tower to automatically delete the Batch pool once the workflow is complete.
+1.  Enable **Dispose resources** if you'd like Tower to automatically delete the Batch pool once the workflow is complete.
 
-14. Select or create a [**Container registry credential**](../credentials/azure_registry_credentials.mdx) to authenticate to an Azure registry (used by the [Wave containers](https://www.nextflow.io/docs/latest/wave.html) service).
+1.  Select or create a [**Container registry credential**](../credentials/azure_registry_credentials.mdx) to authenticate to an Azure registry (used by the [Wave containers](https://www.nextflow.io/docs/latest/wave.html) service).
 
-15. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-16. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-17. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-18. Configure any advanced options (see below), as needed.
+1.  Configure any advanced options (see below), as needed.
 
-19. Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before the compute environment is ready to launch pipelines.
+1.  Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before the compute environment is ready to launch pipelines.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 
@@ -148,39 +148,39 @@ This section is for users with a pre-configured Azure environment. You will need
 
 To create a new compute environment for AWS Batch (without Forge):
 
-1. In a workspace, select **Compute Environments**, then **New Environment**.
+1.  In a workspace, select **Compute Environments**, then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g. "Azure Batch (east-us)".
+1.  Enter a descriptive name for this environment, e.g. "Azure Batch (east-us)".
 
-3. Select **Azure Batch** as the target platform.
+1.  Select **Azure Batch** as the target platform.
 
-4. Select your existing Azure credentials or add new credentials by selecting the **+** button. If you are using existing credentials, skip to step 7.
+1.  Select your existing Azure credentials or add new credentials by selecting the **+** button. If you are using existing credentials, skip to step 7.
 
-5. Enter a name, e.g. "Azure Credentials".
+1.  Enter a name, e.g. "Azure Credentials".
 
-6. Add the **Batch account** and **Blob Storage** credentials that we created previously.
+1.  Add the **Batch account** and **Blob Storage** credentials that we created previously.
 
 :::tip
 You can create multiple credentials in your Tower environment.
 :::
 
-7. Select a **Region**, for example "eastus (East US)".
+1.  Select a **Region**, for example "eastus (East US)".
 
-8. In the **Pipeline work directory** field, add the Azure blob container created previously, e.g. `az://towerrgstorage-container/work`.
+1.  In the **Pipeline work directory** field, add the Azure blob container created previously, e.g. `az://towerrgstorage-container/work`.
 
 :::caution
 The Blob container must be in the same **Region** specified in step 7 above.
 :::
 
-9. Set the **Config mode** to **Manual**.
+1.  Set the **Config mode** to **Manual**.
 
-10. Enter the **Compute Pool name**. This is the name of the Azure Batch pool provided to you by your Azure administrator.
+1.  Enter the **Compute Pool name**. This is the name of the Azure Batch pool provided to you by your Azure administrator.
 
-11. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-12. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-13. Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
+1.  Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created, and then you will be ready to launch pipelines.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/eks.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/eks.mdx
@@ -58,37 +58,37 @@ See the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/add
 
 ## Compute environment
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "Amazon EKS (eu-west-1)".
+1.  Enter a descriptive name for this environment, e.g., "Amazon EKS (eu-west-1)".
 
-3. Select **Amazon EKS** as the target platform.
+1.  Select **Amazon EKS** as the target platform.
 
-4. From the **Credentials** drop-down, select existing AWS credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing AWS credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
 
 :::note
 The user must have the IAM permissions required to describe and list EKS clusters as explained [here](#requirements).
 :::
 
-5. Select a **Region**, e.g., "eu-west-1 - Europe (Ireland)".
+1.  Select a **Region**, e.g., "eu-west-1 - Europe (Ireland)".
 
-6. Select a **Cluster name** from the list of available EKS clusters in the selected region.
+1.  Select a **Cluster name** from the list of available EKS clusters in the selected region.
 
-7. Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is `tower-nf` by default.
+1.  Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is `tower-nf` by default.
 
-8. Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
+1.  Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
 
-9. Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called `tower-scratch` in each of the provided examples.
+1.  Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called `tower-scratch` in each of the provided examples.
 
-10. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/gke.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/gke.mdx
@@ -44,23 +44,23 @@ For more details, refer to the [Google documentation](https://cloud.google.com/k
 
 ## Compute Environment
 
-1. In a Tower workspace, select **Compute environments** and then **New environment**.
+1.  In a Tower workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "Google GKE (europe-west1)".
+1.  Enter a descriptive name for this environment, e.g., "Google GKE (europe-west1)".
 
-3. From the **Provider** drop-down, select **Google GKE**.
+1.  From the **Provider** drop-down, select **Google GKE**.
 
-4. From the **Credentials** drop-down, select existing GKE credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing GKE credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
 
-5. Enter a name for the credentials, e.g., "GKE Credentials".
+1.  Enter a name for the credentials, e.g., "GKE Credentials".
 
-6. Enter the **Service account key** for your Google Service account.
+1.  Enter the **Service account key** for your Google Service account.
 
 :::tip
 You can create multiple credentials in your Tower environment.
 :::
 
-7. Select the **Location** of your GKE cluster.
+1.  Select the **Location** of your GKE cluster.
 
 :::caution
 GKE clusters can be either _regional_ or _zonal_. For example, `us-west1` identifies the United States West-Coast region, which has three zones: `us-west1-a`, `us-west1-b`, and `us-west1-c`.
@@ -70,23 +70,23 @@ GKE clusters can be either _regional_ or _zonal_. For example, `us-west1` identi
 
 :::
 
-8. Select or enter the **Cluster name** of your GKE cluster.
+1.  Select or enter the **Cluster name** of your GKE cluster.
 
-9. Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is `tower-nf` by default.
+1.  Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is `tower-nf` by default.
 
-10. Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is `tower-launcher-sa` by default.
+1.  Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is `tower-launcher-sa` by default.
 
-11. Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This serves as a scratch filesystem for Nextflow pipelines. The storage claim is called `tower-scratch` in each of the provided examples.
+1.  Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This serves as a scratch filesystem for Nextflow pipelines. The storage claim is called `tower-scratch` in each of the provided examples.
 
-12. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-13. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-14. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-15. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-16. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/google-cloud-batch.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/google-cloud-batch.mdx
@@ -11,9 +11,9 @@ Tower provides integration to Google Cloud via the [Batch API](https://cloud.goo
 
 The guide is split into two parts:
 
-1. How to configure your Google Cloud account to use the Batch API.
+1.  How to configure your Google Cloud account to use the Batch API.
 
-2. How to create a Google Cloud Batch compute environment in Tower.
+1.  How to create a Google Cloud Batch compute environment in Tower.
 
 ## Configure Google Cloud
 
@@ -49,15 +49,15 @@ Alternatively, you can enable each API manually by selecting your project in the
 
 ### Create a service account key
 
-1. In the navigation menu, select **IAM & Admin**, then **Service Accounts**.
+1.  In the navigation menu, select **IAM & Admin**, then **Service Accounts**.
 
-2. Select the email address of the **Compute Engine default service account**.
+1.  Select the email address of the **Compute Engine default service account**.
 
-3. Select **Keys**, then **Add key**, then **Create new key**.
+1.  Select **Keys**, then **Add key**, then **Create new key**.
 
-4. Select **JSON** as the key type.
+1.  Select **JSON** as the key type.
 
-5. Select **Create**.
+1.  Select **Create**.
 
 A JSON file will be downloaded to your computer. This file contains the credential needed to configure the compute environment in Tower.
 
@@ -65,33 +65,33 @@ You can manage your key from the **Service Accounts** page.
 
 ### Create a Cloud Storage bucket
 
-1. In the navigation menu (**≡**), select **Cloud Storage**, then **Create bucket**.
+1.  In the navigation menu (**≡**), select **Cloud Storage**, then **Create bucket**.
 
-2. Enter a name for your bucket. You will reference this name when creating the compute environment in Tower.
+1.  Enter a name for your bucket. You will reference this name when creating the compute environment in Tower.
 
 :::caution
 Do not use underscores (`_`) in your bucket name. Use hyphens (`-`) instead.
 :::
 
-3. Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Tower.
+1.  Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Tower.
 
-4. Select **Standard** for the default storage class.
+1.  Select **Standard** for the default storage class.
 
-5. Select **Uniform** for the **Access control**.
+1.  Select **Uniform** for the **Access control**.
 
 :::note
 The Batch API is available in a limited number of [locations](https://cloud.google.com/batch/docs/locations). These locations are only used to store metadata about the pipeline operations. The storage bucket and compute resources can be in any region.
 :::
 
-6. Select **Create**.
+1.  Select **Create**.
 
-7. Once the bucket is created, you will be redirected to the **Bucket details** page.
+1.  Once the bucket is created, you will be redirected to the **Bucket details** page.
 
-8. Select **Permissions**, then **+ Add**.
+1.  Select **Permissions**, then **+ Add**.
 
-9. Copy the email address of the Compute Engine default service account into **New principals**.
+1.  Copy the email address of the Compute Engine default service account into **New principals**.
 
-10. Select the following roles:
+1.  Select the following roles:
 
 - Storage Admin
 - Storage Legacy Bucket Owner
@@ -110,37 +110,37 @@ The following guide to configure Tower assumes you have (1) a service account ke
 
 To create a new compute environment for Google Cloud in Tower:
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g., "Google Cloud Batch (europe-north1)".
+1.  Enter a descriptive name for this environment, e.g., "Google Cloud Batch (europe-north1)".
 
-3. Select **Google Cloud Batch** as the target platform.
+1.  Select **Google Cloud Batch** as the target platform.
 
-4. From the **Credentials** drop-down, select existing Google credentials, or select **+** to add new credentials. If you have existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing Google credentials, or select **+** to add new credentials. If you have existing credentials, skip to step 7.
 
-5. Enter a name for the credentials, e.g. "Google Cloud Credentials".
+1.  Enter a name for the credentials, e.g. "Google Cloud Credentials".
 
-6. Enter the **Service account key** [created previously](#create-a-service-account-key).
+1.  Enter the **Service account key** [created previously](#create-a-service-account-key).
 
-7. Select the [**Location**](https://cloud.google.com/compute/docs/regions-zones#available) where you wish to execute pipelines.
+1.  Select the [**Location**](https://cloud.google.com/compute/docs/regions-zones#available) where you wish to execute pipelines.
 
-8. In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket should be accessible in the location selected in the previous step.
+1.  In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket should be accessible in the location selected in the previous step.
 
-9. Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
+1.  Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
 
-10. Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). <!--(re-added once we have GCP Fusion instructions) See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.-->
+1.  Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). <!--(re-added once we have GCP Fusion instructions) See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.-->
 
-11. Enable **Spot** to use spot instances, which have significantly reduced cost compared to on-demand instances.
+1.  Enable **Spot** to use spot instances, which have significantly reduced cost compared to on-demand instances.
 
-12. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-13. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-14. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-15. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-16. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/google-cloud-lifesciences.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/google-cloud-lifesciences.mdx
@@ -11,9 +11,9 @@ Tower provides integration to Google Cloud via the [Cloud Life Sciences API](htt
 
 This guide is split into two parts:
 
-1. How to configure your Google Cloud account to use the Cloud Life Sciences API.
+1.  How to configure your Google Cloud account to use the Cloud Life Sciences API.
 
-2. How to create a Google Life Sciences compute environment in Tower.
+1.  How to create a Google Life Sciences compute environment in Tower.
 
 ## Configure Google Cloud
 
@@ -49,15 +49,15 @@ Alternatively, select your project in the navigation bar and enable each API man
 
 ### Create a service account key
 
-1. In the navigation menu, select **IAM & Admin**, then **Service Accounts**.
+1.  In the navigation menu, select **IAM & Admin**, then **Service Accounts**.
 
-2. Select the email address of the **Compute Engine default service account**.
+1.  Select the email address of the **Compute Engine default service account**.
 
-3. Select **Keys**, then **Add key**, then **Create new key**.
+1.  Select **Keys**, then **Add key**, then **Create new key**.
 
-4. Select **JSON** as the key type.
+1.  Select **JSON** as the key type.
 
-5. Select **Create**.
+1.  Select **Create**.
 
 A JSON file will be downloaded to your computer. This file contains the credential needed to configure the compute environment in Tower.
 
@@ -65,33 +65,33 @@ You can manage your key from the **Service Accounts** page.
 
 ### Create a Cloud Storage bucket
 
-1. In the navigation menu (**≡**), select **Cloud Storage**, then **Create bucket**.
+1.  In the navigation menu (**≡**), select **Cloud Storage**, then **Create bucket**.
 
-2. Enter a name for your bucket. You will reference this name when creating the compute environment in Tower.
+1.  Enter a name for your bucket. You will reference this name when creating the compute environment in Tower.
 
 :::caution
 Do not use underscores (`_`) in your bucket name. Use hyphens (`-`) instead.
 :::
 
-3. Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Tower.
+1.  Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Tower.
 
-4. Select **Standard** for the default storage class.
+1.  Select **Standard** for the default storage class.
 
-5. Select **Uniform** for the **Access control**.
+1.  Select **Uniform** for the **Access control**.
 
 :::note
 The Cloud Life Sciences API is available in a limited number of [locations](https://cloud.google.com/life-sciences/docs/concepts/locations). These locations are only used to store metadata about the pipeline operations. The storage bucket and compute resources can be in any region.
 :::
 
-6. Select **Create**.
+1.  Select **Create**.
 
-7. Once the bucket is created, you will be redirected to the **Bucket details** page.
+1.  Once the bucket is created, you will be redirected to the **Bucket details** page.
 
-8. Select **Permissions**, then **+ Add**.
+1.  Select **Permissions**, then **+ Add**.
 
-9. Copy the email address of the Compute Engine default service account into **New principals**.
+1.  Copy the email address of the Compute Engine default service account into **New principals**.
 
-10. Select the following roles:
+1.  Select the following roles:
 
 - Storage Admin
 - Storage Legacy Bucket Owner
@@ -106,39 +106,39 @@ The following guide to configure Tower assumes you have (1) a service account ke
 
 To create a new compute environment for Google Cloud in Tower:
 
-1. In a workspace, select **Compute Environments** and then **New Environment**.
+1.  In a workspace, select **Compute Environments** and then **New Environment**.
 
-2. Enter a descriptive name for this environment, e.g., "Google Life Sciences (europe-west2)".
+1.  Enter a descriptive name for this environment, e.g., "Google Life Sciences (europe-west2)".
 
-3. Select **Google Life Sciences** as the target platform.
+1.  Select **Google Life Sciences** as the target platform.
 
-4. From the **Credentials** drop-down, select existing Google Cloud credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing Google Cloud credentials, or add new credentials by selecting the **+** button. If you select to use existing credentials, skip to step 7.
 
-5. Enter a name for the credentials, e.g. "Google Cloud Credentials".
+1.  Enter a name for the credentials, e.g. "Google Cloud Credentials".
 
-6. Enter the **Service account key** [created previously](#create-a-service-account-key).
+1.  Enter the **Service account key** [created previously](#create-a-service-account-key).
 
 :::tip
 You can create multiple credentials in your Tower workspace.
 :::
 
-7. Select the [**Region** and **Zones**](https://cloud.google.com/compute/docs/regions-zones#available) where you wish to execute pipelines. Leave the **Location** empty for the Cloud Life Sciences API to use the closest available location.
+1.  Select the [**Region** and **Zones**](https://cloud.google.com/compute/docs/regions-zones#available) where you wish to execute pipelines. Leave the **Location** empty for the Cloud Life Sciences API to use the closest available location.
 
-8. In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket should be accessible in the region selected in the previous step.
+1.  In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket should be accessible in the region selected in the previous step.
 
-9. You can enable **Preemptible** to use preemptible instances, which have significantly reduced cost compared to on-demand instances.
+1.  You can enable **Preemptible** to use preemptible instances, which have significantly reduced cost compared to on-demand instances.
 
-10. You can use a **Filestore file system** to automatically mount a Google Filestore volume in your pipelines.
+1.  You can use a **Filestore file system** to automatically mount a Google Filestore volume in your pipelines.
 
-11. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-12. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-13. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-14. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-15. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/hpc.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/hpc.mdx
@@ -25,33 +25,33 @@ To launch pipelines into an **HPC** cluster from Tower, the following requiremen
 
 To create a new **HPC** compute environment in Tower:
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment.
+1.  Enter a descriptive name for this environment.
 
-3. Select your HPC environment from the **Platform** dropdown menu.
+1.  Select your HPC environment from the **Platform** dropdown menu.
 
-4. Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5. Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6. Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7. Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8. Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
 
-9. Enter the **Head queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will submit tasks.
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/k8s.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/k8s.mdx
@@ -15,13 +15,13 @@ The following instructions create a Tower compute environment for a **generic Ku
 
 To prepare your Kubernetes cluster for the deployment of Nextflow pipelines using Tower, this guide assumes that you have already created the cluster and that you have administrative privileges.
 
-1. Verify the connection to your Kubernetes cluster:
+1.  Verify the connection to your Kubernetes cluster:
 
    ```bash
    kubectl cluster-info
    ```
 
-2. Create the Tower launcher:
+1.  Create the Tower launcher:
 
    ```bash
    kubectl apply -f https://help.tower.nf/latest/_templates/k8s/tower-launcher.yml
@@ -29,7 +29,7 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
    This command creates a service account called `tower-launcher-sa` and the associated role bindings, all contained in a namespace called `tower-nf`. Tower uses the service account to launch Nextflow pipelines. Use this service account name when setting up the compute environment for this Kubernetes cluster in Tower.
 
-3. Create persistent storage. Tower requires a `ReadWriteMany` persistent volume claim (PVC) mounted to all nodes where workflow pods will be dispatched.
+1.  Create persistent storage. Tower requires a `ReadWriteMany` persistent volume claim (PVC) mounted to all nodes where workflow pods will be dispatched.
 
    You can use any storage solution that supports the `ReadWriteMany` [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes). The setup of this storage is beyond the scope of these instructions — the right solution for you will depend on what is available for your infrastructure or cloud vendor (NFS, GlusterFS, CephFS, Amazon FSx). Ask your cluster administrator for more information.
 
@@ -45,17 +45,17 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
 ## Compute environment
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "K8s cluster".
+1.  Enter a descriptive name for this environment, e.g., "K8s cluster".
 
-3. Select **Kubernetes** as the target platform.
+1.  Select **Kubernetes** as the target platform.
 
-4. From the **Credentials** drop-down, select existing Kubernetes credentials, or select **+** to add new credentials. If you have existing credentials, skip to step 7.
+1.  From the **Credentials** drop-down, select existing Kubernetes credentials, or select **+** to add new credentials. If you have existing credentials, skip to step 7.
 
-5. Enter a name, e.g., "K8s Credentials".
+1.  Enter a name, e.g., "K8s Credentials".
 
-6. Enter the **Service account token**.
+1.  Enter the **Service account token**.
 
    Obtain the token with the following command:
 
@@ -66,7 +66,7 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
    Replace `<SERVICE-ACCOUNT-NAME>` with the name of the service account created in the [cluster preparation](#cluster-preparation) instructions (default: `tower-launcher-sa`).
 
-7. Enter the **Control plane URL**.
+1.  Enter the **Control plane URL**.
 
    Obtain the control plane URL with the following command:
 
@@ -76,25 +76,25 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
    It can also be found in your `~/.kube/config` file under the `server` field corresponding to your cluster.
 
-8. Specify the **SSL certificate** to authenticate your connection.
+1.  Specify the **SSL certificate** to authenticate your connection.
 
    Find the certificate data in your `~/.kube/config` file. It is the `certificate-authority-data` field corresponding to your cluster.
 
-9. Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-nf` by default.
+1.  Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-nf` by default.
 
-10. Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
+1.  Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is `tower-launcher-sa` by default.
 
-11. Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called `tower-scratch` in each of the provided examples.
+1.  Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called `tower-scratch` in each of the provided examples.
 
-12. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-13. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-14. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-15. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-16. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/lsf.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/lsf.mdx
@@ -21,37 +21,37 @@ To launch pipelines into an **LSF** cluster from Tower, the following requiremen
 
 To create a new compute environment for **LSF** in Tower:
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "LSF".
+1.  Enter a descriptive name for this environment, e.g., "LSF".
 
-3. Select **IBM LSF** as the target platform.
+1.  Select **IBM LSF** as the target platform.
 
-4. Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5. Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6. Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7. Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8. Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
 
-9. Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
 
 :::tip
 The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [documentation](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
 :::
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/moab.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/moab.mdx
@@ -21,37 +21,37 @@ To launch pipelines into a **Moab** cluster from Tower, the following requiremen
 
 To create a new compute environment for **Moab** in Tower:
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "Moab cluster".
+1.  Enter a descriptive name for this environment, e.g., "Moab cluster".
 
-3. Select **Moab Workload Manager** as the target platform.
+1.  Select **Moab Workload Manager** as the target platform.
 
-4. Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5. Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6. Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7. Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8. If using SSH credentials, enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  If using SSH credentials, enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
 
-9. Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
 
 :::tip
 The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [documentation](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
 :::
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/overview.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/overview.mdx
@@ -30,9 +30,9 @@ Each compute environment must be configured to enable Tower to submit tasks. See
 
 If you have more than one compute environment, you can select which one will be used by default when launching a pipeline.
 
-1. In a workspace, select **Compute Environments**.
+1.  In a workspace, select **Compute Environments**.
 
-2. Select **Make primary** for a particular compute environment to make it your default.
+1.  Select **Make primary** for a particular compute environment to make it your default.
 
 ### GPU usage
 

--- a/platform_versioned_docs/version-23.2.0/compute-envs/slurm.mdx
+++ b/platform_versioned_docs/version-23.2.0/compute-envs/slurm.mdx
@@ -21,37 +21,37 @@ To launch pipelines into a **Slurm** cluster from Tower, the following requireme
 
 To create a new compute environment for **Slurm** in Tower:
 
-1. In a workspace, select **Compute environments** and then **New environment**.
+1.  In a workspace, select **Compute environments** and then **New environment**.
 
-2. Enter a descriptive name for this environment, e.g., "Slurm cluster".
+1.  Enter a descriptive name for this environment, e.g., "Slurm cluster".
 
-3. Select **Slurm Workload Manager** as the target platform.
+1.  Select **Slurm Workload Manager** as the target platform.
 
-4. Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 
-5. Enter a name for the credentials.
+1.  Enter a name for the credentials.
 
-6. Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-7. Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 
-8. Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
 
-9. Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Head queue name**. This is the cluster queue to which the Nextflow job will be submitted.
 
-10. Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
+1.  Enter the **Compute queue name**. This is the cluster queue to which the Nextflow job will submit tasks.
 
 :::tip
 The compute queue can be overridden by the Nextflow pipeline configuration. See the Nextflow [documentation](https://www.nextflow.io/docs/latest/process.html#queue) for more details.
 :::
 
-11. Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional pre- or post-run Bash scripts that execute before or after the Nextflow pipeline execution in your environment.
 
-12. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 
-13. Configure any advanced options described below, as needed.
+1.  Configure any advanced options described below, as needed.
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 Jump to the documentation for [launching pipelines](../launch/launchpad.mdx).
 

--- a/platform_versioned_docs/version-23.2.0/credentials/aws_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.2.0/credentials/aws_registry_credentials.mdx
@@ -19,13 +19,13 @@ Wave requires programmatic access to your private registry via [long-term access
 
 An IAM administrator can create and manage access keys from the AWS management console:
 
-1. Open the [IAM console](https://console.aws.amazon.com/iam/).
-2. Select **Users** from the navigation pane.
-3. Select the name of the user whose keys you want to manage, then select the **Security credentials** tab. We recommend creating an IAM user specifically for Wave authentication instead of using existing credentials with broader permissions.
-4. In the **Access keys** section, select **Create access key**. Each IAM user can have only two access keys at a time, so if the Create option is deactivated, delete an existing access key first.
-5. On the **Access key best practices & alternatives** page, select **Other** and then **Next**.
-6. On the **Retrieve access key** page, you can either **Show** the user's secret access key details, or store them by selecting **Download .csv file**.
-7. The newly created access key pair is active by default and can be stored as a container registry credential in Tower.
+1.  Open the [IAM console](https://console.aws.amazon.com/iam/).
+1.  Select **Users** from the navigation pane.
+1.  Select the name of the user whose keys you want to manage, then select the **Security credentials** tab. We recommend creating an IAM user specifically for Wave authentication instead of using existing credentials with broader permissions.
+1.  In the **Access keys** section, select **Create access key**. Each IAM user can have only two access keys at a time, so if the Create option is deactivated, delete an existing access key first.
+1.  On the **Access key best practices & alternatives** page, select **Other** and then **Next**.
+1.  On the **Retrieve access key** page, you can either **Show** the user's secret access key details, or store them by selecting **Download .csv file**.
+1.  The newly created access key pair is active by default and can be stored as a container registry credential in Tower.
 
 :::note
 Your credential must be stored in Tower as a **container registry** credential, even if the same access keys already exist in Tower as a workspace credential.

--- a/platform_versioned_docs/version-23.2.0/credentials/azure_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.2.0/credentials/azure_registry_credentials.mdx
@@ -19,18 +19,18 @@ Azure container registry makes use of Azure RBAC (Role-Based Access Control) to 
 
 You must use Azure credentials with long-term registry read (**content/read**) access to authenticate Tower to your registry. We recommend a [token with repository-scoped permissions](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions) that is used only by Tower.
 
-1. In the Azure portal, navigate to your container registry.
-2. Under **Repository permissions**, select **Tokens -> +Add**.
-3. Enter a token name.
-4. Under **Scope map**, select **Create new**.
-5. In the **Create scope map** section, enter a name and description for the new scope map.
-6. Select your **Repository** from the drop-down menu.
-7. Select **content/read** from the **Permissions** drop-down menu, then select **Add** to create the scope map.
-8. In the **Create token** section, ensure the **Status** is **Enabled** (default), then select **Create**.
-9. Return to **Repository permissions -> Tokens** for your registry, then select the token you just created.
-10. On the token details page, select **password1** or **password2**.
-11. In the password details section, uncheck the **Set expiration date?** checkbox, then select **Generate**.
-12. Copy and save the password after it is generated. The password will be displayed only once.
+1.  In the Azure portal, navigate to your container registry.
+1.  Under **Repository permissions**, select **Tokens -> +Add**.
+1.  Enter a token name.
+1.  Under **Scope map**, select **Create new**.
+1.  In the **Create scope map** section, enter a name and description for the new scope map.
+1.  Select your **Repository** from the drop-down menu.
+1.  Select **content/read** from the **Permissions** drop-down menu, then select **Add** to create the scope map.
+1.  In the **Create token** section, ensure the **Status** is **Enabled** (default), then select **Create**.
+1.  Return to **Repository permissions -> Tokens** for your registry, then select the token you just created.
+1.  On the token details page, select **password1** or **password2**.
+1.  In the password details section, uncheck the **Set expiration date?** checkbox, then select **Generate**.
+1.  Copy and save the password after it is generated. The password will be displayed only once.
 
 ### Add credentials to Tower
 

--- a/platform_versioned_docs/version-23.2.0/credentials/docker_hub_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.2.0/credentials/docker_hub_registry_credentials.mdx
@@ -19,11 +19,11 @@ You must use Docker Hub credentials with **Read-only** access to authenticate To
 
 To create your access token in Docker Hub:
 
-1. Log in to [Docker Hub](https://hub.docker.com/).
-2. Select your username in the top right corner and select **Account Settings**.
-3. Select **Security -> New Access Token**.
-4. Enter a token description and select **Read-only** from the Access permissions drop-down menu, then select **Generate**.
-5. Copy and save the generated access token (this is only displayed once).
+1.  Log in to [Docker Hub](https://hub.docker.com/).
+1.  Select your username in the top right corner and select **Account Settings**.
+1.  Select **Security -> New Access Token**.
+1.  Enter a token description and select **Read-only** from the Access permissions drop-down menu, then select **Generate**.
+1.  Copy and save the generated access token (this is only displayed once).
 
 ### Add credentials to Tower
 

--- a/platform_versioned_docs/version-23.2.0/credentials/quay_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.2.0/credentials/quay_registry_credentials.mdx
@@ -17,12 +17,12 @@ Container registry credentials are only leveraged by the Wave containers service
 
 For Quay repositories, we recommend using [robot accounts](https://docs.quay.io/glossary/robot-accounts.html) with **Read** access permissions for authentication:
 
-1. Sign in to [quay.io](https://quay.io/).
-2. From the user or organization view, select the **Robot Accounts** tab.
-3. Select **Create Robot Account**.
-4. Enter a robot account name. The username for robot accounts have the format `namespace+accountname`, where `namespace` is the user or organization name and `accountname` is your chosen robot account name.
-5. Grant the robot account repository **Read** permissions from **Settings -> User and Robot Permissions** in the repository view.
-6. Select the robot account in your admin panel to retrieve the token value.
+1.  Sign in to [quay.io](https://quay.io/).
+1.  From the user or organization view, select the **Robot Accounts** tab.
+1.  Select **Create Robot Account**.
+1.  Enter a robot account name. The username for robot accounts have the format `namespace+accountname`, where `namespace` is the user or organization name and `accountname` is your chosen robot account name.
+1.  Grant the robot account repository **Read** permissions from **Settings -> User and Robot Permissions** in the repository view.
+1.  Select the robot account in your admin panel to retrieve the token value.
 
 ### Add credentials to Tower
 

--- a/platform_versioned_docs/version-23.2.0/credentials/ssh_credentials.mdx
+++ b/platform_versioned_docs/version-23.2.0/credentials/ssh_credentials.mdx
@@ -20,12 +20,12 @@ To use SSH public key authentication:
 
 To generate an SSH key pair:
 
-1. From the target machine, open a terminal and run `ssh-keygen`.
-2. Follow the prompts to:
+1.  From the target machine, open a terminal and run `ssh-keygen`.
+1.  Follow the prompts to:
    - specify a file path and name (or keep the default)
    - specify a passphrase (recommended)
-3. Navigate to the target folder (default `/home/user/.ssh/id_rsa`) and open the private key file with a plain text editor.
-4. Copy the private key file contents before navigating to Tower.
+1.  Navigate to the target folder (default `/home/user/.ssh/id_rsa`) and open the private key file with a plain text editor.
+1.  Copy the private key file contents before navigating to Tower.
 
 ### Create an SSH credential in Tower
 

--- a/platform_versioned_docs/version-23.2.0/datasets/overview.mdx
+++ b/platform_versioned_docs/version-23.2.0/datasets/overview.mdx
@@ -48,11 +48,11 @@ All Tower users have access to the datasets feature in organization workspaces.
 
 To create a new dataset, follow these steps:
 
-1. Open the **Datasets** tab in your organization workspace.
-2. Select **New dataset**.
-3. Complete the **Name** and **Description** fields using information relevant to your dataset.
-4. Add the dataset file to your workspace with drag-and-drop or the system file explorer dialog.
-5. For dataset files that use the first row for column names, customize the dataset view with the **First row as header** option.
+1.  Open the **Datasets** tab in your organization workspace.
+1.  Select **New dataset**.
+1.  Complete the **Name** and **Description** fields using information relevant to your dataset.
+1.  Add the dataset file to your workspace with drag-and-drop or the system file explorer dialog.
+1.  For dataset files that use the first row for column names, customize the dataset view with the **First row as header** option.
 
 :::note
 The size of the dataset file cannot exceed 10MB.
@@ -62,9 +62,9 @@ The size of the dataset file cannot exceed 10MB.
 
 Tower can accommodate multiple versions of a dataset. To add a new version for an existing dataset, follow these steps:
 
-1. Select **Edit** next to the dataset you wish to update.
-2. In the Edit dialog, select **Add a new version**.
-3. Upload the newer version of the dataset and select **Update**.
+1.  Select **Edit** next to the dataset you wish to update.
+1.  In the Edit dialog, select **Add a new version**.
+1.  Upload the newer version of the dataset and select **Update**.
 
 :::caution
 All subsequent versions of a dataset must be the same format (.csv or .tsv) as the initial version.
@@ -74,9 +74,9 @@ All subsequent versions of a dataset must be the same format (.csv or .tsv) as t
 
 To use a dataset with the saved pipelines in your workspace, follow these steps:
 
-1. Open any pipeline that contains a pipeline-schema from the Launchpad.
-2. Select the input field for the pipeline, removing any default value.
-3. Pick the dataset to use as input to your pipeline.
+1.  Open any pipeline that contains a pipeline-schema from the Launchpad.
+1.  Select the input field for the pipeline, removing any default value.
+1.  Pick the dataset to use as input to your pipeline.
 
 :::note
 The input field drop-down menu will only display datasets that match the file type specified in the `nextflow_schema.json` of the chosen pipeline. If the schema specifies `"mimetype": "text/csv"`, no TSV datasets will be available for use with that pipeline, and vice versa.

--- a/platform_versioned_docs/version-23.2.0/enterprise/_templates/nginx/cert_on_frontend.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/_templates/nginx/cert_on_frontend.mdx
@@ -1,7 +1,7 @@
 title: "cert_on_frontend"
 This example assumes deployment on an Amazon Linux 2 AMI.
 
-1. Install nginx and other required packages:
+1.  Install nginx and other required packages:
 
    ```yml
    sudo amazon-linux-extras install nginx1.12
@@ -12,9 +12,9 @@ This example assumes deployment on an Amazon Linux 2 AMI.
    sudo amazon-linux-extras install epel -y
    ```
 
-2. Generate a [private certificate and key](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs).
+1.  Generate a [private certificate and key](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs).
 
-3. Create a `ssl.conf` file.
+1.  Create a `ssl.conf` file.
 
    ```conf
 
@@ -52,15 +52,15 @@ This example assumes deployment on an Amazon Linux 2 AMI.
 
    ```
 
-4. Make a local copy of the `frontend` container's `/etc/nginx/nginx.conf` file.
+1.  Make a local copy of the `frontend` container's `/etc/nginx/nginx.conf` file.
 
-5. Add the following to the `server` block of your local `nginx.conf` file:
+1.  Add the following to the `server` block of your local `nginx.conf` file:
 
    ```conf
    include /etc/nginx/ssl.conf;
    ```
 
-6. Modify the `frontend` container definition in your `docker-compose.yml` file:
+1.  Modify the `frontend` container definition in your `docker-compose.yml` file:
 
    ```yml
    frontend:

--- a/platform_versioned_docs/version-23.2.0/enterprise/advanced-topics/cloudformation.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/advanced-topics/cloudformation.mdx
@@ -14,11 +14,11 @@ This guide assumes that all [prerequisites](../prerequisites/aws.mdx) have been 
 
 ## Setup ECS cluster
 
-1. Navigate to the ECS console in AWS.
+1.  Navigate to the ECS console in AWS.
 
-2. Select **Create cluster**.
+1.  Select **Create cluster**.
 
-3. Select **Amazon ECS** -> **Clusters** -> **EC2 Linux + Networking**.
+1.  Select **Amazon ECS** -> **Clusters** -> **EC2 Linux + Networking**.
 
 ### ECS Cluster Configuration
 
@@ -65,13 +65,13 @@ Obtain Instance `ServerURL`
 
 </details>
 
-1. Download [aws-ecs-cloudformation.json](../_templates/cloudformation/aws-ecs-cloudformation.json) and [params.json.template](../_templates/cloudformation/params.json.template).
+1.  Download [aws-ecs-cloudformation.json](../_templates/cloudformation/aws-ecs-cloudformation.json) and [params.json.template](../_templates/cloudformation/params.json.template).
 
-2. Rename `params.template.json` to `params.json` and configure for your environment.
+1.  Rename `params.template.json` to `params.json` and configure for your environment.
 
    For more information on configuration, visit the [Configuration](../configuration/overview.mdx) section.
 
-3. Deploy the Tower stack to your ECS cluster:
+1.  Deploy the Tower stack to your ECS cluster:
 
    ```bash
    aws cloudformation create-stack \

--- a/platform_versioned_docs/version-23.2.0/enterprise/advanced-topics/db-docker-to-RDS.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/advanced-topics/db-docker-to-RDS.mdx
@@ -9,23 +9,23 @@ While [Docker Compose](../docker-compose.mdx) is a fast and convenient way to de
 
 ## Points to consider before migration
 
-1. **Target Database**
+1.  **Target Database**
 
    You have options when choosing your new MySQL-compliant database. While the process is mostly the same, some of the commands will be different (example: [MariaDB on RDS](../configuration/database_and_redis.mdx#generate-user-and-schema)).
 
-2. **How much data must be moved?**
+1.  **How much data must be moved?**
 
    The data in your database must be exported from the MySQL container and imported to the new instance. Depending on the amount of data in your database and the amount of remaining EC2 EBS capacity, you may be able to save your data directly onto the instance, or be forced to make use of a service with more capacity (such as S3).
 
-3. **Testing**
+1.  **Testing**
 
    What level of testing is required to determine the data has been properly migrated?
 
-4. **Maintenance window**
+1.  **Maintenance window**
 
    It is much simpler to initiate a migration once all transactions to the database cease than to do so while jobs are still running. Perform the migration at a time when an outage can occur and notify your users in advance.
 
-5. **MySQL container volume retention**
+1.  **MySQL container volume retention**
 
    Seqera highly suggests retaining your original volume until you are 100% satisfied that the migration occurred without error. So long as the volume is kept, you can fall back to the MySQL container and ensure that Kinnate does not lose any of the material generated thus far.
 
@@ -33,9 +33,9 @@ While [Docker Compose](../docker-compose.mdx) is a fast and convenient way to de
 
 Before starting your migration, do the following:
 
-1. Create an RDS MySQL-compliant instance and populate it with a [**tower user** and **tower database**](../configuration/database_and_redis.mdx#generate-user-and-schema).
+1.  Create an RDS MySQL-compliant instance and populate it with a [**tower user** and **tower database**](../configuration/database_and_redis.mdx#generate-user-and-schema).
 
-2. Ensure your EC2 instance and database instance's Security Group(s) have been configured to allow MySQL traffic (default: Port 3306).
+1.  Ensure your EC2 instance and database instance's Security Group(s) have been configured to allow MySQL traffic (default: Port 3306).
 
 ## Steps
 
@@ -47,88 +47,88 @@ These steps assume the following:
 
 :::
 
-1. Connect to to the EC2 instance using **SSH** and navigate to Tower's **docker-compose** folder.
+1.  Connect to to the EC2 instance using **SSH** and navigate to Tower's **docker-compose** folder.
 
-2. Shut down Tower:
+1.  Shut down Tower:
 
    ```bash
    docker-compose down
    ```
 
-3. Mount a new folder into the MySQL container for migration activities:
+1.  Mount a new folder into the MySQL container for migration activities:
 
-   1. Create a new folder to hold migration artefacts.
+   1.  Create a new folder to hold migration artefacts.
 
       ```bash
       mkdir ~/tower_migration
       ```
 
-   2. Backup the database.
+   2.  Backup the database.
 
       ```bash
       sudo tar -zcvf ~/tower_migration/tower_backup.tar.gz ~/.tower/db/mysql
       ```
 
-4. Modify the Tower **docker-compose.yml**:
+1.  Modify the Tower **docker-compose.yml**:
 
-   1. Add new volume entry for the db container.
+   1.  Add new volume entry for the db container.
 
    ```
    $HOME/tower_migration:/tower_migration
    ```
 
-5. Restart Tower to ensure your changes were successful.
+1.  Restart Tower to ensure your changes were successful.
 
    ```bash
    docker-compose down
    ```
 
-6. Stop all the non-MySQL containers.
+1.  Stop all the non-MySQL containers.
 
    ```bash
    docker container stop <CONTAINER ID>
    ```
 
-7. Exec onto the MySQL ontainer.
+1.  Exec onto the MySQL ontainer.
 
    ```bash
    docker exec -it <CONTAINER ID> /bin/bash
    ```
 
-   1. Dump your data to disk.
+   1.  Dump your data to disk.
 
       ```bash
       mysqldump -u tower -p --databases tower --no-tablespaces --set-gtid-purged=OFF > /tower_migration/tower_dumpfile.sql
       ```
 
-   2. Exit the container.
+   2.  Exit the container.
 
-8. Stop the MySQL container.
+1.  Stop the MySQL container.
 
    ```bash
    docker container stop <CONTAINER ID>
    ```
 
-9. Import the dump file into your new RDS instance.
+1.  Import the dump file into your new RDS instance.
 
    ```bash
    mysql --host <DB-HOST> --port 3306 -u tower -p tower < ~/tower_migration/tower_dumpfile.sql
    ```
 
-10. Log on to the RDS instance and ensure that the tower database is populated with tables prefixed by 'tw\_'.
+1.  Log on to the RDS instance and ensure that the tower database is populated with tables prefixed by 'tw\_'.
 
-11. Modify the **tower.env** in the Tower docker folder:
+1.  Modify the **tower.env** in the Tower docker folder:
 
-    1. Comment out the existing TOWER_DB-\* variables.
-    2. Add new entries [relevant to your database choice](../configuration/database_and_redis.mdx#configure-towerenv_1).
-    3. Save and exit.
+    1.  Comment out the existing TOWER_DB-\* variables.
+    2.  Add new entries [relevant to your database choice](../configuration/database_and_redis.mdx#configure-towerenv_1).
+    3.  Save and exit.
 
-12. Restart Tower.
+1.  Restart Tower.
 
     ```bash
     docker-compose up
     ```
 
-13. Confirm that Tower starts and that your data is available when you log in.
+1.  Confirm that Tower starts and that your data is available when you log in.
 
 Congratulations! Your migration is complete and your testing can begin.

--- a/platform_versioned_docs/version-23.2.0/enterprise/advanced-topics/manual-aws-batch-setup.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/advanced-topics/manual-aws-batch-setup.mdx
@@ -18,21 +18,21 @@ Batch Forge _automatically creates_ the AWS Batch queues required for your workf
 
 Complete the following procedures to configure AWS Batch manually:
 
-1. Create a user policy.
-2. Create the instance role policy.
-3. Create the AWS Batch service role.
-4. Create an EC2 Instance role.
-5. Create an EC2 SpotFleet role.
-6. Create a launch template.
-7. Create the AWS Batch compute environments.
-8. Create the AWS Batch queue.
+1.  Create a user policy.
+1.  Create the instance role policy.
+1.  Create the AWS Batch service role.
+1.  Create an EC2 Instance role.
+1.  Create an EC2 SpotFleet role.
+1.  Create a launch template.
+1.  Create the AWS Batch compute environments.
+1.  Create the AWS Batch queue.
 
 ### Create a user policy
 
 Create the policy for the user launching Nextflow jobs:
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create policy** from the Policies page.
-1. Create a new policy with the following content:
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create policy** from the Policies page.
+1.  Create a new policy with the following content:
 
    ```json
    {
@@ -58,14 +58,14 @@ Create the policy for the user launching Nextflow jobs:
    }
    ```
 
-1. Save with it the name `seqera-user`.
+1.  Save with it the name `seqera-user`.
 
 ### Create the instance role policy
 
 Create the policy with a role that allows Seqera to submit Batch jobs on your EC2 instances:
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create policy** from the Policies page.
-1. Create a new policy with the following content:
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create policy** from the Policies page.
+1.  Create a new policy with the following content:
 
    ```json
    {
@@ -105,39 +105,39 @@ Create the policy with a role that allows Seqera to submit Batch jobs on your EC
    }
    ```
 
-1. Save it with the name `seqera-batchjob`.
+1.  Save it with the name `seqera-batchjob`.
 
 ### Create the Batch Service role
 
 Create a service role used by AWS Batch to launch EC2 instances on your behalf:
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
-1. Select **AWS service** as the trusted entity type, and **Batch** as the service.
-1. On the next page, the `AWSBatchServiceRole` is already attached. No further permissions are needed for this role.
-1. Enter `seqera-servicerole` as the role name and add an optional description and tags if needed, then select **Create**.
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
+1.  Select **AWS service** as the trusted entity type, and **Batch** as the service.
+1.  On the next page, the `AWSBatchServiceRole` is already attached. No further permissions are needed for this role.
+1.  Enter `seqera-servicerole` as the role name and add an optional description and tags if needed, then select **Create**.
 
 ### Create an EC2 instance role
 
 Create a role that controls which AWS resources the EC2 instances launched by AWS Batch can access:
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
-1. Select AWS service as the trusted entity type, EC2 as the service, and _EC2 - Allows EC2 instances to call AWS services on your behalf_ as the use case.
-1. Select **Next: Permissions**. Search for the following policies to attach to the role:
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
+1.  Select AWS service as the trusted entity type, EC2 as the service, and _EC2 - Allows EC2 instances to call AWS services on your behalf_ as the use case.
+1.  Select **Next: Permissions**. Search for the following policies to attach to the role:
 
-	- `AmazonEC2ContainerServiceforEC2Role`
-	- `AmazonS3FullAccess` (you may want to use a custom policy to allow access only on specific S3 buckets)
-	- `seqera-batchjob` (the instance role policy created above)
+  - `AmazonEC2ContainerServiceforEC2Role`
+  - `AmazonS3FullAccess` (you may want to use a custom policy to allow access only on specific S3 buckets)
+  - `seqera-batchjob` (the instance role policy created above)
 
-1. Enter `seqera-instancerole` as the role name and add an optional description and tags if needed, then select **Create**.
+1.  Enter `seqera-instancerole` as the role name and add an optional description and tags if needed, then select **Create**.
 
 ### Create an EC2 SpotFleet role
 
 The EC2 SpotFleet role allows you to use Spot instances when you run jobs in AWS Batch. Create a role for the creation and launch of Spot fleets — Spot instances with similar compute capabilities (i.e., vCPUs and RAM):
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
-1. Select AWS service as the trusted entity type, EC2 as the service, and _EC2 - Spot Fleet Tagging_ as the use case.
-1. On the next page, the `AmazonEC2SpotFleetTaggingRole` is already attached. No further permissions are needed for this role.
-1. Enter `seqera-fleetrole` as the role name and add an optional description and tags if needed, then select **Create**.
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
+1.  Select AWS service as the trusted entity type, EC2 as the service, and _EC2 - Spot Fleet Tagging_ as the use case.
+1.  On the next page, the `AmazonEC2SpotFleetTaggingRole` is already attached. No further permissions are needed for this role.
+1.  Enter `seqera-fleetrole` as the role name and add an optional description and tags if needed, then select **Create**.
 
 ### Create a launch template
 
@@ -146,8 +146,8 @@ Create a launch template to configure the EC2 instances deployed by Batch jobs:
 <Tabs>
 <TabItem value="AWS Batch with Fusion v2" label="AWS Batch with Fusion v2" default>
 
-  1. In the [EC2 Console](https://console.aws.amazon.com/ec2/v2/home), select **Create launch template** from the Launch templates page.
-  1. Scroll down to **Advanced details** and paste the following in the **User data** field:
+  1.  In the [EC2 Console](https://console.aws.amazon.com/ec2/v2/home), select **Create launch template** from the Launch templates page.
+  1.  Scroll down to **Advanced details** and paste the following in the **User data** field:
 
     ```bash
     MIME-Version: 1.0
@@ -212,14 +212,14 @@ Create a launch template to configure the EC2 instances deployed by Batch jobs:
     --//--
     ```
 
-  1. In the line `| sed 's/$FORGE_ID/<your prefix>/g' \`, replace `<your prefix>` with your desired prefix to be added to the AWS resources created by your compute environment.
-  1. Save the template with the name `seqera-launchtemplate`.
+  1.  In the line `| sed 's/$FORGE_ID/<your prefix>/g' \`, replace `<your prefix>` with your desired prefix to be added to the AWS resources created by your compute environment.
+  1.  Save the template with the name `seqera-launchtemplate`.
 
 </TabItem>
 <TabItem value="AWS Batch without Fusion v2" label="AWS Batch without Fusion v2" default>
 
-  1. In the [EC2 Console](https://console.aws.amazon.com/ec2/v2/home), select **Create launch template** from the Launch templates page.
-  1. Scroll down to **Advanced details** and paste the following in the **User data** field:
+  1.  In the [EC2 Console](https://console.aws.amazon.com/ec2/v2/home), select **Create launch template** from the Launch templates page.
+  1.  Scroll down to **Advanced details** and paste the following in the **User data** field:
 
     ```bash
     MIME-Version: 1.0
@@ -268,8 +268,8 @@ Create a launch template to configure the EC2 instances deployed by Batch jobs:
     --//--
     ```
 
-  1. In the line `| sed 's/$FORGE_ID/<your prefix>/g' \`, replace `<your prefix>` with your desired prefix to be added to the AWS resources created by your compute environment.
-  1. Save the template with the name `seqera-launchtemplate`.
+  1.  In the line `| sed 's/$FORGE_ID/<your prefix>/g' \`, replace `<your prefix>` with your desired prefix to be added to the AWS resources created by your compute environment.
+  1.  Save the template with the name `seqera-launchtemplate`.
 
 </TabItem>
 </Tabs>
@@ -294,37 +294,37 @@ Create a compute environment for each queue in the AWS Batch console:
 
 The head queue requires an on-demand compute environment. Do not select **Use Spot instances** during compute environment creation.
 
-1. In the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home), select **Create** on the Compute environments page.
-1. Select **Amazon EC2** as the compute environment configuration.
+1.  In the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home), select **Create** on the Compute environments page.
+1.  Select **Amazon EC2** as the compute environment configuration.
 
     :::note
     Seqera AWS Batch compute environments created with [Batch Forge](../../compute-envs/aws-batch.md#tower-forge-compute-environment) support using Fargate for the head job, but manual compute environments must use EC2.
     :::
 
-1. Enter a name of your choice, and apply the `seqera-servicerole` and `seqera-instancerole`.
-1. Enter vCPU limits and instance types, if needed.
+1.  Enter a name of your choice, and apply the `seqera-servicerole` and `seqera-instancerole`.
+1.  Enter vCPU limits and instance types, if needed.
 
     :::note
     To use the same queue for both head and compute tasks, you must assign sufficient resources to your compute environment.
     :::
 
-1. Expand **Additional configuration** and select the `seqera-launchtemplate` from the Launch template dropdown.
-1. Configure VPCs, subnets, and security groups on the next page as needed.
-1. Review your configuration and select **Create compute environment**.  
+1.  Expand **Additional configuration** and select the `seqera-launchtemplate` from the Launch template dropdown.
+1.  Configure VPCs, subnets, and security groups on the next page as needed.
+1.  Review your configuration and select **Create compute environment**.  
 
 </TabItem>
 <TabItem value="Compute queue with Spot instances" label="Compute queue with Spot instances" default>
 
 Create this compute environment to use Spot instances for your workflow compute tasks. This compute environment cannot be assigned to the Nextflow head job queue.
 
-1. In the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home), select **Create** on the Compute environments page.
-1. Select **Amazon EC2** as the compute environment configuration.
-1. Enter a name of your choice, and apply the `seqera-servicerole` and `seqera-instancerole`.
-1. Select **Enable using Spot instances** to use Spot instances and save computing costs.  
-1. Select the `seqera-fleetrole` and enter vCPU limits and instance types, if needed.
-1. Expand **Additional configuration** and select the `seqera-launchtemplate` from the Launch template dropdown.
-1. Configure VPCs, subnets, and security groups on the next page as needed.
-1. Review your configuration and select **Create compute environment**.  
+1.  In the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home), select **Create** on the Compute environments page.
+1.  Select **Amazon EC2** as the compute environment configuration.
+1.  Enter a name of your choice, and apply the `seqera-servicerole` and `seqera-instancerole`.
+1.  Select **Enable using Spot instances** to use Spot instances and save computing costs.  
+1.  Select the `seqera-fleetrole` and enter vCPU limits and instance types, if needed.
+1.  Expand **Additional configuration** and select the `seqera-launchtemplate` from the Launch template dropdown.
+1.  Configure VPCs, subnets, and security groups on the next page as needed.
+1.  Review your configuration and select **Create compute environment**.  
 
 </TabItem>
 </Tabs>
@@ -340,18 +340,18 @@ You only need to create one queue if you intend to use on-demand instances for y
 <Tabs>
 <TabItem value="Head queue" label="Head queue" default>
 
-1. Go to the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home).
-2. Create a new queue.
-3. Associate the queue with the head queue compute environment created in the previous section.
-4. Save it with a name of your choice.
+1.  Go to the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home).
+1.  Create a new queue.
+1.  Associate the queue with the head queue compute environment created in the previous section.
+1.  Save it with a name of your choice.
 
 </TabItem>
 <TabItem value="Compute queue" label="Compute queue" default>
 
-1. Go to the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home).
-2. Create a new queue.
-3. Associate the queue with the compute queue environment created in the previous section.
-4. Save it with a name of your choice.
+1.  Go to the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home).
+1.  Create a new queue.
+1.  Associate the queue with the compute queue environment created in the previous section.
+1.  Save it with a name of your choice.
 
 </TabItem>
 </Tabs>

--- a/platform_versioned_docs/version-23.2.0/enterprise/advanced-topics/use-iam-role.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/advanced-topics/use-iam-role.mdx
@@ -33,8 +33,8 @@ Create a custom IAM Policy ([Tower-Role-Policy.json](../_templates/Tower-Role-Po
 
 </details>
 
-1. Modify `BucketPolicy01` and `BucketPolicy02` with the name(s) of the your S3 Buckets.
-2. Revise (if necessary) the scope of access to a specific prefix in the S3 bucket(s).
+1.  Modify `BucketPolicy01` and `BucketPolicy02` with the name(s) of the your S3 Buckets.
+1.  Revise (if necessary) the scope of access to a specific prefix in the S3 bucket(s).
 
 ## Modify the Tower IAM Role Trust Policy (optional)
 
@@ -49,39 +49,39 @@ Review and modify the Role Trust Policy ([Tower-Role-Trust-Policy.json](../_temp
 
 </details>
 
-1. Replace `YOUR-AWS-ACCOUNT` with your own AWS Account Id.
+1.  Replace `YOUR-AWS-ACCOUNT` with your own AWS Account Id.
 
-2. Specify the Users and/or Roles able to assume the Tower IAM Role.
+1.  Specify the Users and/or Roles able to assume the Tower IAM Role.
 
 ## Create the IAM artefacts
 
 [Create the IAM Artefacts](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html) in your AWS Account.
 
-1. Navigate to the folder containing your configured IAM documents:
+1.  Navigate to the folder containing your configured IAM documents:
 
    ```bash
    cd <FOLDER_WITH_YOUR_CONFIGURED_IAM_DOCUMENTS>
    ```
 
-2. Create the **Role**:
+1.  Create the **Role**:
 
    ```bash
    aws iam create-role --role-name Tower-Role --assume-role-policy-document file://Tower-Role-Trust-Policy.json
    ```
 
-3. Create an **inline policy** for the Role:
+1.  Create an **inline policy** for the Role:
 
    ```bash
    aws iam put-role-policy --role-name Tower-Role --policy-name Tower-Role-Policy --policy-document file://Tower-Role-Policy.json
    ```
 
-4. Create an **instance profile**:
+1.  Create an **instance profile**:
 
    ```bash
    aws iam create-instance-profile --instance-profile-name Tower-Instance
    ```
 
-5. **Bind** the Role to the instance profile:
+1.  **Bind** the Role to the instance profile:
 
    ```bash
    aws iam add-role-to-instance-profile --instance-profile-name Tower-Instance --role-name Tower-Role
@@ -91,21 +91,21 @@ Review and modify the Role Trust Policy ([Tower-Role-Trust-Policy.json](../_temp
 
 With the IAM artefacts complete, update your Tower application configuration:
 
-1. Add the following entry to your `tower.env`
+1.  Add the following entry to your `tower.env`
 
    ```env
    TOWER_ALLOW_INSTANCE_CREDENTIALS=true
    ```
 
-2. Restart the Tower application.
+1.  Restart the Tower application.
 
-3. Verify that the change took effect by querying the Tower instance `service-info` endpoint:
+1.  Verify that the change took effect by querying the Tower instance `service-info` endpoint:
 
    ```bash
    curl -X GET "https://YOUR-TOWER-DOMAIN/api/service-info" -H "Accept: application/json" | jq ".serviceInfo.allowInstanceCredentials"
    ```
 
-4. Log in to Tower and create a new AWS credential. You are now prompted for an AWS `arn` instead of access keys.
+1.  Log in to Tower and create a new AWS credential. You are now prompted for an AWS `arn` instead of access keys.
 
    **Before Change**:
    ![](./_images/tower_credentials_aws_keys.png)

--- a/platform_versioned_docs/version-23.2.0/enterprise/configuration/authentication.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/configuration/authentication.mdx
@@ -112,29 +112,29 @@ Complete the setup on Tower side adding the following environment variables to y
 
 To make use of [Azure AD for the OIDC](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc) as identity provider for Tower, configure a new client in your Azure AD service:
 
-1. Log in to the [Azure portal](https://portal.azure.com/).
-2. Navigate to the **Azure Active Directory** service.
-3. Select **Manage Tenants**.
-4. Create a new **Tenant** (e.g. `NextflowTowerOrg`).
-5. Navigate to the newly-created Tenant.
-6. Go to **App Registrations**.
-7. Click **New Registration**.
-   1. Enter a name for the application.
-   2. Specify the scope of user verification (e.g. single tenant, multi-tenant, personal MSFT accounts, etc).
+1.  Log in to the [Azure portal](https://portal.azure.com/).
+1.  Navigate to the **Azure Active Directory** service.
+1.  Select **Manage Tenants**.
+1.  Create a new **Tenant** (e.g. `NextflowTowerOrg`).
+1.  Navigate to the newly-created Tenant.
+1.  Go to **App Registrations**.
+1.  Click **New Registration**.
+   1.  Enter a name for the application.
+   2.  Specify the scope of user verification (e.g. single tenant, multi-tenant, personal MSFT accounts, etc).
 
 :::note
 The Azure AD app must have user consent settings configured to "Allow user consent for apps" to ensure that admin approval is not required for each application login. See [User consent settings](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/configure-user-consent?pivots=portal#configure-user-consent-settings).
 :::
 
-8. Specify the **Redirect** (callback) URI (NOTE: Microsoft requires that this URI uses `HTTPS`)
+1.  Specify the **Redirect** (callback) URI (NOTE: Microsoft requires that this URI uses `HTTPS`)
 
-9. Open the newly-created app:
-   1. Note the Application (client) ID under the Essentials table
-   2. Generate Client credentials under the Essentials table
-   3. Click Endpoints and note the OpenID Connect metadata document URI
-10. Add users to your tenant as required.
+1.  Open the newly-created app:
+   1.  Note the Application (client) ID under the Essentials table
+   2.  Generate Client credentials under the Essentials table
+   3.  Click Endpoints and note the OpenID Connect metadata document URI
+1.  Add users to your tenant as required.
 
-11. Complete the setup on Tower side adding the following environment variables to your configuration:
+1.  Complete the setup on Tower side adding the following environment variables to your configuration:
 
     ```bash
     TOWER_OIDC_CLIENT=<YOUR_APPLICATION_ID>
@@ -142,7 +142,7 @@ The Azure AD app must have user consent settings configured to "Allow user conse
     TOWER_OIDC_ISSUER=<YOUR_OIDC_METADATA_URL_UP_TO_"v2.0">   (e.g. https://login.microsoftonline.com/000000-0000-0000-00-0000000000000/v2.0)
     ```
 
-12. Add `auth-oidc` to the end of the `MICRONAUT_ENVIRONMENTS` value for both the `cron` and `backend` services.
+1.  Add `auth-oidc` to the end of the `MICRONAUT_ENVIRONMENTS` value for both the `cron` and `backend` services.
 
 ## Configure user access allow list
 

--- a/platform_versioned_docs/version-23.2.0/enterprise/docker-compose.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/docker-compose.mdx
@@ -42,17 +42,17 @@ In order for your DB or Redis volume to persist after a `docker restart`, uncomm
 
 </details>
 
-1. Download and configure [tower.env](_templates/docker/tower.env).
+1.  Download and configure [tower.env](_templates/docker/tower.env).
 
-2. Download and configure [tower.yml](_templates/docker/tower.yml), update values for allowed emails.
+1.  Download and configure [tower.yml](_templates/docker/tower.yml), update values for allowed emails.
 
-3. Download and configure [docker-compose.yml](_templates/docker/docker-compose.yml).
+1.  Download and configure [docker-compose.yml](_templates/docker/docker-compose.yml).
 
    The `db` and `mail` containers should only be used for local testing; you may remove them if you have configured these services elsewhere.
 
    Make sure to customize the `TOWER_ENABLE_PLATFORMS` variable to include the execution platform(s) you will use.
 
-4. Deploy Tower and wait for it to initialize (takes a few minutes):
+1.  Deploy Tower and wait for it to initialize (takes a few minutes):
 
    ```bash
    docker-compose up
@@ -66,21 +66,21 @@ For more information on configuration, see [Configuration options](./configurati
 
 To make sure that Tower is properly configured, follow these steps:
 
-1. Login to Tower.
+1.  Login to Tower.
 
-2. Create an **organization**.
+1.  Create an **organization**.
 
-3. Create a **workspace** within that organization.
+1.  Create a **workspace** within that organization.
 
-4. Create a new **Compute Environment**. Refer to [Compute Environments](https://help.tower.nf/compute-envs/overview/) for detailed instructions.
+1.  Create a new **Compute Environment**. Refer to [Compute Environments](https://help.tower.nf/compute-envs/overview/) for detailed instructions.
 
-5. Select **Quick Launch** from the **Launchpad** tab in your workspace.
+1.  Select **Quick Launch** from the **Launchpad** tab in your workspace.
 
-6. Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
+1.  Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
 
-7. In the **Config profiles** dropdown, select the `test` profile.
+1.  In the **Config profiles** dropdown, select the `test` profile.
 
-8. In the **Pipeline parameters** text area, change the output directory to a sensible location based on your Compute Environment:
+1.  In the **Pipeline parameters** text area, change the output directory to a sensible location based on your Compute Environment:
 
    ```yaml
    # save to S3 bucket
@@ -90,7 +90,7 @@ To make sure that Tower is properly configured, follow these steps:
    outdir: /scratch/results
    ```
 
-9. Select **Launch**.
+1.  Select **Launch**.
 
    You'll be transitioned to the **Runs** tab for the workflow. After a few minutes, you'll see the progress logs in the **Execution log** tab for that workflow.
 

--- a/platform_versioned_docs/version-23.2.0/enterprise/general_troubleshooting.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/general_troubleshooting.mdx
@@ -273,9 +273,9 @@ The secret used to generate the login JWT token that is appended to user sign-in
 
 This error points to an issue with the SSH credentials used to authenticate Tower to your HPC cluster (LSF, Slurm, etc.), such as an invalid SSH key or inappropriate permissions on the user directory. Check the following:
 
-1. Test the SSH key to ensure it is still valid. If not, create new SSH keys and [re-create the compute environment](https://help.tower.nf/latest/compute-envs/lsf/) in Tower using the updated credentials.
+1.  Test the SSH key to ensure it is still valid. If not, create new SSH keys and [re-create the compute environment](https://help.tower.nf/latest/compute-envs/lsf/) in Tower using the updated credentials.
 
-2. Check the backend logs for a stack trace similar to the following:
+1.  Check the backend logs for a stack trace similar to the following:
 
    ```
    [io-executor-thread-2] 10.42.0.1 ERROR i.s.t.c.GlobalErrorController - Oops... Unable to process request - Error ID: 5d7rDpS8pByF8YqfUVPvB4
@@ -298,13 +298,13 @@ This error points to an issue with the SSH credentials used to authenticate Towe
        at net.schmizz.sshj.userauth.keyprovider.PKCS5KeyFile$ASN1Data.<init>(PKCS5KeyFile.java:248)
    ```
 
-3. Enable SSH library log tracing with the following environbment variable in your `tower.env` file for verbose debug logging of the SSH connection:
+1.  Enable SSH library log tracing with the following environbment variable in your `tower.env` file for verbose debug logging of the SSH connection:
 
 ```env
 TOWER_SSH_LOGLEVEL=TRACE
 ```
 
-4. Check the permissions of the `/home` directory of the user tied to the cluster's SSH credentials. `/home/[user]` should be `chmod 755`, whereas `/home/[user]/ssh` requires `chmod 700`.
+1.  Check the permissions of the `/home` directory of the user tied to the cluster's SSH credentials. `/home/[user]` should be `chmod 755`, whereas `/home/[user]/ssh` requires `chmod 700`.
 
 ```bash
 $ pwd ; ls -ld .

--- a/platform_versioned_docs/version-23.2.0/enterprise/index.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/index.mdx
@@ -77,15 +77,15 @@ _Reference architecture diagram of Tower on AWS using Elastic Kubernetes Service
 Nextflow Tower is distributed as a collection of Docker containers available through the Seqera Labs
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. Once you have received your credentials, log in to the registry using these steps:
 
-1. Retrieve the **name** and **secret** values from the JSON file you received from Seqera Labs support.
+1.  Retrieve the **name** and **secret** values from the JSON file you received from Seqera Labs support.
 
-2. Authenticate to the registry (using the `name` and `secret` values copied in step 1):
+1.  Authenticate to the registry (using the `name` and `secret` values copied in step 1):
 
    ```bash
    docker login -u '<NAME>' -p '<SECRET>' cr.seqera.io
    ```
 
-3. Pull the Nextflow Tower container images:
+1.  Pull the Nextflow Tower container images:
 
    ```bash
    docker pull {{ images.tower_be_image }}

--- a/platform_versioned_docs/version-23.2.0/enterprise/kubernetes.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/kubernetes.mdx
@@ -17,13 +17,13 @@ You may also use this guide for deployments to other cloud platforms (e.g. Oracl
 
 Create a namespace to group the Tower resources within your K8s cluster.
 
-1. Create the namespace (e.g. `tower-nf`):
+1.  Create the namespace (e.g. `tower-nf`):
 
    ```bash
    kubectl create namespace tower-nf
    ```
 
-2. Switch to the namespace:
+1.  Switch to the namespace:
 
    ```bash
    kubectl config set-context --current --namespace=tower-nf
@@ -34,9 +34,9 @@ Create a namespace to group the Tower resources within your K8s cluster.
 Nextflow Tower is distributed as a collection of Docker containers available through the Seqera Labs
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. Once you have received your credentials, grant your cluster access to the registry using these steps:
 
-1. Retrieve the `name` and `secret` values from the JSON file you received from Seqera Labs support.
+1.  Retrieve the `name` and `secret` values from the JSON file you received from Seqera Labs support.
 
-2. Create a Kubernetes [Secret](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/), using the `name` and `secret` retrieved in step 1, with this command:
+1.  Create a Kubernetes [Secret](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/), using the `name` and `secret` retrieved in step 1, with this command:
 
    ```bash
    kubectl create secret docker-registry cr.seqera.io \
@@ -47,7 +47,7 @@ container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](htt
 
    Note: The credential `name` contains a dollar `$` character. To prevent the Linux shell from interpreting this value as an environment variable, wrap it in single quotes.
 
-3. The following snippet configures the Tower cron service and the Tower frontend and backend to use the Secret created in step 2 (see [tower-cron.yml](./_templates/k8s/tower-cron.yml) and [tower-svc.yml](./_templates/k8s/tower-svc.yml)):
+1.  The following snippet configures the Tower cron service and the Tower frontend and backend to use the Secret created in step 2 (see [tower-cron.yml](./_templates/k8s/tower-cron.yml) and [tower-svc.yml](./_templates/k8s/tower-svc.yml)):
 
 ```yml
 imagePullSecrets:
@@ -64,9 +64,9 @@ This parameter is already included in the templates linked above — if you use 
   ```
 </details>
 
-1. Download and configure [configmap.yml](_templates/k8s/configmap.yml) as per the [configuration](configuration/overview.mdx) page.
+1.  Download and configure [configmap.yml](_templates/k8s/configmap.yml) as per the [configuration](configuration/overview.mdx) page.
 
-2. Deploy the configmap to your cluster:
+1.  Deploy the configmap to your cluster:
 
    ```bash
    kubectl apply -f configmap.yml
@@ -141,11 +141,11 @@ You may also be able to use a managed Redis service such as [Amazon Elasticache]
 
 </details>
 
-1. Download the manifest:
+1.  Download the manifest:
 
 - [tower-cron.yml](_templates/k8s/tower-cron.yml)
 
-2. Deploy to your cluster:
+1.  Deploy to your cluster:
 
 ```bash
 kubectl apply -f tower-cron.yml
@@ -241,21 +241,21 @@ kubectl get pods
 
 To make sure that Tower is properly configured, follow these steps:
 
-1. Log in to Tower.
+1.  Log in to Tower.
 
-2. Create an **organization**.
+1.  Create an **organization**.
 
-3. Create a **workspace** within that organization.
+1.  Create a **workspace** within that organization.
 
-4. Create a new **Compute Environment**. Refer to [Compute Environments](https://help.tower.nf/compute-envs/overview/) for detailed instructions.
+1.  Create a new **Compute Environment**. Refer to [Compute Environments](https://help.tower.nf/compute-envs/overview/) for detailed instructions.
 
-5. Select **Quick Launch** from the **Launchpad** tab in your workspace.
+1.  Select **Quick Launch** from the **Launchpad** tab in your workspace.
 
-6. Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
+1.  Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
 
-7. In the **Config profiles** dropdown, select the `test` profile.
+1.  In the **Config profiles** dropdown, select the `test` profile.
 
-8. In the **Pipeline parameters** textarea, change the output directory to a sensible location based on your Compute Environment:
+1.  In the **Pipeline parameters** textarea, change the output directory to a sensible location based on your Compute Environment:
 
    ```yaml
    # save to S3 bucket
@@ -265,7 +265,7 @@ To make sure that Tower is properly configured, follow these steps:
    outdir: /scratch/results
    ```
 
-9. Select **Launch**.
+1.  Select **Launch**.
 
    You'll be transitioned to the **Runs** tab for the workflow. After a few minutes, you'll see the progress logs in the **Execution log** tab for that workflow.
 
@@ -284,13 +284,13 @@ To make sure that Tower is properly configured, follow these steps:
 
 The included [dbconsole.yml](_templates/k8s/dbconsole.yml) can be used to deploy a simple web frontend to the Tower database. It is _not_ required but it can be useful for administrative purposes.
 
-1. Deploy the database console:
+1.  Deploy the database console:
 
    ```bash
    kubectl apply -f dbconsole.yml
    ```
 
-2. Port-forward the database console to your local machine:
+1.  Port-forward the database console to your local machine:
 
    ```bash
    kubectl port-forward deployment/dbconsole 8080:8080

--- a/platform_versioned_docs/version-23.2.0/enterprise/prerequisites/aws.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/prerequisites/aws.mdx
@@ -12,13 +12,13 @@ This page describes the infrastructure and other prerequisites for deploying Tow
 Nextflow Tower is distributed as a collection of Docker containers available through the Seqera Labs
 container registry ([cr.seqera.io](https://cr.seqera.io)). Contact [support](https://support.seqera.io) to get your container access credentials. Once you have received your credentials, log in to the registry using these steps:
 
-1. Retrieve the **username** and **password** you received from Seqera Labs support.
+1.  Retrieve the **username** and **password** you received from Seqera Labs support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
 
-3. Pull the Nextflow Tower container images with the following commands:
+1.  Pull the Nextflow Tower container images with the following commands:
 
 ```bash
 docker pull {{ images.tower_be_image }}
@@ -116,17 +116,17 @@ This section provides step-by-step instructions for some commonly used AWS servi
 
 From Tower version 23.1, you can retrieve Tower configuration values remotely from the AWS Parameter Store.
 
-1. Configure [AWS authentication](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html) to grant AWS Parameter Store access on your local host.
-2. Retrieve the Tower container images and install Tower per the instructions at the top of this page.
-3. The default value for `tower.application.name` is `tower-app`. This can be changed in your `tower.yml` configuration file. Note that your application name must be specified in the path to your configuration values in AWS Parameter Store (see step 5 below).
-4. Set the `TOWER_ENABLE_AWS_SSM` environment variable to `true`. Alternatively, add the value `aws-ssm` to the `TOWER_ENABLE_PLATFORMS` variable.
-5. Add configuration parameters to the AWS Parameter Store individually, using the format `/config/<application_name>/<cfg_path> : <cfg_value>`. For example:
+1.  Configure [AWS authentication](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html) to grant AWS Parameter Store access on your local host.
+1.  Retrieve the Tower container images and install Tower per the instructions at the top of this page.
+1.  The default value for `tower.application.name` is `tower-app`. This can be changed in your `tower.yml` configuration file. Note that your application name must be specified in the path to your configuration values in AWS Parameter Store (see step 5 below).
+1.  Set the `TOWER_ENABLE_AWS_SSM` environment variable to `true`. Alternatively, add the value `aws-ssm` to the `TOWER_ENABLE_PLATFORMS` variable.
+1.  Add configuration parameters to the AWS Parameter Store individually, using the format `/config/<application_name>/<cfg_path> : <cfg_value>`. For example:
 
    ```bash
    /config/tower-app/tower.logger.levels.com.amazonaws : "WARN"
    ```
 
-6. Start or restart your Tower instance to confirm that the configuration value is fetched. The following entries should appear in your backend log:
+1.  Start or restart your Tower instance to confirm that the configuration value is fetched. The following entries should appear in your backend log:
 
    ```bash
    [main] - INFO  i.m.context.DefaultBeanContext - Reading bootstrap environment configuration
@@ -139,27 +139,27 @@ From Tower version 23.1, you can retrieve Tower configuration values remotely fr
 If you're using Simple Email Service in sandbox mode, ensure that both the _sender_ and the _receiver_ email addresses are verified via AWS SES. Note that sandbox is not recommended for production use. See the [AWS docs](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) for instructions to move out of the sandbox.
 :::
 
-1. Navigate to the [**Amazon Simple Email Service**](https://us-east-2.console.aws.amazon.com/ses) console.
+1.  Navigate to the [**Amazon Simple Email Service**](https://us-east-2.console.aws.amazon.com/ses) console.
 
-2. In the navigation menu, select **SMTP Settings**.
+1.  In the navigation menu, select **SMTP Settings**.
 
-3. Select **Create my SMTP Credentials**
+1.  Select **Create my SMTP Credentials**
 
-4. Select **Create**.
+1.  Select **Create**.
 
-5. Select **Show User SMTP Credentials** to copy your credentials, or select **Download Credentials**.
+1.  Select **Show User SMTP Credentials** to copy your credentials, or select **Download Credentials**.
 
 :::caution
 The credentials (username and password) will not be shown to you again after this instance.
 :::
 
-6. You will be automatically redirected to the IAM dashboard. Log back in to the [Amazon SES Console](https://us-east-2.console.aws.amazon.com/ses).
+1.  You will be automatically redirected to the IAM dashboard. Log back in to the [Amazon SES Console](https://us-east-2.console.aws.amazon.com/ses).
 
-7. Select **Email Addresses** in the navigation menu. Then, select **Verify a new Email Address**.
+1.  Select **Email Addresses** in the navigation menu. Then, select **Verify a new Email Address**.
 
-8. A pop-up asking for your email should automatically appear. Once you type in your email address and select **Verify This Email Address**, you should receive a confirmation email from Amazon SES to confirm email address ownership.
+1.  A pop-up asking for your email should automatically appear. Once you type in your email address and select **Verify This Email Address**, you should receive a confirmation email from Amazon SES to confirm email address ownership.
 
-9. Open the verification link in the message.
+1.  Open the verification link in the message.
 
 :::caution
 The verification link is **only valid for 24 hours** after your original request for verification.
@@ -175,76 +175,76 @@ See the AWS documentation for more options, such as setting up an [Easy DKIM for
 
 ### Amazon RDS
 
-1. Open the [Amazon RDS console](https://console.aws.amazon.com/rds/).
+1.  Open the [Amazon RDS console](https://console.aws.amazon.com/rds/).
 
-2. Select **Create database** -> **Standard create** -> **MySQL**.
+1.  Select **Create database** -> **Standard create** -> **MySQL**.
 
-3. Under **Edition**, select **MySQL Community** and any version under **5.7.x**, or **8.0.x**.
+1.  Under **Edition**, select **MySQL Community** and any version under **5.7.x**, or **8.0.x**.
 
-4. Enter the **DB cluster identifier** (e.g., `nftower-db`).
+1.  Enter the **DB cluster identifier** (e.g., `nftower-db`).
 
-5. Enter the **Master username**, or keep the default.
+1.  Enter the **Master username**, or keep the default.
 
-6. Enter the **Master password**.
+1.  Enter the **Master password**.
 
    - To use an automatically generated master password, select **Auto generate a password**.
    - To use a custom master password, deselect **Auto generate a password** and enter your password in **Master password** and **Confirm password**.
 
-7. Under **Instance configuration**, select the **DB instance class** and instance type.
+1.  Under **Instance configuration**, select the **DB instance class** and instance type.
 
-8. Under **Connectivity**, select the correct **VPC security group**. Confirm this with your AWS administrator.
+1.  Under **Connectivity**, select the correct **VPC security group**. Confirm this with your AWS administrator.
 
-9. Under **Additional configuration**, enter the **Initial database name** (e.g., `tower`).
+1.  Under **Additional configuration**, enter the **Initial database name** (e.g., `tower`).
 
-10. Select **Create database**.
+1.  Select **Create database**.
 
 After your database is created:
 
-1. Update the inbound rules for the underlying EC2 instance to allow MySQL connections.
+1.  Update the inbound rules for the underlying EC2 instance to allow MySQL connections.
 
-2. Update `TOWER_DB_URL` in your configuration value with the database hostname.
+1.  Update `TOWER_DB_URL` in your configuration value with the database hostname.
 
 ### Amazon EC2
 
 If you have never set up an Amazon EC2 instance for Linux, refer to [this guide](https://aws.amazon.com/ec2/getting-started/) to get started with Amazon EC2.
 
-1. Open the [AWS Management console](https://us-east-2.console.aws.amazon.com/console/home).
+1.  Open the [AWS Management console](https://us-east-2.console.aws.amazon.com/console/home).
 
-2. Log in as an IAM user with your credentials.
+1.  Log in as an IAM user with your credentials.
 
-3. Under **AWS services**, select **All Services**.
+1.  Under **AWS services**, select **All Services**.
 
-4. Under **Compute**, select **EC2**.
+1.  Under **Compute**, select **EC2**.
 
-5. Select **Instances**, then **Launch instances**.
+1.  Select **Instances**, then **Launch instances**.
 
-6. You will be asked to choose an Amazon Machine Image (AMI). Scroll to the middle of the page and select **Amazon Linux 2**.
+1.  You will be asked to choose an Amazon Machine Image (AMI). Scroll to the middle of the page and select **Amazon Linux 2**.
 
-7. Once you click **Select**, you will be redirected to **Step 2: Choose an Instance Type**.
+1.  Once you click **Select**, you will be redirected to **Step 2: Choose an Instance Type**.
 
-8. Scroll down and select either **c5a.xlarge** or **c5.large** — these provide 4 CPUs and 8GB of RAM.
+1.  Scroll down and select either **c5a.xlarge** or **c5.large** — these provide 4 CPUs and 8GB of RAM.
 
-9. Select **Next: Configure Instance Details**.
+1.  Select **Next: Configure Instance Details**.
 
-10. If required, configure the instance details settings. Then, select **Next: Add Storage**.
+1.  If required, configure the instance details settings. Then, select **Next: Add Storage**.
 
-11. The root storage should be 20GB. Configure this under **Size (GiB)**.
+1.  The root storage should be 20GB. Configure this under **Size (GiB)**.
 
-12. Select **Add Tags** (if required) to add case-sensitive key-value pairs (e.g., `key = Name` and `value = Webserver`).
+1.  Select **Add Tags** (if required) to add case-sensitive key-value pairs (e.g., `key = Name` and `value = Webserver`).
 
-13. Select **Next: Configure Security Group**.
+1.  Select **Next: Configure Security Group**.
 
-14. Enter `nftower-sg` as the Security Group name.
+1.  Enter `nftower-sg` as the Security Group name.
 
-15. Optionally, you can enter a description for your Security Group's name.
+1.  Optionally, you can enter a description for your Security Group's name.
 
-16. Configure the type of protocol settings. Note that the security group port must be configured to 8000.
+1.  Configure the type of protocol settings. Note that the security group port must be configured to 8000.
 
-17. Select **Review and Launch**.
+1.  Select **Review and Launch**.
 
-18. Once you have reviewed your instance, select **Launch**.
+1.  Once you have reviewed your instance, select **Launch**.
 
-19. Select an existing key pair or create a new one in the pop-up that appears.
+1.  Select an existing key pair or create a new one in the pop-up that appears.
 
     If you already have an existing key pair, select **Choose an existing key pair** and choose from the available options in the drop-down menu.
 
@@ -252,11 +252,11 @@ If you have never set up an Amazon EC2 instance for Linux, refer to [this guide]
 
     **Note:** once you download the key pair, store it in a secure and accessible location. You will not be able to download the file again after it is created.
 
-20. Select **Launch Instances**.
+1.  Select **Launch Instances**.
 
-21. Use the key pair to connect to the server using SSH and its public IP address. Terminal-based SSH is easier to use than browser-based SSH for copying and pasting text.
+1.  Use the key pair to connect to the server using SSH and its public IP address. Terminal-based SSH is easier to use than browser-based SSH for copying and pasting text.
 
-22. Enter the following commands to set up `docker` and `docker-compose`.
+1.  Enter the following commands to set up `docker` and `docker-compose`.
 
 ```bash
 # Install and start the docker engine

--- a/platform_versioned_docs/version-23.2.0/enterprise/prerequisites/azure.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/prerequisites/azure.mdx
@@ -12,15 +12,15 @@ This page describes the infrastructure and other prerequisites for deploying Tow
 Nextflow Tower is distributed as a collection of Docker containers available through the Seqera Labs
 container registry ([cr.seqera.io](https://cr.seqera.io)). Contact [support](https://support.seqera.io) to get your container access credentials. Once you have received your credentials, log in to the registry using these steps:
 
-1. Retrieve the **username** and **password** you received from Seqera Labs support.
+1.  Retrieve the **username** and **password** you received from Seqera Labs support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    ```bash
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
    ```
 
-3. Pull the Nextflow Tower container images with the following commands:
+1.  Pull the Nextflow Tower container images with the following commands:
 
 ```bash
 docker pull {{ images.tower_be_image }}
@@ -101,13 +101,13 @@ This section provides step-by-step instructions for some commonly used Azure ser
 
 ### Azure Resource Group
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
+1.  Sign in to the [Azure portal](https://portal.azure.com).
 
-2. Select **Resource groups**.
+1.  Select **Resource groups**.
 
-3. Select **Add**.
+1.  Select **Add**.
 
-4. Enter the following values:
+1.  Enter the following values:
 
    - **Subscription**: Select your Azure subscription.
 
@@ -115,19 +115,19 @@ This section provides step-by-step instructions for some commonly used Azure ser
 
    - **Region**: Select the Region where your assets will exist (e.g. `East US`).
 
-5. Select **Review and Create**.
+1.  Select **Review and Create**.
 
-6. Select **Create**.
+1.  Select **Create**.
 
 ### Azure Storage Account
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
+1.  Sign in to the [Azure portal](https://portal.azure.com).
 
-2. Select **Storage accounts**.
+1.  Select **Storage accounts**.
 
-3. Select **Create**.
+1.  Select **Create**.
 
-4. Enter the following values:
+1.  Enter the following values:
 
    - **Subscription**: Select your Azure subscription.
 
@@ -141,71 +141,71 @@ This section provides step-by-step instructions for some commonly used Azure ser
 
    - **Redundancy**: Select `Geo-redundant storage (GRS)`
 
-5. Select **Review + create**. Note that the default values are used in the other tabs. See the [Azure documentation](https://docs.microsoft.com/en-ca/azure/storage/common/storage-account-create?tabs=azure-portal#create-a-storage-account-1) for further details on each setting.
+1.  Select **Review + create**. Note that the default values are used in the other tabs. See the [Azure documentation](https://docs.microsoft.com/en-ca/azure/storage/common/storage-account-create?tabs=azure-portal#create-a-storage-account-1) for further details on each setting.
 
-6. Select **Create**.
+1.  Select **Create**.
 
 ### Azure Linux VM
 
 We recommend the following VM settings:
 
-1. Use **default values** unless otherwise specified.
-2. Provision at least **2 CPUS** and **8GB RAM**.
-3. Use the **Ubuntu Server 20.04 LTS - Gen2** image.
-4. Ensure your VM is **accessible by SSH**.
-5. Do not implement DNS or Load Balancing directly against the VM (do so via Azure Application Gateway instead).
+1.  Use **default values** unless otherwise specified.
+1.  Provision at least **2 CPUS** and **8GB RAM**.
+1.  Use the **Ubuntu Server 20.04 LTS - Gen2** image.
+1.  Ensure your VM is **accessible by SSH**.
+1.  Do not implement DNS or Load Balancing directly against the VM (do so via Azure Application Gateway instead).
 
 To create a VM:
 
-1. Configure the **Basics** tab:
+1.  Configure the **Basics** tab:
 
    - Ensure your **Region** is the same as your **Resource group**.
    - Do not set the VM as an **Azure Spot instance**.
    - Ensure your Security Group allows ingress on **Port 8000**.
 
-2. Configure the **Disks** tab:
+1.  Configure the **Disks** tab:
 
    - Ensure your OS disk type is **Standard SSD**.
 
-3. Configure the **Network** tab:
+1.  Configure the **Network** tab:
 
    - Ensure that a **Public IP** is assigned to the VM.
    - Do not place the VM in the backend pool of an existing load balancing solution.
 
-4. Select **Review + create**.
+1.  Select **Review + create**.
 
-5. Select **Create**.
+1.  Select **Create**.
 
 To make the VM's IP address static:
 
-1. Enter **Public IP addresses** in the search.
+1.  Enter **Public IP addresses** in the search.
 
-2. Under **Services**, select **Public IP addresses**.
+1.  Under **Services**, select **Public IP addresses**.
 
-3. On the **Public IP addresses** page, select the entry containing your VM name. A page opens with that IP's details.
+1.  On the **Public IP addresses** page, select the entry containing your VM name. A page opens with that IP's details.
 
-4. Select **Configuration** from the left-hand navigation panel.
+1.  Select **Configuration** from the left-hand navigation panel.
 
-5. Ensure that your IP address assignment is **Static**.
+1.  Ensure that your IP address assignment is **Static**.
 
-6. Do not add a custom DNS name label to the VM.
+1.  Do not add a custom DNS name label to the VM.
 
 To allow ingress on port 8000:
 
-1. Enter **Virtual Machines** in the search bar.
+1.  Enter **Virtual Machines** in the search bar.
 
-2. Under **Services**, select **Virtual machines**.
+1.  Under **Services**, select **Virtual machines**.
 
-3. On the **Virtual machines** page, select your VM name to navigate to the VM details.
+1.  On the **Virtual machines** page, select your VM name to navigate to the VM details.
 
-4. Select **Networking** from the left-hand navigation panel.
+1.  Select **Networking** from the left-hand navigation panel.
 
-5. **Add inbound port rule** for port 8000.
+1.  **Add inbound port rule** for port 8000.
 
 To install Docker:
 
 1.  Complete the steps for the [Install using the apt repository][docker] instructions.
-2.  Confirm that Docker Compose is installed:
+1.  Confirm that Docker Compose is installed:
 
     ```bash
     docker compose version

--- a/platform_versioned_docs/version-23.2.0/enterprise/prerequisites/gcp.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/prerequisites/gcp.mdx
@@ -12,15 +12,15 @@ This page describes the infrastructure and other prerequisites for deploying Tow
 Nextflow Tower is distributed as a collection of Docker containers available through the Seqera Labs
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. Once you have received your credentials, log in to the registry using these steps:
 
-1. Retrieve the **username** and **password** you received from Seqera Labs support.
+1.  Retrieve the **username** and **password** you received from Seqera Labs support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    ```bash
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
    ```
 
-3. Pull the Nextflow Tower container images with the following commands:
+1.  Pull the Nextflow Tower container images with the following commands:
 
    ```bash
    docker pull {{ images.tower_be_image }}
@@ -82,13 +82,13 @@ From Tower 22.1.1, HTTP-only implementations **must** set the `TOWER_ENABLE_UNSA
 
 A public IP address can be reserved for the Tower ingress to keep the IP address constant across restarts. If you do not reserve an IP address, the ingress will create one for you automatically, but it will be different every time you deploy the ingress. See the [detailed instructions](#detailed-instructions) to reserve a public IP address.
 
-1. Browse to **VPC network** → **External IP addresses** and select **Reserve Static Address**
+1.  Browse to **VPC network** → **External IP addresses** and select **Reserve Static Address**
 
-2. Assign a name (e.g., `tower-ip`). This name will be used later to configure the ingress.
+1.  Assign a name (e.g., `tower-ip`). This name will be used later to configure the ingress.
 
-3. Select the region where your GKE cluster is deployed.
+1.  Select the region where your GKE cluster is deployed.
 
-4. Select **Reserve**.
+1.  Select **Reserve**.
 
 ## Detailed instructions
 
@@ -96,37 +96,37 @@ This section provides step-by-step instructions for some commonly used GCP servi
 
 ### Google CloudSQL
 
-1. Browse to **Cloud SQL** and select **Create Instance**.
+1.  Browse to **Cloud SQL** and select **Create Instance**.
 
-2. Select **MySQL** (you may need to enable the API).
+1.  Select **MySQL** (you may need to enable the API).
 
-3. Change to **Single zone** availability, unless there is a need for high availability.
+1.  Change to **Single zone** availability, unless there is a need for high availability.
 
-4. Update the **Region** and **Zone** to match the location of your Tower deployment.
+1.  Update the **Region** and **Zone** to match the location of your Tower deployment.
 
-5. Expand **Show configuration options** and update the **Machine type** and **Storage** settings. The recommended machine type and disk size depends on the number of parallel pipelines you expect to run. In this guide, we use the **Standard** machine type with **1 vCPU**, and **20 GB SSD** storage.
+1.  Expand **Show configuration options** and update the **Machine type** and **Storage** settings. The recommended machine type and disk size depends on the number of parallel pipelines you expect to run. In this guide, we use the **Standard** machine type with **1 vCPU**, and **20 GB SSD** storage.
 
-6. Expand **Connections**, disable **Public IP**, and enable **Private IP**.
+1.  Expand **Connections**, disable **Public IP**, and enable **Private IP**.
 
-7. Select the **Network** (usually **default**). You may need to set up a **Private services access connection** for this VPC if you have not done so already. Enable the API and select **Use an automatically allocated IP range**. Select **Continue**, then **Create Connection**.
+1.  Select the **Network** (usually **default**). You may need to set up a **Private services access connection** for this VPC if you have not done so already. Enable the API and select **Use an automatically allocated IP range**. Select **Continue**, then **Create Connection**.
 
-8. Select **Create Instance**.
+1.  Select **Create Instance**.
 
-9. Once the database has been created, select the instance, then **Databases**. Create a new database named **tower**.
+1.  Once the database has been created, select the instance, then **Databases**. Create a new database named **tower**.
 
-10. Note the Private IP address of the instance as it must be supplied to the `TOWER_DB_URL` environment variable.
+1.  Note the Private IP address of the instance as it must be supplied to the `TOWER_DB_URL` environment variable.
 
 ### Google Compute Engine
 
-1. From the Navigation menu of the Google Cloud console, select **Compute Engine** to create a new VM instance. Select the machine name, region/zone, and machine type. In this example we have used an `e2-standard-2` instance (2 vCPUs, 8 GB memory). We recommend using the [container-optimized OS](https://cloud.google.com/community/tutorials/docker-compose-on-container-optimized-os) for the VM.
+1.  From the Navigation menu of the Google Cloud console, select **Compute Engine** to create a new VM instance. Select the machine name, region/zone, and machine type. In this example we have used an `e2-standard-2` instance (2 vCPUs, 8 GB memory). We recommend using the [container-optimized OS](https://cloud.google.com/community/tutorials/docker-compose-on-container-optimized-os) for the VM.
 
-2. Enable HTTP traffic. By default, the frontend is exposed to port 8000, so you will need to add a firewall rule to the underlying VPC network to allow port 8000 (after VM creation).
+1.  Enable HTTP traffic. By default, the frontend is exposed to port 8000, so you will need to add a firewall rule to the underlying VPC network to allow port 8000 (after VM creation).
 
-3. Connect to the machine using SSH. If you run into issues with SSH, or would like to set up IAP SSH, refer to the documentation for [TCP forward to IAP](https://cloud.google.com/iap/docs/using-tcp-forwarding).
+1.  Connect to the machine using SSH. If you run into issues with SSH, or would like to set up IAP SSH, refer to the documentation for [TCP forward to IAP](https://cloud.google.com/iap/docs/using-tcp-forwarding).
 
-4. Install [Docker](https://docs.docker.com/engine/install/debian/) if it is not already installed.
+1.  Install [Docker](https://docs.docker.com/engine/install/debian/) if it is not already installed.
 
-5. Test Docker by running the [Docker Compose](https://hub.docker.com/r/docker/compose/tags/) image. If Docker does not have sufficient permissions, use [these steps](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) to run it without root, or use `sudo`.
+1.  Test Docker by running the [Docker Compose](https://hub.docker.com/r/docker/compose/tags/) image. If Docker does not have sufficient permissions, use [these steps](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) to run it without root, or use `sudo`.
 
    ```bash
    # test docker compose
@@ -136,7 +136,7 @@ This section provides step-by-step instructions for some commonly used GCP servi
    docker images
    ```
 
-6. Create an alias for `docker-compose`:
+1.  Create an alias for `docker-compose`:
 
    ```bash
    echo alias docker-compose="'"'docker run --rm \
@@ -148,4 +148,4 @@ This section provides step-by-step instructions for some commonly used GCP servi
    source .bashrc
    ```
 
-7. Configure `gcloud` and Docker as described in [Tower container images](#tower-container-images).
+1.  Configure `gcloud` and Docker as described in [Tower container images](#tower-container-images).

--- a/platform_versioned_docs/version-23.2.0/enterprise/prerequisites/on-prem.mdx
+++ b/platform_versioned_docs/version-23.2.0/enterprise/prerequisites/on-prem.mdx
@@ -12,15 +12,15 @@ This page describes the prerequisites for deploying Tower to your on-premises in
 Nextflow Tower is distributed as a collection of Docker containers available through the Seqera Labs
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. Once you have received your credentials, log in to the registry using these steps:
 
-1. Retrieve the **username** and **password** you received from Seqera Labs support.
+1.  Retrieve the **username** and **password** you received from Seqera Labs support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    ```bash
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
    ```
 
-3. Pull the Nextflow Tower container images with the following commands:
+1.  Pull the Nextflow Tower container images with the following commands:
 
    ```bash
    docker pull {{ images.tower_be_image }}

--- a/platform_versioned_docs/version-23.2.0/faqs.mdx
+++ b/platform_versioned_docs/version-23.2.0/faqs.mdx
@@ -11,10 +11,10 @@ tags: [faq, help]
 
 The Administration Console allows Tower instance administrators to interact with all users and organizations registered with the platform. Administrators must be identified in your Tower instance configuration files prior to instantiation of the application.
 
-1. Create a `TOWER_ROOT_USERS` environment variable (e.g. via _tower.env_ or Kubernetes ConfigMap).
-2. Populate the variable with a sequence of comma-delimited email addresses (no spaces).<br/>Example: `TOWER_ROOT_USERS=foo@foo.com,bar@bar.com`
-3. If using a Tower version earlier than 21.12:
-   1. Add the following configuration to _tower.yml_:
+1.  Create a `TOWER_ROOT_USERS` environment variable (e.g. via _tower.env_ or Kubernetes ConfigMap).
+1.  Populate the variable with a sequence of comma-delimited email addresses (no spaces).<br/>Example: `TOWER_ROOT_USERS=foo@foo.com,bar@bar.com`
+1.  If using a Tower version earlier than 21.12:
+   1.  Add the following configuration to _tower.yml_:
 
    ```yml
    tower:
@@ -22,8 +22,8 @@ The Administration Console allows Tower instance administrators to interact with
        root-users: "${TOWER_ROOT_USERS:[]}"
    ```
 
-4. Restart the `cron` and `backend` containers/Deployments.
-5. The console will now be available via your Profile drop-down menu.
+1.  Restart the `cron` and `backend` containers/Deployments.
+1.  The console will now be available via your Profile drop-down menu.
 
 ## API
 
@@ -53,11 +53,11 @@ One such value is `launch.id`; attempting to launch a pipeline without specifyin
 
 If you have encountered the 403 error as a result of being a Launch user who did not provide a `launch.id`, please try resolving the problem as follows:
 
-1. Provide the launch ID to the payload sent to the tower using the same endpoint. To do this;
+1.  Provide the launch ID to the payload sent to the tower using the same endpoint. To do this;
 
-   1. Query the list of pipelines via the `/pipelines` endpoint. Find the `pipelineId` of the pipeline you intend to launch.
-   2. Once you have the `pipelineId`, call the `/pipelines/{pipelineId}/launch` API to retrieve the pipeline's `launch.id`.
-   3. Include the `launch.id` in your call to the `/workflow/launch` API endpoint (see example below).
+   1.  Query the list of pipelines via the `/pipelines` endpoint. Find the `pipelineId` of the pipeline you intend to launch.
+   2.  Once you have the `pipelineId`, call the `/pipelines/{pipelineId}/launch` API to retrieve the pipeline's `launch.id`.
+   3.  Include the `launch.id` in your call to the `/workflow/launch` API endpoint (see example below).
 
       ```
       {
@@ -72,7 +72,7 @@ If you have encountered the 403 error as a result of being a Launch user who did
       }
       ```
 
-2. If a launch id remains unavailable to you, upgrade your user role to 'Maintain' or higher. This will allow you to execute quick launch-type pipeline invocations.
+1.  If a launch id remains unavailable to you, upgrade your user role to 'Maintain' or higher. This will allow you to execute quick launch-type pipeline invocations.
 
 ## Common Errors
 
@@ -88,9 +88,9 @@ Github imposes [rate limits](https://docs.github.com/en/rest/overview/resources-
 
 To resolve the problem, please try the following:
 
-1. Ensure there is at least one Github credential in your Workspace's Credentials tab.
-2. Ensure that the **Access token** field of all Github Credential objects is populated with a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) value, NOT a user password. (_Github PATs are typically several dozen characters long and begin with a `ghp_`prefix; example:`ghp*IqIMNOZH6zOwIEB4T9A2g4EHMy8Ji42q4HA`*)
-3. Confirm that your PAT is providing the elevated threshold and transactions are being charged against it:
+1.  Ensure there is at least one Github credential in your Workspace's Credentials tab.
+1.  Ensure that the **Access token** field of all Github Credential objects is populated with a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) value, NOT a user password. (_Github PATs are typically several dozen characters long and begin with a `ghp_`prefix; example:`ghp*IqIMNOZH6zOwIEB4T9A2g4EHMy8Ji42q4HA`*)
+1.  Confirm that your PAT is providing the elevated threshold and transactions are being charged against it:
 
    `curl -H "Authorization: token ghp_LONG_ALPHANUMERIC_PAT" -H "Accept: application/vnd.github.v3+json" https://api.github.com/rate_limit`
 
@@ -100,14 +100,14 @@ This error can occur if incorrect configuration values are assigned to the `back
 
 Please verify the following:
 
-1. The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `backend` container:
+1.  The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `backend` container:
    - Contains `prod,redis,ha`
    - Does not contain `cron`
-2. The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `cron` container:
+1.  The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `cron` container:
    - Contains `prod,redis,cron`
    - Does not contain `ha`
-3. You do not have another copy of the `MICRONAUT_ENVIRONMENTS` environment variable defined elsewhere in your application (e.g. a _tower.env_ file or Kubernetes ConfigMap).
-4. If you are using a separate container/pod to execute _migrate-db.sh_, there is no `MICRONAUT_ENVIRONMENTS` environment variable assigned to it.
+1.  You do not have another copy of the `MICRONAUT_ENVIRONMENTS` environment variable defined elsewhere in your application (e.g. a _tower.env_ file or Kubernetes ConfigMap).
+1.  If you are using a separate container/pod to execute _migrate-db.sh_, there is no `MICRONAUT_ENVIRONMENTS` environment variable assigned to it.
 
 **<p data-question>Q: Why do I get a `chmod: cannot access PATH/TO/bin/*: No such file or directory` exception?</p>**
 
@@ -186,8 +186,8 @@ Clients who use Amazon Aurora as their database solution may encounter a `java.s
 
 Please modify Tower Enterprise configuration as follows to try resolving the problem:
 
-1. Ensure your `TOWER_DB_DRIVER` uses the specified MariaDB URI.
-2. Modify your `TOWER_DB_URL` to: `TOWER_DB_URL=jdbc:mysql://YOUR_DOMAIN:YOUR_PORT/YOUR_TOWER_DB?usePipelineAuth=false&useBatchMultiSend=false`
+1.  Ensure your `TOWER_DB_DRIVER` uses the specified MariaDB URI.
+1.  Modify your `TOWER_DB_URL` to: `TOWER_DB_URL=jdbc:mysql://YOUR_DOMAIN:YOUR_PORT/YOUR_TOWER_DB?usePipelineAuth=false&useBatchMultiSend=false`
 
 ## Datasets
 
@@ -195,10 +195,10 @@ Please modify Tower Enterprise configuration as follows to try resolving the pro
 
 When uploading Datasets via the Tower UI or CLI, some steps are automatically done on your behalf. To upload Datasets via the TOwer API, additional steps are required:
 
-1. Explicitly define the MIME type of the file being uploaded.
-2. Make two calls to the API:
-   1. Create a Dataset object
-   2. Upload the samplesheet to the Dataset object.
+1.  Explicitly define the MIME type of the file being uploaded.
+1.  Make two calls to the API:
+   1.  Create a Dataset object
+   2.  Upload the samplesheet to the Dataset object.
 
 Example:
 
@@ -258,13 +258,13 @@ TLS connection errors can occur due to variability in the [default TLS version s
 
 To fix the problem, you can either:
 
-1. Set a JDK environment variable to force Nextflow and/or the Tower containers to use TLSv1.2 by default:
+1.  Set a JDK environment variable to force Nextflow and/or the Tower containers to use TLSv1.2 by default:
 
 ```
 export JAVA_OPTIONS="-Dmail.smtp.ssl.protocols=TLSv1.2"
 ```
 
-2. Add the following parameter to your nextflow.config file:
+1.  Add the following parameter to your nextflow.config file:
 
 ```
 mail {
@@ -323,9 +323,9 @@ Users with email addresses other than the `trustedEmails` list will undergo an a
 
 **Note:**
 
-1. You must rebuild your containers (i.e., `docker-compose down`) to force Tower to implement this change. Ensure your database is persistent before issuing the docker-compose down command. See [here](https://help.tower.nf/latest/enterprise/docker-compose/) for more information.
-2. All login attempts are visible to the root user at **Profile -> Admin panel -> Users**.
-3. Any user logged in prior to the restriction will not be subject to the new restriction. An admin of the organization should remove users that have previously logged in via (untrusted) email from the Admin panel users list. This will restart the approval process before they can log in via email.
+1.  You must rebuild your containers (i.e., `docker-compose down`) to force Tower to implement this change. Ensure your database is persistent before issuing the docker-compose down command. See [here](https://help.tower.nf/latest/enterprise/docker-compose/) for more information.
+1.  All login attempts are visible to the root user at **Profile -> Admin panel -> Users**.
+1.  Any user logged in prior to the restriction will not be subject to the new restriction. An admin of the organization should remove users that have previously logged in via (untrusted) email from the Admin panel users list. This will restart the approval process before they can log in via email.
 
 **<p data-question>Q: Why am I receiving login errors stating that admin approval is required when using Azure AD OIDC?</p>**
 
@@ -335,17 +335,17 @@ The Azure AD app integrated with Tower must have user consent settings configure
 
 This can occur for several reasons. Please verify the following:
 
-1. Your `TOWER_SERVER_URL` environment variable uses the `https://` prefix.
-2. Your `tower.yml` has `micronaut.ssl.enabled` set to `true`.
-3. Any Load Balancer instance that sends traffic to the Tower application is configured to use HTTPS as its backend protocol rather than TCP.
+1.  Your `TOWER_SERVER_URL` environment variable uses the `https://` prefix.
+1.  Your `tower.yml` has `micronaut.ssl.enabled` set to `true`.
+1.  Any Load Balancer instance that sends traffic to the Tower application is configured to use HTTPS as its backend protocol rather than TCP.
 
 **<p data-question>Q: Why isn't my OIDC callback working?</p>**
 
 Callbacks could fail for many reasons. To more effectively investigate the problem:
 
-1. Set the Tower environment variable to `TOWER_SECURITY_LOGLEVEL=DEBUG`.
-2. Ensure your `TOWER_OIDC_CLIENT`, `TOWER_OIDC_SECRET`, and `TOWER_OIDC_ISSUER` environment variables all match the values specified in your OIDC provider's corresponding application.
-3. Ensure your network infrastructure allow necessary egress and ingress traffic.
+1.  Set the Tower environment variable to `TOWER_SECURITY_LOGLEVEL=DEBUG`.
+1.  Ensure your `TOWER_OIDC_CLIENT`, `TOWER_OIDC_SECRET`, and `TOWER_OIDC_ISSUER` environment variables all match the values specified in your OIDC provider's corresponding application.
+1.  Ensure your network infrastructure allow necessary egress and ingress traffic.
 
 **<p data-question>Q: Why did Google SMTP start returning `Username and Password not accepted` errors?</p>**
 
@@ -388,7 +388,7 @@ Yes. You can mount the APM solution's JAR file in the `backend` container and se
 **<p data-question>Q: Is it possible to retrieve the trace file for a Tower-based workflow run?</p>**
 Yes. Although it is not possible to directly download the file via Tower, you can configure your workflow to export the file to persistent storage:
 
-1. Set the following block in your `nextflow.config`:
+1.  Set the following block in your `nextflow.config`:
 
 ```nextflow
 trace {
@@ -396,7 +396,7 @@ trace {
 }
 ```
 
-2. Add a copy command to your pipeline's **Advanced options > Post-run script** field:
+1.  Add a copy command to your pipeline's **Advanced options > Post-run script** field:
 
 ```
 # Example: Export the generated trace file to an S3 bucket
@@ -600,9 +600,9 @@ Runs will fail if your Nextflow script or Nextflow config contain illegal charac
 
 The Groovy shell used by Nextflow to execute your workflow has a hard limit on string size (64KiB). Check the size of your scripts with the `ls -llh` command. If the size is greater than 65,535 bytes, consider these mitigation techniques:
 
-1. Remove any unnecessary code or comments from the script.
-2. Move long script bodies into a separate script file in the pipeline `/bin` directory.
-3. Consider using DSL2 so you can move each function, process, and workflow definition into its own script and include these scripts as [modules](https://www.nextflow.io/docs/latest/dsl2.html#modules).
+1.  Remove any unnecessary code or comments from the script.
+1.  Move long script bodies into a separate script file in the pipeline `/bin` directory.
+1.  Consider using DSL2 so you can move each function, process, and workflow definition into its own script and include these scripts as [modules](https://www.nextflow.io/docs/latest/dsl2.html#modules).
 
 ## Nextflow Launcher
 
@@ -616,8 +616,8 @@ If you are restricted from using public container registries, please see Tower E
 
 Each Nextflow Tower release uses a specific nf-launcher image by default. This image is loaded with a specific Nextflow version, meaning that any workflow run in the container uses this Nextflow version by default. You can force your jobs to use a newer/older version of Nextflow with any of the following strategies:
 
-1. Use the **Pre-run script** advanced launch option to set the desired Nextflow version. Example: `export NXF_VER=22.08.0-edge`
-2. For jobs executing in an AWS Batch compute environment, create a [custom job definition](https://install.tower.nf/22.2/advanced-topics/custom-launch-container/) which references a different nf-launcher image.
+1.  Use the **Pre-run script** advanced launch option to set the desired Nextflow version. Example: `export NXF_VER=22.08.0-edge`
+1.  For jobs executing in an AWS Batch compute environment, create a [custom job definition](https://install.tower.nf/22.2/advanced-topics/custom-launch-container/) which references a different nf-launcher image.
 
 ## OIDC
 
@@ -697,8 +697,8 @@ This error can occur if the Nextflow head job fails to retrieve the necessary re
 
 To determine if this is the case, please do the following:
 
-1. Check your Nextflow log for an entry like `DEBUG nextflow.scm.RepositoryProvider - Request [credentials -:-]`.
-2. If the above is true, please check the protocol of the string that was assigned to your Tower instance's `TOWER_SERVER_URL` configuration value. It is possible this has been erroneously set to `http` rather than `https`.
+1.  Check your Nextflow log for an entry like `DEBUG nextflow.scm.RepositoryProvider - Request [credentials -:-]`.
+1.  If the above is true, please check the protocol of the string that was assigned to your Tower instance's `TOWER_SERVER_URL` configuration value. It is possible this has been erroneously set to `http` rather than `https`.
 
 ## Secrets
 
@@ -725,8 +725,8 @@ Users may encounter a few different errors when executing pipelines that use Sec
 
   To resolve the issue, please upgrade your Nextflow version to 22.08.0-edge. If you cannot upgrade, you can use the following as workarounds:
 
-  1. Use a different container image for each process.
-  2. Define the same set of Secrets in each process that uses the same container image.
+  1.  Use a different container image for each process.
+  2.  Define the same set of Secrets in each process that uses the same container image.
 
 ## Tower Agent
 
@@ -748,8 +748,8 @@ Yes. Provide a POSIX-compliant path to the `TOWER_CONFIG_FILE` environment varia
 
 There are two reasons why configurations specified in `tower.yml` are not being expressed by your Tower instance:
 
-1. There is a typo in one of the key value pairs.
-2. There is a duplicate key present in your file.
+1.  There is a typo in one of the key value pairs.
+1.  There is a duplicate key present in your file.
 
    ```yaml
    # EXAMPLE
@@ -785,8 +785,8 @@ You can force your Nextflow head job to use DSL2 syntax via any of the following
 
 Yes. As of v22.1, Nextflow Tower Enterprise can link to workflows stored in "local" git repositories. To do so:
 
-1. Volume mount your repository folder into the Tower Enterprise `backend` container.
-2. Update your `tower.yml` with the following configuration:
+1.  Volume mount your repository folder into the Tower Enterprise `backend` container.
+1.  Update your `tower.yml` with the following configuration:
 
 ```yml
 tower:
@@ -810,9 +810,9 @@ Activating the **Enable GPU** field while creating an AWS Batch environment with
 
 Note:
 
-1. Activation does not cause GPU-enabled instances to automatically spawn in your Batch cluster. You must still specify these in the Forge screen's **Advanced options > Instance types** field.
-2. Population of the Forge screen's **Advanced options > AMI Id** field will supersede the AWS-recommended AMI.
-3. Your Nextflow script must include [accelerator directives](https://www.nextflow.io/docs/latest/process.html?highlight=accelerator) to use the provisioned GPUs.
+1.  Activation does not cause GPU-enabled instances to automatically spawn in your Batch cluster. You must still specify these in the Forge screen's **Advanced options > Instance types** field.
+1.  Population of the Forge screen's **Advanced options > AMI Id** field will supersede the AWS-recommended AMI.
+1.  Your Nextflow script must include [accelerator directives](https://www.nextflow.io/docs/latest/process.html?highlight=accelerator) to use the provisioned GPUs.
 
 ## tw CLI
 
@@ -874,8 +874,8 @@ This problem will express itself with the following entry in your Nextflow log: 
 
 This can occur due to the following reasons:
 
-1. An access token value has been hardcoded in the `tower.accessToken` block of your `nextflow.config` (either via the git repository itself or override value in the launch form).
-2. In cases where your compute environment is an HPC cluster, the credentialized user's home directory contains a stateful `nextflow.config` with a hardcoded token (e.g. `~/.nextflow/config).
+1.  An access token value has been hardcoded in the `tower.accessToken` block of your `nextflow.config` (either via the git repository itself or override value in the launch form).
+1.  In cases where your compute environment is an HPC cluster, the credentialized user's home directory contains a stateful `nextflow.config` with a hardcoded token (e.g. `~/.nextflow/config).
 
 **<p data-question>Q: What privilege level is granted to a user assigned to a Workspace both as a Participant and Team member?</p>**
 
@@ -932,9 +932,9 @@ There are multiple reasons why your pipeline could fail with an `Essential conta
 
 Please try the following:
 
-1. [Upgrade your ECS Agent](https://github.com/aws/amazon-ecs-agent/releases) to [1.54.1](https://github.com/aws/amazon-ecs-agent/pull/2940) or newer ([instructions for checking your ECS Agent version](https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/ECS/latest-agent-version.html));
-2. Provision more storage space for your EC2 instance (preferably via ebs-autoscaling to ensure scalability).
-3. If the error is accompanied by `command exit status: 123` and a `permissions denied` error tied to a system command, please ensure that the binary is set to be executable (i.e. `chmod u+x`).
+1.  [Upgrade your ECS Agent](https://github.com/aws/amazon-ecs-agent/releases) to [1.54.1](https://github.com/aws/amazon-ecs-agent/pull/2940) or newer ([instructions for checking your ECS Agent version](https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/ECS/latest-agent-version.html));
+1.  Provision more storage space for your EC2 instance (preferably via ebs-autoscaling to ensure scalability).
+1.  If the error is accompanied by `command exit status: 123` and a `permissions denied` error tied to a system command, please ensure that the binary is set to be executable (i.e. `chmod u+x`).
 
 ### Queues
 
@@ -980,7 +980,7 @@ As of Nextflow Tower v21.12, you can specify an Amazon FSX for Lustre instance a
 
 If you need to save files to an S3 bucket protected by a [bucket policy which enforces AES256 server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html), additional configuration settings must be provided to the [nf-launcher](https://quay.io/repository/seqeralabs/nf-launcher?tab=tags) script which invokes the Nextflow head job:
 
-1. Add the following configuration to the **Advanced options > Nextflow config file** textbox of the **Launch Pipeline** screen:
+1.  Add the following configuration to the **Advanced options > Nextflow config file** textbox of the **Launch Pipeline** screen:
 
    ```
    aws {
@@ -990,7 +990,7 @@ If you need to save files to an S3 bucket protected by a [bucket policy which en
    }
    ```
 
-2. Add the following configuration to the **Advanced options > Pre-run script** textbox of the **Launch Pipeline** screen:
+1.  Add the following configuration to the **Advanced options > Pre-run script** textbox of the **Launch Pipeline** screen:
 
    ```bash
    export TOWER_AWS_SSE=AES256
@@ -1031,7 +1031,7 @@ This can occur if a tool/library in your task container requires SSL certificate
 
 You may be able to solve the issue by:
 
-1. Mounting host certificates into the container ([example](https://github.com/nextflow-io/nextflow/blob/v21.10.6/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy#L348-L351)).
+1.  Mounting host certificates into the container ([example](https://github.com/nextflow-io/nextflow/blob/v21.10.6/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy#L348-L351)).
 
 **<p data-question>Q: Why is my deployment using Azure SQL database returning an error about `Connections using insecure transport are prohibited while --require_secure_transport=ON.`</p>**
 
@@ -1059,10 +1059,10 @@ process {
 
 The following roles are needed to be granted to the `nextflow-service-account`.
 
-1. Cloud Life Sciences Workflows Runner
-2. Service Account User
-3. Service Usage Consumer
-4. Storage Object Admin
+1.  Cloud Life Sciences Workflows Runner
+1.  Service Account User
+1.  Service Usage Consumer
+1.  Storage Object Admin
 
 For detailed information, please refer to this [guide.](https://cloud.google.com/life-sciences/docs/tutorials/nextflow#create_a_service_account_and_add_roles)
 
@@ -1108,24 +1108,24 @@ Nextflow is trying to use the Java VM defined for the following environment vari
 
 Possible reasons for this error:
 
-1. The queue where the Nextflow head job runs in a different environment/node than your login node userspace.
-2. If your HPC cluster uses modules, the Java module may not be loaded by default.
+1.  The queue where the Nextflow head job runs in a different environment/node than your login node userspace.
+1.  If your HPC cluster uses modules, the Java module may not be loaded by default.
 
 To troubleshoot:
 
-1. Open an interactive session with the head job queue.
-2. Launch the Nextflow job from the interactive session.
-3. If you cluster used modules:
-   1. Add `module load <your_java_module>` in the **Advanced Features > Pre-run script** field when creating your HPC Compute Environment within Nextflow Tower.
-4. If you cluster does not use modules:
-   1. Source an environment with java and Nextflow using the **Advanced Features > Pre-run script** field when creating your HPC Compute Environment within Nextflow Tower.
+1.  Open an interactive session with the head job queue.
+1.  Launch the Nextflow job from the interactive session.
+1.  If you cluster used modules:
+   1.  Add `module load <your_java_module>` in the **Advanced Features > Pre-run script** field when creating your HPC Compute Environment within Nextflow Tower.
+1.  If you cluster does not use modules:
+   1.  Source an environment with java and Nextflow using the **Advanced Features > Pre-run script** field when creating your HPC Compute Environment within Nextflow Tower.
 
 **<p data-question>Q: Why do pipelines I submit to my HPC cluster fail, but those submitted by another user succeed?</p>**
 
 Nextflow launcher scripts will fail if processed by a non-Bash shell (e.g., `zsh`, `tcsh`). This problem can be identified from certain error entries:
 
-1. Your _.nextflow.log_ contains an error like `Invalid workflow status - expected: SUBMITTED; current: FAILED`.
-2. Your Tower **Error report** tab contains an error like:
+1.  Your _.nextflow.log_ contains an error like `Invalid workflow status - expected: SUBMITTED; current: FAILED`.
+1.  Your Tower **Error report** tab contains an error like:
 
 ```yaml
 Slurm job submission failed
@@ -1136,6 +1136,6 @@ Slurm job submission failed
 
 Connect to the head node via SSH and run `ps -p $$` to verify your default shell. If you see an entry other than Bash, fix as follows:
 
-1. Check which shells are available to you: `cat /etc/shells`
-2. Change your shell: `chsh -s /usr/bin/bash` (note: the path to the binary may differ, depending on your HPC configuration)
-3. If submissions continue to fail after this shell change, ask your Tower admin to restart the **backend** and **cron** containers, and submit from Tower again.
+1.  Check which shells are available to you: `cat /etc/shells`
+1.  Change your shell: `chsh -s /usr/bin/bash` (note: the path to the binary may differ, depending on your HPC configuration)
+1.  If submissions continue to fail after this shell change, ask your Tower admin to restart the **backend** and **cron** containers, and submit from Tower again.

--- a/platform_versioned_docs/version-23.2.0/getting-started/community-showcase.mdx
+++ b/platform_versioned_docs/version-23.2.0/getting-started/community-showcase.mdx
@@ -29,15 +29,15 @@ The community showcase includes [pipeline secrets](../secrets/overview.mdx) that
 
 ## Run pipeline with sample data
 
-1. From the [Launchpad](../launch/launchpad.mdx), select the pipeline of your choice to view the pipeline detail page. nf-core-rnaseq is a good first pipeline example.
-2. (Optional) Select the URL under **Workflow repository** to view the pipeline code repository in another tab.
-3. In Tower Cloud, select **Launch** from the pipeline detail page.
-4. On the **Launch pipeline** page, enter a unique **Workflow run name** or accept the pre-filled random name.
-5. (Optional) Enter labels to be assigned to the run in the **Labels** field.
-6. Under **Input/output options**, select the dataset named after your chosen pipeline from the drop-down menu under **input**.
-7. Under **outdir**, specify an output directory where run results will be saved. This must be an absolute path to storage on cloud infrastructure and defaults to `./results`.
-8. Under **email**, enter an email address where you wish to receive the run completion summary.
-9. Under **multiqc_title**, enter a title for the MultiQC report. This is used as both the report page header and filename.
+1.  From the [Launchpad](../launch/launchpad.mdx), select the pipeline of your choice to view the pipeline detail page. nf-core-rnaseq is a good first pipeline example.
+1.  (Optional) Select the URL under **Workflow repository** to view the pipeline code repository in another tab.
+1.  In Tower Cloud, select **Launch** from the pipeline detail page.
+1.  On the **Launch pipeline** page, enter a unique **Workflow run name** or accept the pre-filled random name.
+1.  (Optional) Enter labels to be assigned to the run in the **Labels** field.
+1.  Under **Input/output options**, select the dataset named after your chosen pipeline from the drop-down menu under **input**.
+1.  Under **outdir**, specify an output directory where run results will be saved. This must be an absolute path to storage on cloud infrastructure and defaults to `./results`.
+1.  Under **email**, enter an email address where you wish to receive the run completion summary.
+1.  Under **multiqc_title**, enter a title for the MultiQC report. This is used as both the report page header and filename.
 
 The remaining launch form fields will vary depending on the pipeline you have selected. Parameters required for the pipeline to run are pre-filled by default, and empty fields are optional.
 

--- a/platform_versioned_docs/version-23.2.0/getting-started/deployment-options.mdx
+++ b/platform_versioned_docs/version-23.2.0/getting-started/deployment-options.mdx
@@ -40,15 +40,15 @@ You can access Tower through the web user interface, the [API](../api/overview.m
 
 ### Tower UI
 
-1. Create an account and log in to Tower, available free of charge at [cloud.tower.nf](https://cloud.tower.nf).
+1.  Create an account and log in to Tower, available free of charge at [cloud.tower.nf](https://cloud.tower.nf).
 
    :::note
    Tower login sessions remain active as long as the application browser window remains open and active. When the browser window is terminated, automatic logout occurs within 6 hours by default.
    :::
 
-2. Create and configure a new [compute environment](../compute-envs/overview.mdx).
+1.  Create and configure a new [compute environment](../compute-envs/overview.mdx).
 
-3. Start [launching pipelines](../launch/launchpad.mdx).
+1.  Start [launching pipelines](../launch/launchpad.mdx).
 
 ### Tower API
 
@@ -62,30 +62,30 @@ See [CLI](../cli/cli.mdx).
 
 If you have an existing environment where you run Nextflow directly, you can still leverage Tower capabilities by executing your Nextflow run with a `with-tower` flag.
 
-1. Create an account and log in to Tower.
-2. From your personal workspace, select **Your tokens** from **Settings** in the user top-right menu.
-3. Select **Add token**.
-4. Enter a unique name for your token, then select **Add**.
-5. Copy and store your token securely.
+1.  Create an account and log in to Tower.
+1.  From your personal workspace, select **Your tokens** from **Settings** in the user top-right menu.
+1.  Select **Add token**.
+1.  Enter a unique name for your token, then select **Add**.
+1.  Copy and store your token securely.
 
 :::caution
 The access token will be displayed only once. Save the token value before closing the **Personal Access Token** window.
 :::
 
-6. Open a terminal and create environment variables to store the Tower access token and Nextflow version:
+1.  Open a terminal and create environment variables to store the Tower access token and Nextflow version:
 
    ```bash
    export TOWER_ACCESS_TOKEN=eyxxxxxxxxxxxxxxxQ1ZTE=
    export NXF_VER=23.1.3
    ```
 
-7. Replace `eyxxxxxxxxxxxxxxxQ1ZTE=` with your newly-created token.
+1.  Replace `eyxxxxxxxxxxxxxxxQ1ZTE=` with your newly-created token.
 
 :::note
 Bearer token support requires Nextflow version 20.10.0 or later. Set with the `NXF_VER` environment variable.
 :::
 
-8. To submit a pipeline to a [workspace](./workspace.mdx) using Nextflow, add the workspace ID to your environment:
+1.  To submit a pipeline to a [workspace](./workspace.mdx) using Nextflow, add the workspace ID to your environment:
 
    ```bash
    export TOWER_WORKSPACE_ID=000000000000000
@@ -93,7 +93,7 @@ Bearer token support requires Nextflow version 20.10.0 or later. Set with the `N
 
    To find your workspace ID, select your organization in Tower and navigate to the **Workspaces** tab.
 
-9. Run your Nextflow pipeline with the `-with-tower` flag:
+1.  Run your Nextflow pipeline with the `-with-tower` flag:
 
    ```bash
    nextflow run main.nf -with-tower

--- a/platform_versioned_docs/version-23.2.0/getting-started/usage.mdx
+++ b/platform_versioned_docs/version-23.2.0/getting-started/usage.mdx
@@ -9,11 +9,11 @@ You can use Tower through the web interface, the API, the CLI, or in Nextflow di
 
 ### Tower web interface
 
-1. Create an account and log in to Tower, available free of charge at [tower.nf](https://cloud.tower.nf).
+1.  Create an account and log in to Tower, available free of charge at [tower.nf](https://cloud.tower.nf).
 
-2. Create and configure a new [compute environment](../compute-envs/overview.mdx).
+1.  Create and configure a new [compute environment](../compute-envs/overview.mdx).
 
-3. Start [launching pipelines](../launch/launchpad.mdx).
+1.  Start [launching pipelines](../launch/launchpad.mdx).
 
 ### Tower API
 
@@ -25,17 +25,17 @@ See [CLI](../cli.mdx).
 
 ### Nextflow `-with-tower`
 
-1. Create an account and log in to Tower.
+1.  Create an account and log in to Tower.
 
-2. Create a new token. You can access your tokens from the **Settings** drop-down menu:
+1.  Create a new token. You can access your tokens from the **Settings** drop-down menu:
 
    ![](./_images/usage_create_token.png)
 
-3. Name your token.
+1.  Name your token.
 
    ![](./_images/usage_name_token.png)
 
-4. Store your token securely.
+1.  Store your token securely.
 
    ![](./_images/usage_token.png)
 
@@ -43,7 +43,7 @@ See [CLI](../cli.mdx).
 The token will only be displayed once. You must copy and save the token before closing the Personal Access Token window.
 :::
 
-5. Open a terminal and enter the following commands:
+1.  Open a terminal and enter the following commands:
 
    ```bash
    export TOWER_ACCESS_TOKEN=eyxxxxxxxxxxxxxxxQ1ZTE=
@@ -64,7 +64,7 @@ export TOWER_WORKSPACE_ID=000000000000000
 The workspace ID can be found on the organization workspaces overview page.
 :::
 
-6. Run your Nextflow pipeline with the `-with-tower` flag:
+1.  Run your Nextflow pipeline with the `-with-tower` flag:
 
    ```bash
    nextflow run hello.nf -with-tower

--- a/platform_versioned_docs/version-23.2.0/git/overview.mdx
+++ b/platform_versioned_docs/version-23.2.0/git/overview.mdx
@@ -39,13 +39,13 @@ All credentials are (AES-256) encrypted before secure storage and are not expose
 
 When your Tower instance has multiple stored credentials, selection of the most relevant credential for your repository takes precedence in the following order:
 
-1. Tower evaluates all the stored credentials available to the current Workspace.
+1.  Tower evaluates all the stored credentials available to the current Workspace.
 
-2. Credentials are filtered by Git provider (GitHub, GitLab, Bitbucket, etc.)
+1.  Credentials are filtered by Git provider (GitHub, GitLab, Bitbucket, etc.)
 
-3. Tower selects the credential with a **Repository base URL** most similar to the target repository.
+1.  Tower selects the credential with a **Repository base URL** most similar to the target repository.
 
-4. If no **Repository base URL** values are specified in the Workspace credentials, the the most long-lived credential is selected.
+1.  If no **Repository base URL** values are specified in the Workspace credentials, the the most long-lived credential is selected.
 
 **Example**:
 
@@ -91,17 +91,17 @@ You can authenticate to Azure Devops repositories using a [personal access token
 
 Once you have created and copied your access token, create a new credential in Tower using these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "Azure DevOps" as the **Provider**.
+1.  Select "Azure DevOps" as the **Provider**.
 
-5. Enter your **Username** and **Access token**.
+1.  Enter your **Username** and **Access token**.
 
-6. Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://dev.azure.com/{your organization}/{your project}`.
+1.  Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://dev.azure.com/{your organization}/{your project}`.
 
 ### GitHub
 
@@ -117,17 +117,17 @@ For **fine-grained** tokens, the repository's organization must [opt in](https:/
 
 Once you have created and copied your access token, create a new credential in Tower using these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "GitHub" as the **Provider**.
+1.  Select "GitHub" as the **Provider**.
 
-5. Enter your **Username** and **Access token**.
+1.  Enter your **Username** and **Access token**.
 
-6. Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://github.com/seqeralabs`.
+1.  Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://github.com/seqeralabs`.
 
 ### GitLab
 
@@ -135,19 +135,19 @@ GitLab supports [Personal](https://docs.gitlab.com/ee/user/profile/personal_acce
 
 To connect Tower to a private [GitLab](https://gitlab.com/) repository:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "GitLab" as the **Provider**.
+1.  Select "GitLab" as the **Provider**.
 
-5. Enter your **Username**. For Group and Project access tokens, the username can be any non-empty value.
+1.  Enter your **Username**. For Group and Project access tokens, the username can be any non-empty value.
 
-6. Enter your token value in the **Password** and **Access token** fields.
+1.  Enter your token value in the **Password** and **Access token** fields.
 
-7. Enter the **Repository base URL** (recommended). This option is used to apply the credentials to a specific repository, e.g. `https://gitlab.com/seqeralabs`.
+1.  Enter the **Repository base URL** (recommended). This option is used to apply the credentials to a specific repository, e.g. `https://gitlab.com/seqeralabs`.
 
 ### Gitea
 
@@ -155,51 +155,51 @@ To connect Tower to a private [GitLab](https://gitlab.com/) repository:
 
 To connect to a private [Gitea](https://gitea.io/) repository, supply your Gitea user credentials to create a new credential in Tower with these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "Gitea" as the **Provider**.
+1.  Select "Gitea" as the **Provider**.
 
-5. Enter your **Username**.
+1.  Enter your **Username**.
 
-6. Enter your **Password**.
+1.  Enter your **Password**.
 
-7. Enter your **Repository base URL** (required).
+1.  Enter your **Repository base URL** (required).
 
 ### Bitbucket
 
 To connect to a private BitBucket repository, refer to the [BitBucket documentation](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) to learn how to create a BitBucket App password. Then, create a new credential in Tower using these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "BitBucket" as the **Provider**.
+1.  Select "BitBucket" as the **Provider**.
 
-5. Enter your **Username** and **Password**.
+1.  Enter your **Username** and **Password**.
 
-6. Enter the **Repository base URL** (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://bitbucket.org/seqeralabs`.
+1.  Enter the **Repository base URL** (recommended). This option can be used to apply the provided credentials to a specific repository, e.g. `https://bitbucket.org/seqeralabs`.
 
 ### AWS CodeCommit
 
 To connect to a private AWS CodeCommit repository, refer to the [AWS documentation](https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-iam-identity-based-access-control.html) to learn more about IAM permissions for CodeCommit. Then, supply the IAM account access key and secret key to create a credential in Tower using these steps:
 
-1. Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
+1.  Navigate to the **Credentials** tab. If you are using your personal workspace, select **Your credentials** from the user icon menu (top right).
 
-2. Select **Add Credentials**.
+1.  Select **Add Credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select "CodeCommit" as the **Provider**.
+1.  Select "CodeCommit" as the **Provider**.
 
-5. Enter the **Access key** and **Secret key** of the AWS IAM account that will be used to access the desired CodeCommit repository.
+1.  Enter the **Access key** and **Secret key** of the AWS IAM account that will be used to access the desired CodeCommit repository.
 
-6. Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific region, e.g. `https://git-codecommit.eu-west-1.amazonaws.com`.
+1.  Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the provided credentials to a specific region, e.g. `https://git-codecommit.eu-west-1.amazonaws.com`.
 
 ### Self-hosted Git
 

--- a/platform_versioned_docs/version-23.2.0/labels/overview.mdx
+++ b/platform_versioned_docs/version-23.2.0/labels/overview.mdx
@@ -49,6 +49,7 @@ Apply a label to a workflow run when launching a workflow run, on the workflow r
 ![](./_images/launch_labels.png)
 
 ### Search and filter with labels
+
 Search and filter pipelines and workflow runs using one or more labels.
 Filter and search are complementary.
 

--- a/platform_versioned_docs/version-23.2.0/launch/launch.mdx
+++ b/platform_versioned_docs/version-23.2.0/launch/launch.mdx
@@ -11,23 +11,23 @@ The **Launch Form** can be used for launching pipelines and for adding pipelines
 
 To launch a pipeline:
 
-1. Select **Start Quick Launch** in the navigation bar. The Launch Form will appear.
+1.  Select **Start Quick Launch** in the navigation bar. The Launch Form will appear.
 
-2. Select a **Compute Environment** from the available options.
+1.  Select a **Compute Environment** from the available options.
 
    Visit the [Compute Environment](../compute-envs/overview.mdx) documentation to learn how to create an environment for your preferred execution platform.
 
-3. Enter a repository URL for the **Pipeline to launch** (e.g. `https://github.com/nf-core/rnaseq.git`).
+1.  Enter a repository URL for the **Pipeline to launch** (e.g. `https://github.com/nf-core/rnaseq.git`).
 
 :::tip
 Nextflow pipelines are just Git repositories and they can reside on any public or private Git-hosting platform. See [Git Integration](../git/overview.mdx) in the Tower docs and [Pipeline Sharing](https://www.nextflow.io/docs/latest/sharing.html) in the Nextflow docs for more details.
 :::
 
-4. You can select a **Revision number** to use a specific version of the pipeline.
+1.  You can select a **Revision number** to use a specific version of the pipeline.
 
    The Git default branch (e.g. `main` or `master`) or `manifest.defaultBranch` in the Nextflow configuration will be used by default.
 
-5. Enter the **Work directory**, which corresponds to the Nextflow work directory.
+1.  Enter the **Work directory**, which corresponds to the Nextflow work directory.
 
    The default work directory of the compute environment will be used by default.
 
@@ -35,11 +35,11 @@ Nextflow pipelines are just Git repositories and they can reside on any public o
 The credentials associated with the compute environment must be able to access the work directory (e.g. an S3 bucket).
 :::
 
-6.  Select any **Config profiles** you would like to use.
+1.  Select any **Config profiles** you would like to use.
 
     Visit the Nextflow [Config profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) documentation for more details.
 
-7.  Enter any **Pipeline parameters** in YAML or JSON format.
+1.  Enter any **Pipeline parameters** in YAML or JSON format.
 
         YAML example:
         ```yaml
@@ -51,4 +51,4 @@ The credentials associated with the compute environment must be able to access t
 In YAML, quotes should be used for paths but not for numbers or Booleans.
 :::
 
-8.  Select **Launch** to launch the pipeline.
+1.  Select **Launch** to launch the pipeline.

--- a/platform_versioned_docs/version-23.2.0/orgs-and-teams/organizations.mdx
+++ b/platform_versioned_docs/version-23.2.0/orgs-and-teams/organizations.mdx
@@ -13,17 +13,17 @@ Organizations are the top-level structure and contain Workspaces, Members, Teams
 
 To create a new organization:
 
-1. Navigate to [Your organizations](https://tower.nf/orgs) and select **Add Organization**.
+1.  Navigate to [Your organizations](https://tower.nf/orgs) and select **Add Organization**.
 
-2. Enter a **Name** and **Full name** for your organization.
+1.  Enter a **Name** and **Full name** for your organization.
 
 :::caution
 The organization name must follow a specific pattern. Refer to the UI for guidance.
 :::
 
-3. Enter any other optional fields as needed: **Description**, **Location**, **Website URL** and **Logo**.
+1.  Enter any other optional fields as needed: **Description**, **Location**, **Website URL** and **Logo**.
 
-4. Select **Add**.
+1.  Select **Add**.
 
 You can view the list of all **Members**, **Teams**, and **Collaborators** in an organization on the organization's page. You can also edit any of the optional fields by selecting **Edit** from the [organizations page](https://tower.nf/orgs) or by selecting the **Settings** tab from the organization's page, provided that you are an **Owner** of the organization.
 
@@ -41,9 +41,9 @@ Tower provides access control for members of an organization by classifying them
 
 To add a new member to an organization:
 
-1. Go to the **Members** tab of the organization menu
-2. Click on **Invite member**
-3. Enter the email ID of user you'd like to add to the organization
+1.  Go to the **Members** tab of the organization menu
+1.  Click on **Invite member**
+1.  Enter the email ID of user you'd like to add to the organization
 
 An e-mail invitiation will be sent which needs to be accepted by the user. Once they accept the invitation, they can switch to the organization (or organization workspace) using their workspace dropdown.
 
@@ -65,9 +65,9 @@ New collaborators to an organization's workspace can be added using **Participan
 
 To create a new team within an organization:
 
-1. Go to the **Teams** tab of the organization menu
-2. Click on **New team**
-3. Enter the **Name** of team
-4. Optionally, add the **Description** and the team's **Avatar**
-5. For the newly created team, click on **View**
-6. Click on **Add team member** and type in the name of the organization members or collaborators
+1.  Go to the **Teams** tab of the organization menu
+1.  Click on **New team**
+1.  Enter the **Name** of team
+1.  Optionally, add the **Description** and the team's **Avatar**
+1.  For the newly created team, click on **View**
+1.  Click on **Add team member** and type in the name of the organization members or collaborators

--- a/platform_versioned_docs/version-23.2.0/orgs-and-teams/workspace-management.mdx
+++ b/platform_versioned_docs/version-23.2.0/orgs-and-teams/workspace-management.mdx
@@ -19,12 +19,12 @@ A workspace participant may be a member of the workspace organization or a colla
 
 Organization owners and admins can create a new workspace within an organization:
 
-1. Go to the **Workspaces** tab of the organization page.
-2. Select **Add Workspace**.
-3. Enter the **Name** and **Full name** for the workspace.
-4. Optionally, add a **Description** for the workspace.
-5. Under **Visibility**, select either **Private** or **Shared**. Private visibility means that workspace pipelines are only accessible to workspace participants.
-6. Select **Add**.
+1.  Go to the **Workspaces** tab of the organization page.
+1.  Select **Add Workspace**.
+1.  Enter the **Name** and **Full name** for the workspace.
+1.  Optionally, add a **Description** for the workspace.
+1.  Under **Visibility**, select either **Private** or **Shared**. Private visibility means that workspace pipelines are only accessible to workspace participants.
+1.  Select **Add**.
 
 :::tip
 Optional workspace fields can be modified after workspace creation, either by using the **Edit** option on the workspace listing for an organization or by accessing the **Settings** tab within the workspace page, provided that you are the **Owner** of the workspace.
@@ -36,10 +36,10 @@ Apart from the **Participants** tab, the organization workspace is similar to th
 
 To add a new participant to a workspace:
 
-1. Go to the **Participants** tab in the workspace menu.
-2. Select **Add participant**.
-3. Enter the **Name** of the new participant.
-4. Optionally, update the participant **role**. For more information on **roles**, see [participant roles](#participant-roles).
+1.  Go to the **Participants** tab in the workspace menu.
+1.  Select **Add participant**.
+1.  Enter the **Name** of the new participant.
+1.  Optionally, update the participant **role**. For more information on **roles**, see [participant roles](#participant-roles).
 
 :::tip
 A new workspace participant can be an existing organization member, team, or collaborator.
@@ -55,15 +55,15 @@ It is also possible to group **members** and **collaborators** into **teams** an
 
 There are five roles available for every workspace participant.
 
-1. **Owner**: The participant has full permissions for all resources within the workspace, including the workspace settings.
+1.  **Owner**: The participant has full permissions for all resources within the workspace, including the workspace settings.
 
-2. **Admin**: The participant has full permissions for resources associated with the workspace. They can create, modify, and delete pipelines, compute environments, actions, and credentials. They can add or remove users from the workspace but cannot access the workspace settings.
+1.  **Admin**: The participant has full permissions for resources associated with the workspace. They can create, modify, and delete pipelines, compute environments, actions, and credentials. They can add or remove users from the workspace but cannot access the workspace settings.
 
-3. **Maintain**: The participant can launch pipelines and modify pipeline executions (e.g., they can change the pipeline launch compute environments, parameters, pre/post-run scripts, and Nextflow configuration) and create new pipelines in the Launchpad. Users with maintain permissions cannot modify compute environments and credentials.
+1.  **Maintain**: The participant can launch pipelines and modify pipeline executions (e.g., they can change the pipeline launch compute environments, parameters, pre/post-run scripts, and Nextflow configuration) and create new pipelines in the Launchpad. Users with maintain permissions cannot modify compute environments and credentials.
 
-4. **Launch**: The participant can launch pipelines and modify the pipeline input/output parameters in the Launchpad. They cannot modify the launch configuration or other resources.
+1.  **Launch**: The participant can launch pipelines and modify the pipeline input/output parameters in the Launchpad. They cannot modify the launch configuration or other resources.
 
-5. **View**: The participant can view workspace pipelines and runs in read-only mode.
+1.  **View**: The participant can view workspace pipelines and runs in read-only mode.
 
 ### Workspace run monitoring
 

--- a/platform_versioned_docs/version-23.2.0/pipeline-actions/overview.mdx
+++ b/platform_versioned_docs/version-23.2.0/pipeline-actions/overview.mdx
@@ -17,19 +17,19 @@ A **GitHub webhook** listens for any changes made in the pipeline repository. Wh
 
 To create a new **Pipeline action**, select the **Actions** tab and select **Add Action**.
 
-1. Enter a **Name** for your Action.
+1.  Enter a **Name** for your Action.
 
-2. Select **GitHub webhook** as the **Event source**.
+1.  Select **GitHub webhook** as the **Event source**.
 
    ![](./_images/actions_githook.png)
 
-3. Select the **Compute environment** where the pipeline will be executed.
+1.  Select the **Compute environment** where the pipeline will be executed.
 
-4. Select the **Pipeline to launch** and (optionally) the **Revision number**.
+1.  Select the **Pipeline to launch** and (optionally) the **Revision number**.
 
-5. Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
+1.  Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
 
-6. Select **Add**.
+1.  Select **Add**.
 
    ![](./_images/actions_params.png)
 
@@ -43,19 +43,19 @@ A **Tower launch hook** creates a custom endpoint URL which can be used to trigg
 
 To create a new **Pipeline action**, select the **Actions** tab and select **Add Action**.
 
-1. Enter a **Name** for your Action.
+1.  Enter a **Name** for your Action.
 
-2. Select **Tower launch hook** as the event source.
+1.  Select **Tower launch hook** as the event source.
 
    ![](./_images/actions_tower_hook.png)
 
-3. Select the **Compute environment** to execute your pipeline.
+1.  Select the **Compute environment** to execute your pipeline.
 
-4. Enter the **Pipeline to launch** and (optionally) the **Revision number**.
+1.  Enter the **Pipeline to launch** and (optionally) the **Revision number**.
 
-5. Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
+1.  Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
 
-6. Select **Add**.
+1.  Select **Add**.
 
    ![](./_images/actions_tower_hook_params.png)
 

--- a/platform_versioned_docs/version-23.2.0/reports/overview.mdx
+++ b/platform_versioned_docs/version-23.2.0/reports/overview.mdx
@@ -27,8 +27,8 @@ Users can download a report directly from Tower or using the path. Download is n
 
 To render reports users need to create a Tower config file that defines the paths to a selection of output files published by the pipeline. There are 2 ways users can provide the Tower config file both of which have to be in YAML format:
 
-1. **Pipeline repository**: If a file called _tower.yml_ exists in the root of the pipeline repository then this will be fetched automatically before the pipeline execution.,
-2. **Tower UI**: Providing the YAML definition within the _Advanced options > Tower config file_ box when:
+1.  **Pipeline repository**: If a file called _tower.yml_ exists in the root of the pipeline repository then this will be fetched automatically before the pipeline execution.,
+1.  **Tower UI**: Providing the YAML definition within the _Advanced options > Tower config file_ box when:
    1.Creating a Pipeline in the Launchpad
    2.Amending the Launch settings when launching a Pipeline. Users with _Maintain_ role only.
 

--- a/platform_versioned_docs/version-23.2.0/resource-labels/overview.mdx
+++ b/platform_versioned_docs/version-23.2.0/resource-labels/overview.mdx
@@ -107,15 +107,15 @@ The [`forge-policy.json`](https://github.com/seqeralabs/nf-tower-aws/blob/master
 
 To view and manage the resource labels applied to AWS resources by Tower and Nextflow, navigate to the [AWS Tag Editor](https://docs.aws.amazon.com/tag-editor/latest/userguide/find-resources-to-tag.html)(as an administrative user) and follow these steps:
 
-1. Under **Find resources to tag**, search for the resource label key and value in the relevant search fields under **Tags**. Your search can be further refined by AWS region and resource type. Then select **Search resources**.
+1.  Under **Find resources to tag**, search for the resource label key and value in the relevant search fields under **Tags**. Your search can be further refined by AWS region and resource type. Then select **Search resources**.
 
-2. **Resource search results** displays all the resources tagged with your given resource label key and/or value.
+1.  **Resource search results** displays all the resources tagged with your given resource label key and/or value.
 
 To include the cost information associated with your resource labels in your AWS billing reports, follow these steps:
 
-1. You need to [activate](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activating-tags.html) the associated tags in the **AWS Billing and Cost Management console**. Note that newly-applied tags may take up to 24 hours to appear on your cost allocation tags page.
+1.  You need to [activate](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activating-tags.html) the associated tags in the **AWS Billing and Cost Management console**. Note that newly-applied tags may take up to 24 hours to appear on your cost allocation tags page.
 
-2. Once your tags are activated and displayed on your **Cost allocation tags** page in the Billing and Cost Management console, you can apply those tags when creating [cost allocation reports](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/configurecostallocreport.html#allocation-viewing).
+1.  Once your tags are activated and displayed on your **Cost allocation tags** page in the Billing and Cost Management console, you can apply those tags when creating [cost allocation reports](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/configurecostallocreport.html#allocation-viewing).
 
 #### AWS limits
 

--- a/platform_versioned_docs/version-23.2.0/supported_software/agent/agent.mdx
+++ b/platform_versioned_docs/version-23.2.0/supported_software/agent/agent.mdx
@@ -16,22 +16,22 @@ jobs. The jobs are submitted on behalf of the user running the agent.
 
 Tower Agent is distributed as a single executable file to simply download and execute.
 
-1. Download the latest release from [Github](https://github.com/seqeralabs/tower-agent) and make the file executable:
+1.  Download the latest release from [Github](https://github.com/seqeralabs/tower-agent) and make the file executable:
 
    ```bash
    curl -fSL https://github.com/seqeralabs/tower-agent/releases/latest/download/tw-agent-linux-x86_64 > tw-agent
    chmod +x ./tw-agent
    ```
 
-2. (Optional) Move it to a folder that is in your $PATH.
+1.  (Optional) Move it to a folder that is in your $PATH.
 
 ### Quickstart
 
 Before running the Agent:
 
-1. Create a [**personal access token**](../../api/overview.mdx#authentication) in Tower.
+1.  Create a [**personal access token**](../../api/overview.mdx#authentication) in Tower.
 
-2. Create **Tower Agent** credentials in a Tower workspace. See [here](../../credentials/overview.mdx) for more instructions.
+1.  Create **Tower Agent** credentials in a Tower workspace. See [here](../../credentials/overview.mdx) for more instructions.
 
 :::note
 To share a single Tower Agent instance with all members of a workspace, create a Tower Agent credential with **Shared agent** enabled.

--- a/platform_versioned_docs/version-23.2.0/supported_software/dragen/overview.mdx
+++ b/platform_versioned_docs/version-23.2.0/supported_software/dragen/overview.mdx
@@ -27,9 +27,9 @@ To deploy the pipeline on your own AWS cloud infrastructure, please follow the i
 
 DRAGEN is a commercial technology provided by Illumina, so you will need to purchase a license from them. To run on Tower, you will need to obtain the following information from Illumina:
 
-1. DRAGEN AWS private AMI ID
-2. DRAGEN license username
-3. DRAGEN license password
+1.  DRAGEN AWS private AMI ID
+1.  DRAGEN license username
+1.  DRAGEN license password
 
 Batch Forge automates most of the tasks required to set up an AWS Batch Compute Environment. Please follow [our guide](../../compute-envs/aws-batch.mdx) for more details.
 
@@ -47,7 +47,7 @@ Please ensure that the Region you select contains DRAGEN F1 instances.
 
 Please see the [dragen.nf](https://github.com/seqeralabs/nf-dragen/blob/master/modules/local/dragen.nf) module implemented in the [nf-dragen](https://github.com/seqeralabs/nf-dragen) pipeline for reference. Any Nextflow processes that run DRAGEN must:
 
-1. Define `label ‘dragen’`
+1.  Define `label ‘dragen’`
 
    The `label` directive allows you to annotate a process with mnemonic identifiers of your choice. Tower will use the `dragen` label to determine which processes need to be executed on DRAGEN F1 instances.
 
@@ -61,7 +61,7 @@ Please see the [dragen.nf](https://github.com/seqeralabs/nf-dragen/blob/master/m
 
    Please refer to the [Nextflow label docs](https://www.nextflow.io/docs/latest/process.html?highlight=label#label) for more information.
 
-2. Define Secrets
+1.  Define Secrets
 
    At Seqera, we use Secrets to safely encrypt sensitive information when running licensed software via Nextflow. This enables our team to use the DRAGEN software safely via the `nf-dragen` pipeline without having to worry about the setup or safe configuration of the license key. These Secrets will be provided securely to the `--lic-server` option when running DRAGEN on the CLI to validate the license.
 

--- a/platform_versioned_docs/version-23.2.0/supported_software/fusion/fusion.mdx
+++ b/platform_versioned_docs/version-23.2.0/supported_software/fusion/fusion.mdx
@@ -31,11 +31,11 @@ Fusion v2 improves pipeline throughput for containerized tasks by simplifying di
 
 We recommend using Fusion with AWS NVMe instances (fast instance storage) as this delivers the fastest performance when compared to environments using only AWS EBS (Elastic Block Store).
 
-1. For this configuration, use Tower version 23.1 or later.
-2. Create an [AWS Batch compute environment](https://help.tower.nf/latest/compute-envs/aws-batch/#tower-forge).
-3. Enable Wave containers, Fusion v2, and fast instance storage.
-4. Select the **Batch Forge** config mode.
-5. Select your **Instance types** under Advanced options:
+1.  For this configuration, use Tower version 23.1 or later.
+1.  Create an [AWS Batch compute environment](https://help.tower.nf/latest/compute-envs/aws-batch/#tower-forge).
+1.  Enable Wave containers, Fusion v2, and fast instance storage.
+1.  Select the **Batch Forge** config mode.
+1.  Select your **Instance types** under Advanced options:
    - If left unspecified, Tower will select the following NVMe-based instance type families: `'c5ad', 'c5d', 'c6id', 'i3', 'i4i', 'm5ad', 'm5d', 'm6id', 'r5ad', 'r5d', 'r6id'`
    - To specify an NVMe instance family type, select from the following:
      - Intel: `'c5ad', 'c5d', 'c6id', 'dl1', 'f1', 'g4ad', 'g4dn', 'g5', 'i3', 'i3en', 'i4i', 'm5ad', 'm5d', 'm5dn', 'm6id', 'p3dn', 'p4d', 'p4de', 'r5ad', 'r5d', 'r5dn', 'r6id', 'x2idn', 'x2iedn', 'z1d'`
@@ -49,17 +49,17 @@ When enabling fast instance storage, do not select the `optimal` instance type f
 We recommend selecting 8xlarge or above for large and long-lived production pipelines. Dedicated networking ensures a guaranteed network speed service level compared with "burstable" instances. See [Instance network bandwidth](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-network-bandwidth.html) for more information.
 :::
 
-6. Use an S3 bucket as the pipeline work directory.
+1.  Use an S3 bucket as the pipeline work directory.
 
 #### Batch Forge AWS compute environments with Fusion only
 
 To use Fusion in AWS environments without NVMe instances, enable Wave containers and Fusion v2 when creating a new compute environment without enabling fast instance storage. This option configures an AWS EBS (Elastic Bucket Store) disk with settings optimized for the Fusion file system.
 
-1. For this configuration, use Tower version 23.1 or later.
-2. Create an [AWS Batch compute environment](https://help.tower.nf/latest/compute-envs/aws-batch/#tower-forge).
-3. Enable Wave containers and Fusion v2.
-4. Select the **Batch Forge** config mode.
-5. When you enable Fusion v2 without fast instance storage, the following settings are applied:
+1.  For this configuration, use Tower version 23.1 or later.
+1.  Create an [AWS Batch compute environment](https://help.tower.nf/latest/compute-envs/aws-batch/#tower-forge).
+1.  Enable Wave containers and Fusion v2.
+1.  Select the **Batch Forge** config mode.
+1.  When you enable Fusion v2 without fast instance storage, the following settings are applied:
 
    - `process.scratch = false` is added to the Nextflow configuration file
    - EBS autoscaling is disabled
@@ -67,7 +67,7 @@ To use Fusion in AWS environments without NVMe instances, enable Wave containers
    - EBS boot disk type is changed to GP3
    - EBS boot disk throughput is increased to 325MB/s
 
-6. Use an S3 bucket as the pipeline work directory.
+1.  Use an S3 bucket as the pipeline work directory.
 
 #### Fusion in manual compute environments
 

--- a/platform_versioned_docs/version-23.3.0/compute-envs/aws-batch.mdx
+++ b/platform_versioned_docs/version-23.3.0/compute-envs/aws-batch.mdx
@@ -11,8 +11,8 @@ This guide assumes you have an existing [Amazon Web Service (AWS)](https://aws.a
 
 There are two ways to create a Seqera Platform compute environment for AWS Batch:
 
-1. [**Batch Forge**](#tower-forge): This option automatically creates the AWS Batch resources in your AWS account. This eliminates the need to set up your AWS Batch infrastructure manually.
-2. [**Manual**](#manual): This option allows Seqera to use existing AWS Batch resources.
+1.  [**Batch Forge**](#tower-forge): This option automatically creates the AWS Batch resources in your AWS account. This eliminates the need to set up your AWS Batch infrastructure manually.
+1.  [**Manual**](#manual): This option allows Seqera to use existing AWS Batch resources.
 
 ## Batch Forge
 
@@ -28,32 +28,32 @@ We recommend that you create separate IAM policies for Batch Forge and launch pe
 
 **Create Seqera IAM policies**
 
-1. Open the [AWS IAM console](https://console.aws.amazon.com/iam).
-2. From the left navigation menu, select **Policies** under **Access management**.
-3. Select **Create policy**.
-4. On the **Create policy** page, select the **JSON** tab.
-5. Copy the contents of your policy JSON file ([Forge](https://github.com/seqeralabs/nf-tower-aws/blob/master/forge/forge-policy.json) or [Launch](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/launch-policy.json), depending on the policy being created) and replace the default text in the policy editor area under the JSON tab. To create a Launch user, you must also create the [S3 bucket write policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) separately to attach to your Launch user.
-6. Select **Next: Tags**.
-7. Select **Next: Review**.
-8. Enter a name and description for the policy on the **Review policy** page, then select **Create policy**.
-9. Repeat these steps for both the `forge-policy.json` and `launch-policy.json` files. For a Launch user, also create the `s3-bucket-write-policy.json` listed in step 5 above.
+1.  Open the [AWS IAM console](https://console.aws.amazon.com/iam).
+1.  From the left navigation menu, select **Policies** under **Access management**.
+1.  Select **Create policy**.
+1.  On the **Create policy** page, select the **JSON** tab.
+1.  Copy the contents of your policy JSON file ([Forge](https://github.com/seqeralabs/nf-tower-aws/blob/master/forge/forge-policy.json) or [Launch](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/launch-policy.json), depending on the policy being created) and replace the default text in the policy editor area under the JSON tab. To create a Launch user, you must also create the [S3 bucket write policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) separately to attach to your Launch user.
+1.  Select **Next: Tags**.
+1.  Select **Next: Review**.
+1.  Enter a name and description for the policy on the **Review policy** page, then select **Create policy**.
+1.  Repeat these steps for both the `forge-policy.json` and `launch-policy.json` files. For a Launch user, also create the `s3-bucket-write-policy.json` listed in step 5 above.
 
 **Create an IAM user**
 
-1. From the [AWS IAM console](https://console.aws.amazon.com/iam), select **Users** in the left navigation menu, then select **Add User** at the top right of the page.
-2. Enter a name for your user (e.g., _seqera_) and select the **Programmatic access** type.
-3. Select **Next: Permissions**.
-4. Select **Next: Tags > Next: Review > Create User**.
+1.  From the [AWS IAM console](https://console.aws.amazon.com/iam), select **Users** in the left navigation menu, then select **Add User** at the top right of the page.
+1.  Enter a name for your user (e.g., _seqera_) and select the **Programmatic access** type.
+1.  Select **Next: Permissions**.
+1.  Select **Next: Tags > Next: Review > Create User**.
 
 :::note
 For the time being, you can ignore the "user has no permissions" warning. Permissions will be applied using the **IAM Policy**.
 :::
 
-5. Save the **Access key ID** and **Secret access key** in a secure location as you will use these when creating credentials in Seqera.
-6. After you have saved the keys, select **Close**.
-7. Back in the users table, select the newly created user, then select **Add permissions** under the **Permissions** tab.
-8. Select **Attach existing policies**, then search for and select each of the policies created above.
-9. Select **Next: Review > Add permissions**.
+1.  Save the **Access key ID** and **Secret access key** in a secure location as you will use these when creating credentials in Seqera.
+1.  After you have saved the keys, select **Close**.
+1.  Back in the users table, select the newly created user, then select **Add permissions** under the **Permissions** tab.
+1.  Select **Attach existing policies**, then search for and select each of the policies created above.
+1.  Select **Next: Review > Add permissions**.
 
 ### S3 Bucket
 
@@ -61,17 +61,17 @@ S3 (Simple Storage Service) is a type of **object storage**. To access files and
 
 **Create an S3 bucket**
 
-1. Navigate to the [S3 service](https://console.aws.amazon.com/s3/home).
-2. Select **Create New Bucket**.
-3. Enter a unique name for your bucket and select a region.
+1.  Navigate to the [S3 service](https://console.aws.amazon.com/s3/home).
+1.  Select **Create New Bucket**.
+1.  Enter a unique name for your bucket and select a region.
 
 :::note
 To maximize data transfer resilience and minimize cost, storage should be in the same region as compute.
 :::
 
-4. Select the default options in **Configure options**.
-5. Select the default options in **Set permissions**.
-6. Review and select **Create bucket**.
+1.  Select the default options in **Configure options**.
+1.  Select the default options in **Set permissions**.
+1.  Review and select **Create bucket**.
 
 :::note
 S3 is used by Nextflow for the storage of intermediate files. In production pipelines, this can amount to a lot of data. To reduce costs, consider using a retention policy when creating a bucket, such as automatically deleting intermediate files after 30 days. See [here](https://aws.amazon.com/premiumsupport/knowledge-center/s3-empty-bucket-lifecycle-rule/) for more information.
@@ -83,32 +83,32 @@ Batch Forge automates the configuration of an [AWS Batch](https://aws.amazon.com
 
 **Create a Batch Forge AWS Batch compute environment**
 
-1. In a workspace, select **Compute environments > New environment**.
-2. Enter a descriptive name for this environment, e.g., _AWS Batch Spot (eu-west-1)_.
-3. Select **AWS Batch** as the target platform.
-4. From the **Credentials** drop-down, select existing AWS credentials, or select **+** to add new credentials. If you're using existing credentials, skip to step 8.
+1.  In a workspace, select **Compute environments > New environment**.
+1.  Enter a descriptive name for this environment, e.g., _AWS Batch Spot (eu-west-1)_.
+1.  Select **AWS Batch** as the target platform.
+1.  From the **Credentials** drop-down, select existing AWS credentials, or select **+** to add new credentials. If you're using existing credentials, skip to step 8.
 
 :::note
 You can create multiple credentials in your Seqera environment. See [Credentials](../credentials/overview.mdx).
 :::
 
-5. Enter a name, e.g., _AWS Credentials_.
-6. Add the **Access key** and **Secret key**. These are the keys you saved previously when you created the Seqera IAM user.
-7. (Optional) Under **Assume role**, specify the IAM role to be assumed by the Seqera IAM user to access the compute environment's AWS resources.
+1.  Enter a name, e.g., _AWS Credentials_.
+1.  Add the **Access key** and **Secret key**. These are the keys you saved previously when you created the Seqera IAM user.
+1.  (Optional) Under **Assume role**, specify the IAM role to be assumed by the Seqera IAM user to access the compute environment's AWS resources.
 
 :::note
 When using AWS keys without an assumed role, the associated AWS user account must have [Launch](https://github.com/seqeralabs/nf-tower-aws/tree/master/launch) and [Forge](https://github.com/seqeralabs/nf-tower-aws/tree/master/forge) permissions. When an assumed role is provided, the keys are only used to retrieve temporary credentials impersonating the role specified. In this case, [Launch](https://github.com/seqeralabs/nf-tower-aws/tree/master/launch) and [Forge](https://github.com/seqeralabs/nf-tower-aws/tree/master/forge) permissions must be granted to the role instead of the user account.
 :::
 
-8. Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
-9. Enter your S3 bucket path in the **Pipeline work directory** field, e.g., `s3://seqera-bucket`. This bucket must be in the same region chosen in the previous step.
+1.  Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
+1.  Enter your S3 bucket path in the **Pipeline work directory** field, e.g., `s3://seqera-bucket`. This bucket must be in the same region chosen in the previous step.
 
     :::note
     When you specify an S3 bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. Seqera adds a `cloudcache` block to the Nextflow configuration file for all runs executed with this compute environment. This block includes the path to a `cloudcache` folder in your work directory, e.g., `s3://seqera-bucket/cloudcache/.cache`. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
     :::
 
-10. Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
-11. Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled. See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
+1.  Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
+1.  Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled. See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
 
 When using Fusion v2 without fast instance storage (see below), the following EBS settings are applied to optimize file system performance:
 
@@ -119,64 +119,64 @@ When using Fusion v2 without fast instance storage (see below), the following EB
 
 Extensive benchmarking of Fusion v2 has demonstrated that the increased cost associated with these settings are generally outweighed by the costs saved due to decreased run time.
 
-12. Select **Enable fast instance storage** to use NVMe instance storage to speed up I/O and disk access operations. NVMe instance storage requires Fusion v2 to be enabled.
+1.  Select **Enable fast instance storage** to use NVMe instance storage to speed up I/O and disk access operations. NVMe instance storage requires Fusion v2 to be enabled.
 
 :::note
 Fast instance storage requires an EC2 instance type that uses NVMe disks. Seqera validates any instance types you specify (from **Advanced options > Instance types**) during compute environment creation. If you do not specify an instance type, a standard EC2 instance with NVMe disks will be used (`'c5ad', 'c5d', 'c6id', 'i3', 'i4i', 'm5ad', 'm5d', 'm6id', 'r5ad', 'r5d', 'r6id'` EC2 instance families) for fast storage.
 :::
 
-13. Set the **Config mode** to **Batch Forge**.
-14. Select a **Provisioning model**. In most cases, this will be **Spot**. You can specify an allocation strategy and instance types under [**Advanced options**](#advanced-options). If advanced options are omitted, Seqera Platform 23.2 and later versions default to `BEST_FIT_PROGRESSIVE` for on-demand and `SPOT_CAPACITY_OPTIMIZED` for spot compute environments.
+1.  Set the **Config mode** to **Batch Forge**.
+1.  Select a **Provisioning model**. In most cases, this will be **Spot**. You can specify an allocation strategy and instance types under [**Advanced options**](#advanced-options). If advanced options are omitted, Seqera Platform 23.2 and later versions default to `BEST_FIT_PROGRESSIVE` for on-demand and `SPOT_CAPACITY_OPTIMIZED` for spot compute environments.
 
 :::note
 You can create a compute environment that launches either spot or on-demand instances. Spot instances can cost as little as 20% of on-demand instances, and with Nextflow's ability to automatically relaunch failed tasks, spot is almost always the recommended provisioning model. Note, however, that when choosing spot instances, Seqera will also create a dedicated queue for running the main Nextflow job using a single on-demand instance to prevent any execution interruptions.
 :::
 
-15. Enter the **Max CPUs**, e.g., `64`. This is the maximum number of combined CPUs (the sum of all instances' CPUs) AWS Batch will provision at any time.
-16. Select **EBS Auto scale** to allow the EC2 virtual machines to dynamically expand the amount of available disk space during task execution.
+1.  Enter the **Max CPUs**, e.g., `64`. This is the maximum number of combined CPUs (the sum of all instances' CPUs) AWS Batch will provision at any time.
+1.  Select **EBS Auto scale** to allow the EC2 virtual machines to dynamically expand the amount of available disk space during task execution.
 
 :::note
 When you run large AWS Batch clusters (hundreds of compute nodes or more), EC2 API rate limits may cause the deletion of unattached EBS volumes to fail. You should delete volumes that remain active after Nextflow jobs have completed to avoid additional costs. Monitor your AWS account for any orphaned EBS volumes via the EC2 console, or with a Lambda function. See [here](https://aws.amazon.com/blogs/mt/controlling-your-aws-costs-by-deleting-unused-amazon-ebs-volumes/) for more information.
 :::
 
-17. With the optional **Enable Fusion mounts (deprecated)** feature enabled, S3 buckets specified in **Pipeline work directory** and **Allowed S3 Buckets** are mounted as file system volumes in the EC2 instances carrying out the Batch job execution. These buckets can then be accessed at `/fusion/s3/<bucket-name>`. For example, if the bucket name is `s3://imputation-gp2`, your pipeline will access it using the file system path `/fusion/s3/imputation-gp2`. **Note:** This feature has been deprecated. Consider using Fusion v2 (see above) for enhanced performance and stability.
+1.  With the optional **Enable Fusion mounts (deprecated)** feature enabled, S3 buckets specified in **Pipeline work directory** and **Allowed S3 Buckets** are mounted as file system volumes in the EC2 instances carrying out the Batch job execution. These buckets can then be accessed at `/fusion/s3/<bucket-name>`. For example, if the bucket name is `s3://imputation-gp2`, your pipeline will access it using the file system path `/fusion/s3/imputation-gp2`. **Note:** This feature has been deprecated. Consider using Fusion v2 (see above) for enhanced performance and stability.
 
 :::note
 You do not need to modify your pipeline or files to take advantage of this feature. Nextflow will automatically recognize and replace any reference to files prefixed with `s3://` with the corresponding Fusion mount paths.
 :::
 
-18. Select **Enable Fargate for head job** to run the Nextflow head job with the [AWS Fargate](https://aws.amazon.com/fargate/) container service and speed up pipeline launch. Fargate is a serverless compute engine that enables users to run containers without the need to provision servers or clusters in advance. AWS takes a few minutes to spin up an EC2 instance, whereas jobs can be launched with Fargate in under a minute (depending on container size). We recommend Fargate for most pipeline deployments, but EC2 is more suitable for environments that use GPU instances, custom AMIs, or that require more than 16 vCPUs. If you specify a custom AMI ID in the [Advanced options](#advanced-options) below, this will not be applied to the Fargate-enabled head job. See [here](https://docs.aws.amazon.com/batch/latest/userguide/fargate.html#when-to-use-fargate) for more information on Fargate's limitations.
+1.  Select **Enable Fargate for head job** to run the Nextflow head job with the [AWS Fargate](https://aws.amazon.com/fargate/) container service and speed up pipeline launch. Fargate is a serverless compute engine that enables users to run containers without the need to provision servers or clusters in advance. AWS takes a few minutes to spin up an EC2 instance, whereas jobs can be launched with Fargate in under a minute (depending on container size). We recommend Fargate for most pipeline deployments, but EC2 is more suitable for environments that use GPU instances, custom AMIs, or that require more than 16 vCPUs. If you specify a custom AMI ID in the [Advanced options](#advanced-options) below, this will not be applied to the Fargate-enabled head job. See [here](https://docs.aws.amazon.com/batch/latest/userguide/fargate.html#when-to-use-fargate) for more information on Fargate's limitations.
 
 :::note
 Fargate requires the Fusion v2 file system and a **spot** provisioning model. Fargate is not compatible with EFS and FSx file systems.
 :::
 
-19. Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. See [GPU usage](./overview.mdx#aws-batch) for more information.
-20. Select **Use Graviton CPU architecture** to execute on Graviton-based EC2 instances (ARM64 CPU architecture). When enabled, `c6g` instance types are used by default for compute jobs. You can specify your own **Instance types** under [**Advanced options**](#advanced-options). Seqera Platform supports all AWS Batch-compatible Graviton2 and Graviton3 instance types.
+1.  Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. See [GPU usage](./overview.mdx#aws-batch) for more information.
+1.  Select **Use Graviton CPU architecture** to execute on Graviton-based EC2 instances (ARM64 CPU architecture). When enabled, `c6g` instance types are used by default for compute jobs. You can specify your own **Instance types** under [**Advanced options**](#advanced-options). Seqera Platform supports all AWS Batch-compatible Graviton2 and Graviton3 instance types.
 
     :::note
     Graviton requires Fargate, Wave containers, and Fusion v2 file system to be enabled. This feature is not compatible with GPU-based architecture.
     :::
 
-21. Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.
-22. To use **EFS**, you can either select **Use existing EFS file system** and specify an existing EFS instance, or select **Create new EFS file system** to create one. To use the EFS file system as your work directory, specify `<your_EFS_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
+1.  Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.
+1.  To use **EFS**, you can either select **Use existing EFS file system** and specify an existing EFS instance, or select **Create new EFS file system** to create one. To use the EFS file system as your work directory, specify `<your_EFS_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
 
 - To use an existing EFS file system, enter the **EFS file system id** and **EFS mount path**. This is the path where the EFS volume is accessible to the compute environment. For simplicity, we recommend that you use `/mnt/efs` as the EFS mount path.
 - To create a new EFS file system, enter the **EFS mount path**. We advise that you specify `/mnt/efs` as the EFS mount path.
 - EFS file systems created by Batch Forge are automatically tagged in AWS with `Name=TowerForge-<id>`, with `<id>` being the compute environment ID. Any manually-added resource label with the key `Name` (capital N) will override the automatically-assigned `TowerForge-<id>` label.
 
- 23. To use **FSx for Lustre**, you can either select **Use existing FSx file system** and specify an existing FSx instance, or select **Create new FSx file system** to create one. To use the FSx file system as your work directory, specify `<your_FSx_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
+ 23.  To use **FSx for Lustre**, you can either select **Use existing FSx file system** and specify an existing FSx instance, or select **Create new FSx file system** to create one. To use the FSx file system as your work directory, specify `<your_FSx_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
 
 - To use an existing FSx file system, enter the **FSx DNS name** and **FSx mount path**. The FSx mount path is the path where the FSx volume is accessible to the compute environment. For simplicity, we recommend that you use `/mnt/fsx` as the FSx mount path.
 - To create a new FSx file system, enter the **FSx size** (in GB) and the **FSx mount path**. We advise that you specify `/mnt/fsx` as the FSx mount path.
 - FSx file systems created by Batch Forge are automatically tagged in AWS with `Name=TowerForge-<id>`, with `<id>` being the compute environment ID. Any manually-added resource label with the key `Name` (capital N) will override the automatically-assigned `TowerForge-<id>` label.
 
-24. Select **Dispose resources** to automatically delete these AWS resources if you delete the compute environment in Seqera Platform.
-25. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-26. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-27. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
-28. Configure any advanced options described in the next section, as needed.
-29. Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before you are ready to [launch pipelines](../launch/launchpad.mdx).
+1.  Select **Dispose resources** to automatically delete these AWS resources if you delete the compute environment in Seqera Platform.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1.  Configure any advanced options described in the next section, as needed.
+1.  Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before you are ready to [launch pipelines](../launch/launchpad.mdx).
 
 ### Advanced options
 
@@ -244,11 +244,11 @@ Seqera can use S3 to store the intermediate files and output data generated by p
 
 **Assign an S3 access policy to Seqera IAM users**
 
-1. Go to the IAM User table in the [IAM service](https://console.aws.amazon.com/iam/home).
-2. Select the IAM user.
-3. Select **Add inline policy**.
-4. Copy the contents of [this policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) into the **JSON** tab. Replace `YOUR-BUCKET-NAME` (lines 10 and 21) with your bucket name.
-5. Name your policy and select **Create policy**.
+1.  Go to the IAM User table in the [IAM service](https://console.aws.amazon.com/iam/home).
+1.  Select the IAM user.
+1.  Select **Add inline policy**.
+1.  Copy the contents of [this policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) into the **JSON** tab. Replace `YOUR-BUCKET-NAME` (lines 10 and 21) with your bucket name.
+1.  Name your policy and select **Create policy**.
 
 ### Seqera manual compute environment
 
@@ -256,30 +256,30 @@ With your AWS environment and resources set up and your user permissions configu
 
 **Create a manual Seqera compute environment**
 
-1. In a workspace, select **Compute environments > New environment**.
-2. Enter a descriptive name for this environment, e.g., _AWS Batch Manual (eu-west-1)_.
-3. Select **AWS Batch** as the target platform.
-4. Select **+** to add new credentials.
-5. Enter a name for the credentials, e.g., _AWS Credentials_.
-6. Enter the **Access key** and **Secret key** for your IAM user.
+1.  In a workspace, select **Compute environments > New environment**.
+1.  Enter a descriptive name for this environment, e.g., _AWS Batch Manual (eu-west-1)_.
+1.  Select **AWS Batch** as the target platform.
+1.  Select **+** to add new credentials.
+1.  Enter a name for the credentials, e.g., _AWS Credentials_.
+1.  Enter the **Access key** and **Secret key** for your IAM user.
 
 :::note
 You can create multiple credentials in your Seqera environment. See [Credentials](../credentials/overview.mdx).
 :::
 
-7. Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
-8. Enter an S3 bucket path for the **Pipeline work directory**, e.g., `s3://seqera-bucket`. This bucket must be in the same region chosen in the previous step.
+1.  Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
+1.  Enter an S3 bucket path for the **Pipeline work directory**, e.g., `s3://seqera-bucket`. This bucket must be in the same region chosen in the previous step.
 
     :::note
     When you specify an S3 bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. Seqera adds a `cloudcache` block to the Nextflow configuration file for all runs executed with this compute environment. This block includes the path to a `cloudcache` folder in your work directory, e.g., `s3://seqera-bucket/cloudcache/.cache`. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
     :::
 
-9. Set the **Config mode** to **Manual**.
-10. Enter the **Head queue**, which is the name of the AWS Batch queue that the Nextflow main job will run.
-11. Enter the **Compute queue**, which is the name of the AWS Batch queue where tasks will be submitted.
-12. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
-13. Configure any advanced options described in the next section, as needed.
-14. Select **Create** to finalize the compute environment setup.
+1.  Set the **Config mode** to **Manual**.
+1.  Enter the **Head queue**, which is the name of the AWS Batch queue that the Nextflow main job will run.
+1.  Enter the **Compute queue**, which is the name of the AWS Batch queue where tasks will be submitted.
+1.  Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1.  Configure any advanced options described in the next section, as needed.
+1.  Select **Create** to finalize the compute environment setup.
 
 ### Advanced options
 

--- a/platform_versioned_docs/version-23.3.0/compute-envs/azure-batch.mdx
+++ b/platform_versioned_docs/version-23.3.0/compute-envs/azure-batch.mdx
@@ -37,11 +37,11 @@ A resource group in Azure is a unit of related resources in Azure. As a rule of 
 
 ### Create a resource group
 
-1. Log in to your Azure account, go to the [Create Resource group][az-create-rg] page, and select **Create new resource group**.
-2. Enter a name for the resource group, e.g., _towerrg_.
-3. Choose the preferred region.
-4. Select **Review and Create** to proceed.
-5. Select **Create**.
+1.  Log in to your Azure account, go to the [Create Resource group][az-create-rg] page, and select **Create new resource group**.
+1.  Enter a name for the resource group, e.g., _towerrg_.
+1.  Choose the preferred region.
+1.  Select **Review and Create** to proceed.
+1.  Select **Create**.
 
 ## Storage account
 
@@ -49,30 +49,30 @@ After creating a resource group, set up an [Azure storage account][az-learn-stor
 
 ### Create a storage account
 
-1. Log in to your Azure account, go to the [Create storage account][az-create-storage] page, and select **Create a storage account**.
+1.  Log in to your Azure account, go to the [Create storage account][az-create-storage] page, and select **Create a storage account**.
 
     :::note
     If you haven't created a resource group, you can do so now.
     :::
 
-2. Enter a name for the storage account (e.g., _towerrgstorage_).
-3. Choose the preferred region (same as the Batch account).
-4. The platform supports any performance or redundancy settings — select the most appropriate settings for your use case.
-5. Select **Next: Advanced**.
-6. Enable _storage account key access_.
-7. Select **Next: Networking**.
+1.  Enter a name for the storage account (e.g., _towerrgstorage_).
+1.  Choose the preferred region (same as the Batch account).
+1.  The platform supports any performance or redundancy settings — select the most appropriate settings for your use case.
+1.  Select **Next: Advanced**.
+1.  Enable _storage account key access_.
+1.  Select **Next: Networking**.
    - Enable public access from all networks. You can enable public access from selected virtual networks and IP addresses, but you will be unable to use Forge to create compute resources. Disabling public access is not supported.
-8. Select **Data protection**.
+1.  Select **Data protection**.
     - Configure appropriate settings. All settings are supported by the platform.
-9. Select **Encryption**.
+1.  Select **Encryption**.
     - Only Microsoft-managed keys (MMK) are supported.
-10. In **tags**, add any required tags for the storage account.
-11. Select **Review and Create**.
-12. Select **Create** to create the Azure Storage account.
-13. You will need at least one blob storage container to act as a working directory for Nextflow.
-14. Go to your new storage account and select **+ Container** to create a new Blob storage container. A new container dialogue will open. Enter a suitable name, e.g., _towerrgstorage-container_.
-15. Go to the **Access Keys** section of your new storage account (_towerrgstorage_ in this example).
-16. Store the access keys for your Azure Storage account, to be used when you create a Seqera compute environment.
+1.  In **tags**, add any required tags for the storage account.
+1.  Select **Review and Create**.
+1.  Select **Create** to create the Azure Storage account.
+1.  You will need at least one blob storage container to act as a working directory for Nextflow.
+1.  Go to your new storage account and select **+ Container** to create a new Blob storage container. A new container dialogue will open. Enter a suitable name, e.g., _towerrgstorage-container_.
+1.  Go to the **Access Keys** section of your new storage account (_towerrgstorage_ in this example).
+1.  Store the access keys for your Azure Storage account, to be used when you create a Seqera compute environment.
 
 :::caution
 Blob container storage credentials are associated with the Batch pool configuration. Avoid changing these credentials in your Seqera instance after you have created the compute environment.
@@ -84,27 +84,27 @@ After you have created a resource group and storage account, create a [Batch acc
 
 ### Create a Batch account
 
-1. Log in to your Azure account and select **Create a batch account** on [this page][az-create-batch].
-2. Select the existing resource group or create a new one.
-3. Enter a name for the Batch account, e.g., _towerrgbatch_.
-4. Choose the preferred region (same as the storage account).
-5. Select **Advanced**.
-6. For _Pool allocation mode_, select Batch service.
-7. For _Authentication mode_, ensure _Shared Key_ is selected.
-8. Select **Networking**. Ensure networking access is sufficient for the platform and any additional required resources.
-9. In **tags**, add any required tags for the Batch account.
-10. Select **Review and Create**.
-11. Select **Create**.
-12. Go to your new Batch account, then select **Access Keys**.
-13. Store the access keys for your Azure Batch account, to be used when you create a Seqera compute environment.
+1.  Log in to your Azure account and select **Create a batch account** on [this page][az-create-batch].
+1.  Select the existing resource group or create a new one.
+1.  Enter a name for the Batch account, e.g., _towerrgbatch_.
+1.  Choose the preferred region (same as the storage account).
+1.  Select **Advanced**.
+1.  For _Pool allocation mode_, select Batch service.
+1.  For _Authentication mode_, ensure _Shared Key_ is selected.
+1.  Select **Networking**. Ensure networking access is sufficient for the platform and any additional required resources.
+1.  In **tags**, add any required tags for the Batch account.
+1.  Select **Review and Create**.
+1.  Select **Create**.
+1.  Go to your new Batch account, then select **Access Keys**.
+1.  Store the access keys for your Azure Batch account, to be used when you create a Seqera compute environment.
 
 :::caution
 A newly-created Azure Batch account may not be entitled to create virtual machines without making a service request to Azure.
 See [Azure Batch service quotas and limits][az-batch-quotas] for more information.
 :::
 
-14. Select the **+ Quotas** tab of the Azure Batch account to check and increase existing quotas if necessary.
-15. Select **+ Request quota increase** and add the quantity of resources you require. Here is a brief guideline:
+1.  Select the **+ Quotas** tab of the Azure Batch account to check and increase existing quotas if necessary.
+1.  Select **+ Request quota increase** and add the quantity of resources you require. Here is a brief guideline:
 
     - **Active jobs and schedules**: Each Nextflow process will require an active Azure Batch job per pipeline while running, so increase this number to a high level. See [here][az-learn-jobs] to learn more about jobs in Azure Batch.
     - **Pools**: Each Platform compute environment requires one Azure Batch pool. Each pool is composed of multiple machines of one virtual machine size.
@@ -128,41 +128,41 @@ There are two ways to create an Azure Batch compute environment in Seqera Platfo
 
 **Create a Batch Forge Azure Batch compute environment**
 
-1. In a workspace, select **Compute Environments > New Environment**.
-2. Enter a descriptive name, e.g., _Azure Batch (east-us)_.
-3. Select **Azure Batch** as the target platform.
-4. Choose existing Azure credentials or add a new credential. If you are using existing credentials, skip to step 7.
+1.  In a workspace, select **Compute Environments > New Environment**.
+1.  Enter a descriptive name, e.g., _Azure Batch (east-us)_.
+1.  Select **Azure Batch** as the target platform.
+1.  Choose existing Azure credentials or add a new credential. If you are using existing credentials, skip to step 7.
 
 :::tip
 You can create multiple credentials in your Seqera environment.
 :::
 
-5. Enter a name for the credentials, e.g., _Azure Credentials_.
-6. Add the **Batch account** and **Blob Storage** account names and access keys.
-7. Select a **Region**, e.g., _eastus_.
-8. In the **Pipeline work directory** field, enter the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
+1.  Enter a name for the credentials, e.g., _Azure Credentials_.
+1.  Add the **Batch account** and **Blob Storage** account names and access keys.
+1.  Select a **Region**, e.g., _eastus_.
+1.  In the **Pipeline work directory** field, enter the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
 
     :::note
     When you specify a Blob Storage bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
     :::
 
-9. Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers][wave-docs] for more information.
-10. Select **Enable Fusion v2** to allow access to your Azure Blob Storage data via the [Fusion v2][nf-fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled. See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
-11. Set the **Config mode** to **Batch Forge**.
-12. Enter the default **VMs type**, depending on your quota limits set previously. The default is _Standard_D4_v3_.
-13. Enter the **VMs count**. If autoscaling is enabled (default), this is the maximum number of VMs you wish the pool to scale up to. If autoscaling is disabled, this is the fixed number of virtual machines in the pool.
-14. Enable **Autoscale** to scale up and down automatically, based on the number of pipeline tasks. The number of VMs will vary from **0** to **VMs count**.
-15. Enable **Dispose resources** for Seqera to automatically delete the Batch pool if the compute environment is deleted on the platform.
-16. Select or create [**Container registry credentials**](../credentials/azure_registry_credentials.mdx) to authenticate a registry (used by the [Wave containers](https://www.nextflow.io/docs/latest/wave.html) service). It is recommended to use an [Azure Container registry](https://azure.microsoft.com/en-gb/products/container-registry) within the same region for maximum performance.
-17. Apply [**Resource labels**](../resource-labels/overview.mdx). This will populate the **Metadata** fields of the Azure Batch pool.
-18. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre-and-post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-19. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
-20. Configure any advanced options you need:
+1.  Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers][wave-docs] for more information.
+1.  Select **Enable Fusion v2** to allow access to your Azure Blob Storage data via the [Fusion v2][nf-fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled. See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
+1.  Set the **Config mode** to **Batch Forge**.
+1.  Enter the default **VMs type**, depending on your quota limits set previously. The default is _Standard_D4_v3_.
+1.  Enter the **VMs count**. If autoscaling is enabled (default), this is the maximum number of VMs you wish the pool to scale up to. If autoscaling is disabled, this is the fixed number of virtual machines in the pool.
+1.  Enable **Autoscale** to scale up and down automatically, based on the number of pipeline tasks. The number of VMs will vary from **0** to **VMs count**.
+1.  Enable **Dispose resources** for Seqera to automatically delete the Batch pool if the compute environment is deleted on the platform.
+1.  Select or create [**Container registry credentials**](../credentials/azure_registry_credentials.mdx) to authenticate a registry (used by the [Wave containers](https://www.nextflow.io/docs/latest/wave.html) service). It is recommended to use an [Azure Container registry](https://azure.microsoft.com/en-gb/products/container-registry) within the same region for maximum performance.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx). This will populate the **Metadata** fields of the Azure Batch pool.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre-and-post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1.  Configure any advanced options you need:
 
     - Use **Jobs cleanup policy** to control how Nextflow process jobs are deleted on completion. Active jobs consume the quota of the Azure Batch account. By default, jobs are terminated by Nextflow and removed from the quota when all tasks succesfully complete. If set to _Always_, all jobs are deleted by Nextflow after pipeline completion. If set to _Never_, jobs are never deleted. If set to _On success_, successful tasks are removed but failed tasks will be left for debugging purposes.
     - Use **Token duration** to control the duration of the SAS token generated by Nextflow. This must be as long as the longest period of time the pipeline will run.
 
-21. Select **Add** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before the compute environment is ready to launch pipelines.
+1.  Select **Add** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before the compute environment is ready to launch pipelines.
 
 **See [Launch pipelines](../launch/launchpad.mdx) to start executing workflows in your Azure Batch compute environment.**
 
@@ -172,38 +172,38 @@ This section is for users with a pre-configured Azure Batch pool. This requires 
 
 **Create a manual Seqera Azure Batch compute environment**
 
-1. In a workspace, select **Compute Environments > New Environment**.
-2. Enter a descriptive name for this environment, e.g., _Azure Batch (east-us)_.
-3. Select **Azure Batch** as the target platform.
-4. Select your existing Azure credentials or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
+1.  In a workspace, select **Compute Environments > New Environment**.
+1.  Enter a descriptive name for this environment, e.g., _Azure Batch (east-us)_.
+1.  Select **Azure Batch** as the target platform.
+1.  Select your existing Azure credentials or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
 
 :::tip
 You can create multiple credentials in your Seqera environment.
 :::
 
-5. Enter a name, e.g., _Azure Credentials_.
-6. Add the **Batch account** and **Blob Storage** credentials you created previously.
-7. Select a **Region**, e.g., _eastus (East US)_.
-8. In the **Pipeline work directory** field, add the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
+1.  Enter a name, e.g., _Azure Credentials_.
+1.  Add the **Batch account** and **Blob Storage** credentials you created previously.
+1.  Select a **Region**, e.g., _eastus (East US)_.
+1.  In the **Pipeline work directory** field, add the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
 
     :::note
     When you specify a Blob Storage bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
     :::
 
-9. Set the **Config mode** to **Manual**.
-10. Enter the **Compute Pool name**. This is the name of the Azure Batch pool you created previously in the Azure Batch account.
+1.  Set the **Config mode** to **Manual**.
+1.  Enter the **Compute Pool name**. This is the name of the Azure Batch pool you created previously in the Azure Batch account.
 
     :::note
     The default Azure Batch implementation uses a single pool for head and compute nodes. To use separate pools for head and compute nodes (e.g., to use low-priority VMs for compute jobs), see [this FAQ entry](../faqs.mdx#azure).
     :::
 
-11. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
-12. Configure any advanced options you need:
+1.  Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1.  Configure any advanced options you need:
 
     - Use **Jobs cleanup policy** to control how Nextflow process jobs are deleted on completion. Active jobs consume the quota of the Azure Batch account. By default, jobs are terminated by Nextflow and removed from the quota when all tasks succesfully complete. If set to _Always_, all jobs are deleted by Nextflow after pipeline completion. If set to _Never_, jobs are never deleted. If set to _On success_, successful tasks are removed but failed tasks will be left for debugging purposes.
     - Use **Token duration** to control the duration of the SAS token generated by Nextflow. This must be as long as the longest period of time the pipeline will run.
 
-13. Select **Add** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before you are ready to launch pipelines.
+1.  Select **Add** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before you are ready to launch pipelines.
 
 **See [Launch pipelines](../launch/launchpad.mdx) to start executing workflows in your Azure Batch compute environment.**
 

--- a/platform_versioned_docs/version-23.3.0/compute-envs/eks.mdx
+++ b/platform_versioned_docs/version-23.3.0/compute-envs/eks.mdx
@@ -19,13 +19,13 @@ Assign a service account role to the AWS IAM user used by Seqera to access the E
 
 **Assign a service account role to your Seqera IAM user**
 
-1. Modify the EKS auth configuration:
+1.  Modify the EKS auth configuration:
 
 ```bash
 kubectl edit configmap -n kube-system aws-auth
 ```
 
-2. In the editor that opens, add this entry:
+1.  In the editor that opens, add this entry:
 
 ```yaml
 mapUsers: |
@@ -35,7 +35,7 @@ mapUsers: |
     - tower-launcher-role
 ```
 
-3. Retrieve your user ARN from the [AWS IAM console](https://console.aws.amazon.com/iam), or with the AWS CLI:
+1.  Retrieve your user ARN from the [AWS IAM console](https://console.aws.amazon.com/iam), or with the AWS CLI:
 
 ```bash
 aws sts get-caller-identity
@@ -45,7 +45,7 @@ aws sts get-caller-identity
 The same user must be used when specifying the AWS credentials in the Seqera compute environment configuration.
 :::
 
-4. The AWS user must have [this](../_templates/eks/eks-iam-policy.json) IAM policy applied.
+1.  The AWS user must have [this](../_templates/eks/eks-iam-policy.json) IAM policy applied.
 
 See the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html) for more details.
 
@@ -53,44 +53,44 @@ See the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/add
 
 After you have prepared your Kubernetes cluster and assigned a service account role to your Seqera IAM user, create a Seqera EKS compute environment:
 
-1. In a workspace, select **Compute environments > New environment**.
-2. Enter a descriptive name for this environment, e.g., _Amazon EKS (eu-west-1)_.
-3. From the **Provider** drop-down menu, select **Amazon EKS**.
-4. Under **Storage**, select either **Fusion storage** (recommended) or **Legacy storage**. The [Fusion v2](../supported_software/fusion/fusion.mdx) virtual distributed file system allows access to your AWS S3-hosted data (`s3://` URLs). This eliminates the need to configure a shared file system in your Kubernetes cluster. See [Fusion v2](#fusion-v2) below.
-5. From the **Credentials** drop-down menu, select existing AWS credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 9.
+1.  In a workspace, select **Compute environments > New environment**.
+1.  Enter a descriptive name for this environment, e.g., _Amazon EKS (eu-west-1)_.
+1.  From the **Provider** drop-down menu, select **Amazon EKS**.
+1.  Under **Storage**, select either **Fusion storage** (recommended) or **Legacy storage**. The [Fusion v2](../supported_software/fusion/fusion.mdx) virtual distributed file system allows access to your AWS S3-hosted data (`s3://` URLs). This eliminates the need to configure a shared file system in your Kubernetes cluster. See [Fusion v2](#fusion-v2) below.
+1.  From the **Credentials** drop-down menu, select existing AWS credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 9.
 
 :::note
 The user must have the IAM permissions required to describe and list EKS clusters, per service account role requirements in the previous section.
 :::
 
-6. Enter a name, e.g., _EKS Credentials_.
-7. Add the IAM user **Access key** and **Secret key**. This is the IAM user with the service account role detailed in the previous section.
-8. (Optional) Under **Assume role**, specify the IAM role to be assumed by the Seqera IAM user to access the compute environment AWS resources.
+1.  Enter a name, e.g., _EKS Credentials_.
+1.  Add the IAM user **Access key** and **Secret key**. This is the IAM user with the service account role detailed in the previous section.
+1.  (Optional) Under **Assume role**, specify the IAM role to be assumed by the Seqera IAM user to access the compute environment AWS resources.
 
 :::note
 When using AWS keys without an assumed role, the associated AWS user account must have Seqera [Launch](https://github.com/seqeralabs/nf-tower-aws/tree/master/launch) and [Forge](https://github.com/seqeralabs/nf-tower-aws/tree/master/forge) permissions. When an assumed role is provided, the keys are only used to retrieve temporary credentials impersonating the role specified. In this case, Seqera [Launch](https://github.com/seqeralabs/nf-tower-aws/tree/master/launch) and [Forge](https://github.com/seqeralabs/nf-tower-aws/tree/master/forge) permissions must be granted to the role instead of the user account.
 :::
 
-9. Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
-10. Select a **Cluster name** from the list of available EKS clusters in the selected region.
-11. Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is _tower-nf_ by default.
-12. Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is _tower-launcher-sa_ by default.
+1.  Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
+1.  Select a **Cluster name** from the list of available EKS clusters in the selected region.
+1.  Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is _tower-nf_ by default.
+1.  Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is _tower-launcher-sa_ by default.
 
 :::note
 If you enable Fusion v2 (**Fusion storage** in step 4 above), the head service account must have access to the S3 storage bucket specified as your work directory.
 :::
 
-13. Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in the provided examples.
+1.  Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in the provided examples.
 
 :::note
 The **Storage claim** isn't needed when Fusion v2 is enabled.
 :::
 
-14. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-15. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-16. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
-17. Configure any advanced options described in the next section, as needed.
-18. Select **Create** to finalize the compute environment setup.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1.  Configure any advanced options described in the next section, as needed.
+1.  Select **Create** to finalize the compute environment setup.
 
 ### Advanced options
 
@@ -129,7 +129,7 @@ To use [Fusion v2](../supported_software/fusion/fusion.mdx) in your Seqera EKS c
 
 **Configure IAM to use Fusion v2**
 
-1. Allow the IAM role access to your S3 bucket:
+1.  Allow the IAM role access to your S3 bucket:
 
 ```json
 {
@@ -156,7 +156,7 @@ To use [Fusion v2](../supported_software/fusion/fusion.mdx) in your Seqera EKS c
 
 Replace `<YOUR-BUCKET>` with a bucket name of your choice.
 
-2. The IAM role must have a trust relationship with your Kubernetes service account:
+1.  The IAM role must have a trust relationship with your Kubernetes service account:
 
 ```json
 {
@@ -181,7 +181,7 @@ Replace `<YOUR-BUCKET>` with a bucket name of your choice.
 
 Replace `<YOUR-ACCOUNT-ID>`, `<YOUR-REGION>`, `<YOUR-CLUSTER-ID>`, `<YOUR-EKS-SERVICE-ACCOUNT>` with your corresponding values.
 
-3. Annotate the Kubernetes service account with the IAM role:
+1.  Annotate the Kubernetes service account with the IAM role:
 
 ```shell
 kubectl annotate serviceaccount <YOUR-EKS-SERVICE-ACCOUNT> --namespace <YOUR-EKS-NAMESPACE> eks.amazonaws.com/role-arn=arn:aws:iam::<YOUR-ACCOUNT-ID>:role/<YOUR-IAM-ROLE>

--- a/platform_versioned_docs/version-23.3.0/compute-envs/gke.mdx
+++ b/platform_versioned_docs/version-23.3.0/compute-envs/gke.mdx
@@ -46,25 +46,25 @@ See [Role-based access control](https://cloud.google.com/kubernetes-engine/docs/
 
 After you've prepared your Kubernetes cluster and granted cluster access to your service account, create a Seqera GKE compute environment:
 
-1. In a Seqera workspace, select **Compute environments > New environment**.
+1.  In a Seqera workspace, select **Compute environments > New environment**.
 
-2. Enter a descriptive name for this environment, e.g., _Google GKE (europe-west1)_.
+1.  Enter a descriptive name for this environment, e.g., _Google GKE (europe-west1)_.
 
-3. From the **Provider** drop-down, select **Google GKE**.
+1.  From the **Provider** drop-down, select **Google GKE**.
 
-4. Under **Storage**, select either **Fusion storage** (recommended) or **Legacy storage**. The [Fusion v2](../supported_software/fusion/fusion.mdx) virtual distributed file system allows access to your Google Cloud-hosted data (`gs://` URLs). This eliminates the need to configure a shared file system in your Kubernetes cluster. See [Fusion v2](#fusion-v2) below.
+1.  Under **Storage**, select either **Fusion storage** (recommended) or **Legacy storage**. The [Fusion v2](../supported_software/fusion/fusion.mdx) virtual distributed file system allows access to your Google Cloud-hosted data (`gs://` URLs). This eliminates the need to configure a shared file system in your Kubernetes cluster. See [Fusion v2](#fusion-v2) below.
 
-5. From the **Credentials** drop-down menu, select existing GKE credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 8.
+1.  From the **Credentials** drop-down menu, select existing GKE credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 8.
 
-6. Enter a name for the credentials, e.g., _GKE Credentials_.
+1.  Enter a name for the credentials, e.g., _GKE Credentials_.
 
-7. Enter the **Service account key** for your Google service account.
+1.  Enter the **Service account key** for your Google service account.
 
 :::tip
 You can create multiple credentials in your Seqera environment. See [Credentials](../credentials/overview.mdx).
 :::
 
-8. Select the **Location** of your GKE cluster.
+1.  Select the **Location** of your GKE cluster.
 
 :::caution
 GKE clusters can be either regional or zonal. For example, `us-west1` identifies the United States West-Coast _region_, which has three _zones_: `us-west1-a`, `us-west1-b`, and `us-west1-c`.
@@ -73,31 +73,31 @@ Seqera Platform's auto-completion only shows regions. You should manually edit t
 ![](./_images/gke_regions.png)
 :::
 
-9. Select or enter the **Cluster name** of your GKE cluster.
+1.  Select or enter the **Cluster name** of your GKE cluster.
 
-10. Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is _tower-nf_ by default.
+1.  Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is _tower-nf_ by default.
 
-11. Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is _tower-launcher-sa_ by default.
+1.  Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is _tower-launcher-sa_ by default.
 
 :::note
 If you enable Fusion v2 (**Fusion storage** in step 4 above), the head service account must have access to the Google Cloud storage bucket specified as your work directory.
 :::
 
-12. Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in the provided examples.
+1.  Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in the provided examples.
 
 :::note
 The **Storage claim** isn't needed when Fusion v2 is enabled.
 :::
 
-13. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-14. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
 
-15. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1.  Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
 
-16. Configure any advanced options described in the next section, as needed.
+1.  Configure any advanced options described in the next section, as needed.
 
-17. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 ### Advanced options
 
@@ -134,12 +134,12 @@ To use [Fusion v2](../supported_software/fusion/fusion.mdx) in your Seqera GKE c
 
 **Configure IAM to use Fusion v2**
 
-1. Ensure the **Workload Identity** feature is enabled for the cluster:
+1.  Ensure the **Workload Identity** feature is enabled for the cluster:
 
 - **Enable Workload Identity** in the cluster **Security** settings.
 - **Enable GKE Metadata Server** in the node group **Security** settings.
 
-2. Allow the IAM service account access to your Google storage bucket:
+1.  Allow the IAM service account access to your Google storage bucket:
 
 ```shell
 gcloud storage buckets add-iam-policy-binding gs://<YOUR-BUCKET> --role roles/storage.objectAdmin --member serviceAccount:<IAM-SERVICE-ACCOUNT>@<GOOGLE-CLOUD-PROJECT>.iam.gserviceaccount.com
@@ -147,13 +147,13 @@ gcloud storage buckets add-iam-policy-binding gs://<YOUR-BUCKET> --role roles/st
 
 The role must have at least `storage.objects.create`, `storage.objects.get`, and `storage.objects.list` permissions.
 
-3. Allow the Kubernetes service account to impersonate the IAM service account:
+1.  Allow the Kubernetes service account to impersonate the IAM service account:
 
 ```shell
 gcloud iam service-accounts add-iam-policy-binding <IAM-SERVICE-ACCOUNT>@<GOOGLE-CLOUD-PROJECT>.iam.gserviceaccount.com --role roles/iam.workloadIdentityUser --member "serviceAccount:<GOOGLE-CLOUD-PROJECT>.svc.id.goog[<GKE-NAMESPACE>/<GKE-SERVICE-ACCOUNT>]"
 ```
 
-4. Annotate the Kubernetes service account with the email address of the IAM service account:
+1.  Annotate the Kubernetes service account with the email address of the IAM service account:
 
 ```shell
 kubectl annotate serviceaccount <GKE-SERVICE-ACCOUNT> --namespace <GKE-NAMESPACE> iam.gke.io/gcp-service-account=<IAM-SERVICE-ACCOUNT>@<GOOGLE-CLOUD-PROJECT>.iam.gserviceaccount.com

--- a/platform_versioned_docs/version-23.3.0/compute-envs/google-cloud-batch.mdx
+++ b/platform_versioned_docs/version-23.3.0/compute-envs/google-cloud-batch.mdx
@@ -11,8 +11,8 @@ This guide assumes you have an existing Google Cloud account. Sign up for a free
 
 The guide is split into two parts:
 
-1. How to configure your Google Cloud account to use the Batch API.
-2. How to create a Google Cloud Batch compute environment in Seqera.
+1.  How to configure your Google Cloud account to use the Batch API.
+1.  How to create a Google Cloud Batch compute environment in Seqera.
 
 ## Configure Google Cloud
 
@@ -75,16 +75,16 @@ Ask your Google Cloud administrator to grant you the following IAM user permissi
 
 To configure a credential in Seqera, you must first create a [service account JSON key file][get-json]:
 
-1. In the Google Cloud navigation menu, select **IAM & Admin > Service Accounts**.
-2. Select the email address of the service account.
+1.  In the Google Cloud navigation menu, select **IAM & Admin > Service Accounts**.
+1.  Select the email address of the service account.
 
     :::note
     The Compute Engine default service account is not recommended for production environments due to its powerful permissions. To use a service account other than the Compute Engine default, specify the service account email address under **Advanced options** on the Seqera compute environment creation form.
     :::
 
-3. Select **Keys > Add key > Create new key**.
-4. Select **JSON** as the key type.
-5. Select **Create**.
+1.  Select **Keys > Add key > Create new key**.
+1.  Select **JSON** as the key type.
+1.  Select **Create**.
 
 A JSON file will be downloaded to your computer. This file contains the credential needed to configure the compute environment in Seqera.
 
@@ -96,23 +96,23 @@ Google Cloud Storage is a type of **object storage**. To access files and store 
 
 **Create a Cloud Storage bucket**
 
-1. In the hamburger menu (**≡**), select **Cloud Storage**.
-2. From the **Buckets** tab, select **Create**.
-3. Enter a name for your bucket. You will reference this name when you create the compute environment in Seqera.
-4. Select **Region** for the **Location type** and select the **Location** for your bucket. You'll reference this location when you create the compute environment in Seqera.
-5. Select **Standard** for the default storage class.
-6. Under **Access control**, select **Uniform**.
+1.  In the hamburger menu (**≡**), select **Cloud Storage**.
+1.  From the **Buckets** tab, select **Create**.
+1.  Enter a name for your bucket. You will reference this name when you create the compute environment in Seqera.
+1.  Select **Region** for the **Location type** and select the **Location** for your bucket. You'll reference this location when you create the compute environment in Seqera.
+1.  Select **Standard** for the default storage class.
+1.  Under **Access control**, select **Uniform**.
 
     :::note
     The Batch API is available in a limited number of [locations][batch-locations]. These locations are only used to store metadata about the pipeline operations. The storage bucket and compute resources can be in any region.
     :::
 
-7. Select any additional object data protection tools, per your organization's data protection requirements.
-8. Select **Create**.
-9. After the bucket is created, you are redirected to the **Bucket details** page.
-10. Select **Permissions**, then **Grant access** under **View by principals**.
-11. Copy the email address of your service account into **New principals**.
-12. Select the **Storage Admin** role.
+1.  Select any additional object data protection tools, per your organization's data protection requirements.
+1.  Select **Create**.
+1.  After the bucket is created, you are redirected to the **Bucket details** page.
+1.  Select **Permissions**, then **Grant access** under **View by principals**.
+1.  Copy the email address of your service account into **New principals**.
+1.  Select the **Storage Admin** role.
 
 :::tip
 You've created a project, enabled the necessary Google APIs, created a bucket, and created a service account JSON key file with the required credentials. You now have what you need to set up a new compute environment in Seqera.
@@ -122,26 +122,26 @@ You've created a project, enabled the necessary Google APIs, created a bucket, a
 
 After your Google Cloud resources have been created, create a new Seqera compute environment:
 
-1. In a workspace, select **Compute Environments > New Environment**.
-2. Enter a descriptive name for this environment, e.g., _Google Cloud Batch (europe-north1)_.
-3. Select **Google Cloud Batch** as the target platform.
-4. From the **Credentials** drop-down, select existing Google credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
-5. Enter a name for the credentials, e.g., _Google Cloud Credentials_.
-6. Enter the **Service account key** from the JSON key file you created earlier.
-7. Select the **Location** where you will execute your pipelines. See [Location][location] to learn more.
-8. In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket must be accessible in the location selected in the previous step.
+1.  In a workspace, select **Compute Environments > New Environment**.
+1.  Enter a descriptive name for this environment, e.g., _Google Cloud Batch (europe-north1)_.
+1.  Select **Google Cloud Batch** as the target platform.
+1.  From the **Credentials** drop-down, select existing Google credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
+1.  Enter a name for the credentials, e.g., _Google Cloud Credentials_.
+1.  Enter the **Service account key** from the JSON key file you created earlier.
+1.  Select the **Location** where you will execute your pipelines. See [Location][location] to learn more.
+1.  In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket must be accessible in the location selected in the previous step.
 
     :::note
     When you specify a Cloud Storage bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
     :::
 
-9. (_Optional_) Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers][wave-docs] for more information.
-10. (_Optional_) Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2][fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled in the previous step. See [Fusion file system][platform-fusion-docs] for configuration details.
-11. Enable **Spot** to use spot instances, which have significantly reduced cost compared to on-demand instances.
-12. Apply [**Resource labels**][resource-labels] to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-13. Expand **Staging options** to include optional [pre- or post-run Bash scripts][pre-post-run-scripts] that execute before or after the Nextflow pipeline execution in your environment.
-14. Specify custom **Environment variables** for the Head job and/or Compute jobs.
-15. Configure any advanced options you need:
+1.  (_Optional_) Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers][wave-docs] for more information.
+1.  (_Optional_) Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2][fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled in the previous step. See [Fusion file system][platform-fusion-docs] for configuration details.
+1.  Enable **Spot** to use spot instances, which have significantly reduced cost compared to on-demand instances.
+1.  Apply [**Resource labels**][resource-labels] to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts][pre-post-run-scripts] that execute before or after the Nextflow pipeline execution in your environment.
+1.  Specify custom **Environment variables** for the Head job and/or Compute jobs.
+1.  Configure any advanced options you need:
 
     - Enable **Use Private Address** to ensure that your Google Cloud VMs aren't accessible to the public internet.
 
@@ -159,7 +159,7 @@ After your Google Cloud resources have been created, create a new Seqera compute
     **VPC** and **Subnet** must both be specified for your compute environment to use either.
     :::
 
-16. Select **Create** to finish the compute environment setup.
+1.  Select **Create** to finish the compute environment setup.
 
 Your new compute environment may take a few minutes to become available for pipeline execution after it is added to your workspace.
 

--- a/platform_versioned_docs/version-23.3.0/compute-envs/google-cloud-lifesciences.mdx
+++ b/platform_versioned_docs/version-23.3.0/compute-envs/google-cloud-lifesciences.mdx
@@ -9,8 +9,8 @@ This guide assumes you have an existing Google Cloud account. Sign up for a free
 
 This guide is split into two parts:
 
-1. How to configure your Google Cloud account to use the Cloud Life Sciences API.
-2. How to create a Google Life Sciences compute environment in Seqera.
+1.  How to configure your Google Cloud account to use the Cloud Life Sciences API.
+1.  How to create a Google Life Sciences compute environment in Seqera.
 
 ## Configure Google Cloud
 
@@ -50,11 +50,11 @@ Seqera requires a service account with appropriate permissions to interact with 
 
 **Create a service account**
 
-1. In the navigation menu, select **IAM & Admin > Service Accounts**.
-2. Select the email address of the **Compute Engine default service account**.
-3. Select **Keys > Add key > Create new key**.
-4. Select **JSON** as the key type.
-5. Select **Create**.
+1.  In the navigation menu, select **IAM & Admin > Service Accounts**.
+1.  Select the email address of the **Compute Engine default service account**.
+1.  Select **Keys > Add key > Create new key**.
+1.  Select **JSON** as the key type.
+1.  Select **Create**.
 
 A JSON file will be downloaded to your computer. This file contains the credentials needed to configure the compute environment in Seqera.
 
@@ -66,26 +66,26 @@ Google Cloud Storage is a type of **object storage**. To access files and store 
 
 **Create a Cloud Storage bucket**
 
-1. In the hamburger menu (**≡**), select **Cloud Storage > Create bucket**.
-2. Enter a name for your bucket. You will reference this name when creating the compute environment in Seqera.
+1.  In the hamburger menu (**≡**), select **Cloud Storage > Create bucket**.
+1.  Enter a name for your bucket. You will reference this name when creating the compute environment in Seqera.
 
 :::caution
 Do not use underscores (`_`) in your bucket name. Use hyphens (`-`) instead.
 :::
 
-3. Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Seqera.
-4. Select **Standard** for the default storage class.
-5. Select **Uniform** for the **Access control**.
+1.  Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Seqera.
+1.  Select **Standard** for the default storage class.
+1.  Select **Uniform** for the **Access control**.
 
 :::note
 The Cloud Life Sciences API is available in a limited number of [locations](https://cloud.google.com/life-sciences/docs/concepts/locations). These locations are only used to store metadata about the pipeline operations. The storage bucket and compute resources can be in any region.
 :::
 
-6. Select **Create**.
-7. Once the bucket is created, you will be redirected to the **Bucket details** page.
-8. Select **Permissions**, then **+ Add**.
-9. Copy the email address of the Compute Engine default service account into **New principals**.
-10. Select the following roles:
+1.  Select **Create**.
+1.  Once the bucket is created, you will be redirected to the **Bucket details** page.
+1.  Select **Permissions**, then **+ Add**.
+1.  Copy the email address of the Compute Engine default service account into **New principals**.
+1.  Select the following roles:
 
     - Storage Admin
     - Storage Legacy Bucket Owner
@@ -98,30 +98,30 @@ After your Google Cloud resources have been created, create a new Seqera compute
 
 **Create a Seqera Google Cloud Life Sciences compute environment**
 
-1. In a workspace, select **Compute Environments > New Environment**.
-2. Enter a descriptive name for this environment, e.g., _Google Life Sciences (europe-west2)_.
-3. Select **Google Life Sciences** as the target platform.
-4. From the **Credentials** drop-down, select existing Google Cloud credentials, or add new credentials by selecting the **+** button. If you choose to use existing credentials, skip to step 7.
+1.  In a workspace, select **Compute Environments > New Environment**.
+1.  Enter a descriptive name for this environment, e.g., _Google Life Sciences (europe-west2)_.
+1.  Select **Google Life Sciences** as the target platform.
+1.  From the **Credentials** drop-down, select existing Google Cloud credentials, or add new credentials by selecting the **+** button. If you choose to use existing credentials, skip to step 7.
 
 :::tip
 You can create multiple credentials in your Seqera workspace. See [Credentials](../credentials/overview.mdx).
 :::
 
-5. Enter a name for the credentials, e.g., _Google Cloud Credentials_.
-6. Enter the **Service account key** created previously.
-7. Select the [**Region** and **Zones**](https://cloud.google.com/compute/docs/regions-zones#available) where you wish to execute pipelines. Leave the **Location** empty for the Cloud Life Sciences API to use the closest available location.
-8. In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket must be accessible in the region selected in the previous step.
+1.  Enter a name for the credentials, e.g., _Google Cloud Credentials_.
+1.  Enter the **Service account key** created previously.
+1.  Select the [**Region** and **Zones**](https://cloud.google.com/compute/docs/regions-zones#available) where you wish to execute pipelines. Leave the **Location** empty for the Cloud Life Sciences API to use the closest available location.
+1.  In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket must be accessible in the region selected in the previous step.
 
     :::note
     When you specify a Cloud Storage bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
     :::
 
-9. You can enable **Preemptible** to use preemptible instances, which have significantly reduced cost compared to on-demand instances.
-10. You can use a **Filestore file system** to automatically mount a Google Filestore volume in your pipelines.
-11. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-12. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-13. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
-14. Configure any advanced options you need:
+1.  You can enable **Preemptible** to use preemptible instances, which have significantly reduced cost compared to on-demand instances.
+1.  You can use a **Filestore file system** to automatically mount a Google Filestore volume in your pipelines.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Configure any advanced options you need:
 
     - Enable **Use Private Address** to ensure that your Google Cloud VMs aren't accessible to the public internet.
 
@@ -129,6 +129,6 @@ You can create multiple credentials in your Seqera workspace. See [Credentials](
 
     - Use **Head Job CPUs** and **Head Job Memory** to specify the CPUs and memory allocated for head jobs.
 
-15. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 See [Launch pipelines](../launch/launchpad.mdx) to start executing workflows in your Google Cloud Life Sciences compute environment.

--- a/platform_versioned_docs/version-23.3.0/compute-envs/hpc.mdx
+++ b/platform_versioned_docs/version-23.3.0/compute-envs/hpc.mdx
@@ -26,18 +26,18 @@ To launch pipelines into an **HPC** cluster from Seqera, the following requireme
 To create a new **HPC** compute environment:
 
 1.  In a Seqera workspace, select **Compute environments > New environment**.
-2.  Enter a descriptive name for this environment. Use only alphanumeric characters, dashes, and underscores.
-3.  Select your HPC environment from the **Platform** dropdown menu.
-4.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
-5.  Enter a name for the credentials.
-6.  Enter the absolute path of the **Work directory** to be used on the cluster.
-7.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
-8.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
-9.  Enter the **Head queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will be submitted.
-10. Enter the **Compute queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will submit tasks.
-11. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-12. Specify custom **Environment variables** for the head job and/or compute jobs.
-13. Configure any advanced options needed:
+1.  Enter a descriptive name for this environment. Use only alphanumeric characters, dashes, and underscores.
+1.  Select your HPC environment from the **Platform** dropdown menu.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Enter a name for the credentials.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Head queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Compute queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will submit tasks.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  Specify custom **Environment variables** for the head job and/or compute jobs.
+1.  Configure any advanced options needed:
 
     - Use the **Nextflow queue size** to limit the number of jobs that Nextflow can submit to the scheduler at the same time.
     - Use the **Head job submit options** to specify platform-specific submit options for the head job. You can optionally apply these options to compute jobs as well:
@@ -52,6 +52,6 @@ Once set during compute environment creation, these options can't be overridden 
 In IBM LSF compute environments, use **Unit for memory limits**, **Per job memory limits**, and **Per task reserve** to control how memory is requested for Nextflow jobs.
 :::
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 See [Launch pipelines](../launch/launchpad.mdx) to start executing workflows in your HPC compute environment.

--- a/platform_versioned_docs/version-23.3.0/compute-envs/k8s.mdx
+++ b/platform_versioned_docs/version-23.3.0/compute-envs/k8s.mdx
@@ -17,15 +17,15 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
 **Prepare your Kubernetes cluster for Seqera Platform**
 
-1. Verify the connection to your Kubernetes cluster:
+1.  Verify the connection to your Kubernetes cluster:
 
    ```bash
    kubectl cluster-info
    ```
 
-2. Download the [tower-launcher.yml](../_templates/k8s/tower-launcher.yml) file.
+1.  Download the [tower-launcher.yml](../_templates/k8s/tower-launcher.yml) file.
 
-3. Create the Seqera launcher:
+1.  Create the Seqera launcher:
 
    ```bash
    kubectl apply -f path/to/tower-launcher.yml
@@ -33,7 +33,7 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
    This command creates a service account called `tower-launcher-sa` and the associated role bindings, all contained in a namespace called `tower-nf`. Seqera uses the service account to launch Nextflow pipelines. Use this service account name when setting up the compute environment for this Kubernetes cluster in Seqera.
 
-4. Create persistent storage. Seqera requires a `ReadWriteMany` persistent volume claim (PVC) mounted to all nodes where workflow pods will be dispatched.
+1.  Create persistent storage. Seqera requires a `ReadWriteMany` persistent volume claim (PVC) mounted to all nodes where workflow pods will be dispatched.
 
    You can use any storage solution that supports the `ReadWriteMany` [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes). The setup of this storage is beyond the scope of these instructions — the right solution for you will depend on what is available for your infrastructure or cloud vendor (NFS, GlusterFS, CephFS, Amazon FSx). Ask your cluster administrator for more information.
 
@@ -41,7 +41,7 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
    - Example PVC backed by NFS server: [tower-scratch-nfs.yml](../_templates/k8s/tower-scratch-nfs.yml)
 
-5. Apply the appropriate PVC configuration to your cluster:
+1.  Apply the appropriate PVC configuration to your cluster:
 
    ```bash
    kubectl apply -f <PVC_YAML_FILE>.
@@ -53,17 +53,17 @@ After you've prepared your Kubernetes cluster for Seqera integration, create a c
 
 **Create a Seqera Kubernetes compute environment**
 
-1. In a workspace, select **Compute environments > New environment**.
-2. Enter a descriptive name for this environment, e.g., _K8s cluster_.
-3. Select **Kubernetes** as the target platform.
-4. From the **Credentials** drop-down, select existing Kubernetes credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
+1.  In a workspace, select **Compute environments > New environment**.
+1.  Enter a descriptive name for this environment, e.g., _K8s cluster_.
+1.  Select **Kubernetes** as the target platform.
+1.  From the **Credentials** drop-down, select existing Kubernetes credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
 
 :::tip
 You can create multiple credentials in your Seqera workspace. See [Credentials](../credentials/overview.mdx).
 :::
 
-5. Enter a name, e.g., _K8s Credentials_.
-6. Select either the **Service Account Token** or **X509 Client Certs** tab:
+1.  Enter a name, e.g., _K8s Credentials_.
+1.  Select either the **Service Account Token** or **X509 Client Certs** tab:
 
    - To authenticate using a Kubernetes service account, enter your **Service account token**. Obtain the token with the following command:
 
@@ -76,7 +76,7 @@ You can create multiple credentials in your Seqera workspace. See [Credentials](
 
    - To authenticate using an X509 client certificate, paste the contents of your certificate and key file (including the `-----BEGIN...-----` and `-----END...-----` lines) in the **Client certificate** and **Client Key** fields respectively. See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/certificates/) for instructions to generate your client certificate and key.
 
-7. Enter the **Control plane URL**, obtained with this command:
+1.  Enter the **Control plane URL**, obtained with this command:
 
    ```bash
    kubectl cluster-info
@@ -84,18 +84,18 @@ You can create multiple credentials in your Seqera workspace. See [Credentials](
 
    It can also be found in your `~/.kube/config` file under the `server` field corresponding to your cluster.
 
-8. Specify the **SSL certificate** to authenticate your connection.
+1.  Specify the **SSL certificate** to authenticate your connection.
 
    Find the certificate data in your `~/.kube/config` file. It is the `certificate-authority-data` field corresponding to your cluster.
 
-9. Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is _tower-nf_ by default.
-10. Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is _tower-launcher-sa_ by default.
-11. Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in each of the provided examples.
-12. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-13. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-14. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
-15. Configure any advanced options described below, as needed.
-16. Select **Create** to finalize the compute environment setup.
+1.  Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is _tower-nf_ by default.
+1.  Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is _tower-launcher-sa_ by default.
+1.  Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in each of the provided examples.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Configure any advanced options described below, as needed.
+1.  Select **Create** to finalize the compute environment setup.
 
 See [Launch pipelines](../launch/launchpad.mdx) to start executing workflows in your Kubernetes compute environment.
 

--- a/platform_versioned_docs/version-23.3.0/credentials/aws_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.3.0/credentials/aws_registry_credentials.mdx
@@ -17,13 +17,13 @@ Wave requires programmatic access to your private Elastic Container Registry (EC
 
 **Create an IAM user with AWS ECR access**
 
-1. Open the [IAM console](https://console.aws.amazon.com/iam/).
-2. Select **Users** from the navigation pane.
-3. Select the name of the user whose keys you want to manage, then select the **Security credentials** tab. We recommend creating an IAM user specifically for Wave authentication instead of using existing credentials with broader permissions.
-4. In the **Access keys** section, select **Create access key**. Each IAM user can have only two access keys at a time, so if the Create option is deactivated, delete an existing access key first.
-5. On the **Access key best practices & alternatives** page, select **Other** and then **Next**.
-6. On the **Retrieve access key** page, you can either **Show** the user's secret access key details, or store them by selecting **Download .csv file**.
-7. The newly created access key pair is active by default and can be stored as a container registry credential in Seqera.
+1.  Open the [IAM console](https://console.aws.amazon.com/iam/).
+1.  Select **Users** from the navigation pane.
+1.  Select the name of the user whose keys you want to manage, then select the **Security credentials** tab. We recommend creating an IAM user specifically for Wave authentication instead of using existing credentials with broader permissions.
+1.  In the **Access keys** section, select **Create access key**. Each IAM user can have only two access keys at a time, so if the Create option is deactivated, delete an existing access key first.
+1.  On the **Access key best practices & alternatives** page, select **Other** and then **Next**.
+1.  On the **Retrieve access key** page, you can either **Show** the user's secret access key details, or store them by selecting **Download .csv file**.
+1.  The newly created access key pair is active by default and can be stored as a container registry credential in Seqera.
 
 :::note
 Your credential must be stored in Seqera Platform as a **container registry** credential, even if the same access keys already exist as a workspace credential.
@@ -35,7 +35,7 @@ Your credential must be stored in Seqera Platform as a **container registry** cr
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -43,4 +43,4 @@ Your credential must be stored in Seqera Platform as a **container registry** cr
     - **Password**: Specify your IAM user secret access.
     - **Registry server**: Specify container registry server name. For example, `<aws_account_id>.dkr.ecr.<region>.amazonaws.com`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/platform_versioned_docs/version-23.3.0/credentials/azure_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.3.0/credentials/azure_registry_credentials.mdx
@@ -19,18 +19,18 @@ You must use Azure credentials with long-term registry read (**content/read**) a
 
 **Create an access token with Azure container registry access**
 
-1. In the Azure portal, navigate to your container registry.
-2. Under **Repository permissions**, select **Tokens > +Add**.
-3. Enter a token name.
-4. Under **Scope map**, select **Create new**.
-5. In the **Create scope map** section, enter a name and description for the new scope map.
-6. Select your **Repository** from the drop-down menu.
-7. Select **content/read** from the **Permissions** drop-down menu, then select **Add** to create the scope map.
-8. In the **Create token** section, ensure the **Status** is **Enabled** (default), then select **Create**.
-9. Return to **Repository permissions > Tokens** for your registry, then select the token you just created.
-10. On the token details page, select **password1** or **password2**.
-11. In the password details section, uncheck the **Set expiration date?** checkbox, then select **Generate**.
-12. Copy and save the generated password (this is only displayed once).
+1.  In the Azure portal, navigate to your container registry.
+1.  Under **Repository permissions**, select **Tokens > +Add**.
+1.  Enter a token name.
+1.  Under **Scope map**, select **Create new**.
+1.  In the **Create scope map** section, enter a name and description for the new scope map.
+1.  Select your **Repository** from the drop-down menu.
+1.  Select **content/read** from the **Permissions** drop-down menu, then select **Add** to create the scope map.
+1.  In the **Create token** section, ensure the **Status** is **Enabled** (default), then select **Create**.
+1.  Return to **Repository permissions > Tokens** for your registry, then select the token you just created.
+1.  On the token details page, select **password1** or **password2**.
+1.  In the password details section, uncheck the **Set expiration date?** checkbox, then select **Generate**.
+1.  Copy and save the generated password (this is only displayed once).
 
 ## Add credentials to Seqera
 
@@ -38,7 +38,7 @@ You must use Azure credentials with long-term registry read (**content/read**) a
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -46,4 +46,4 @@ You must use Azure credentials with long-term registry read (**content/read**) a
     - **Password**: Your registry token password. For example, `my-registry-token`.
     - **Registry server**: Specify the container registry server name. You can obtain this from the Azure portal: **Settings > Access keys > Login server**. For example, `myregistry.azurecr.io`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/platform_versioned_docs/version-23.3.0/credentials/docker_hub_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.3.0/credentials/docker_hub_registry_credentials.mdx
@@ -17,11 +17,11 @@ You must use Docker Hub credentials with **Read-only** access to authenticate Se
 
 **Create a Docker Hub PAT**
 
-1. Log in to [Docker Hub](https://hub.docker.com/).
-2. Select your username in the top right corner and select **Account Settings**.
-3. Select **Security > New Access Token**.
-4. Enter a token description and select **Read-only** from the Access permissions drop-down menu, then select **Generate**.
-5. Copy and save the generated access token (this is only displayed once).
+1.  Log in to [Docker Hub](https://hub.docker.com/).
+1.  Select your username in the top right corner and select **Account Settings**.
+1.  Select **Security > New Access Token**.
+1.  Enter a token description and select **Read-only** from the Access permissions drop-down menu, then select **Generate**.
+1.  Copy and save the generated access token (this is only displayed once).
 
 ## Add credentials to Seqera
 
@@ -29,7 +29,7 @@ You must use Docker Hub credentials with **Read-only** access to authenticate Se
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -37,4 +37,4 @@ You must use Docker Hub credentials with **Read-only** access to authenticate Se
     - **Password**: Specify your personal access token (PAT). For example, `1fcd02dc-...215bc3f3`.
     - **Registry server**: Specify the container registry hostname, excluding the protocol. For example, `docker.io`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/platform_versioned_docs/version-23.3.0/credentials/gitea_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.3.0/credentials/gitea_registry_credentials.mdx
@@ -23,7 +23,7 @@ You must create a PAT to access your Gitea container registry from Wave. For mor
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -31,7 +31,7 @@ You must create a PAT to access your Gitea container registry from Wave. For mor
     - **Password**: Specify your Gitea personal access token (PAT). For example, `1fcd02dc-...215bc3f3`.
     - **Registry server**: Specify your Gitea container registry URL. For example, `gitea.example.com`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
 
 [gitea-auth]: https://docs.gitea.com/usage/packages/container#login-to-the-container-registry
 [gitea-create]: https://docs.gitea.com/development/api-usage#authentication

--- a/platform_versioned_docs/version-23.3.0/credentials/github_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.3.0/credentials/github_registry_credentials.mdx
@@ -23,7 +23,7 @@ You must create a PAT to access your GitHub container registry from Wave. For mo
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -31,7 +31,7 @@ You must create a PAT to access your GitHub container registry from Wave. For mo
     - **Password**: Specify your personal access token (PAT) classic. For example, `1fcd02dc-...215bc3f3`.
     - **Registry server**: Specify your GitHub container registry URL. For example, `ghcr.io`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
 
 [github-pat]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic
 [github-create]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic

--- a/platform_versioned_docs/version-23.3.0/credentials/gitlab_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.3.0/credentials/gitlab_registry_credentials.mdx
@@ -23,7 +23,7 @@ If your organization enabled 2FA for your organization or project, you must crea
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -31,7 +31,7 @@ If your organization enabled 2FA for your organization or project, you must crea
     - **Password**: Specify your personal access token (PAT), group access token, or project access token if 2FA is enabled by your GitLab organization. Otherwise specify your GitLab password.
     - **Registry server**: Specify your GitLab container registry URL. For example, `gitlab.example.com`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
 
 [gitlab-cr]: https://docs.gitlab.com/ee/user/packages/container_registry/authenticate_with_container_registry.html
 [gitlab-pat]: https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html

--- a/platform_versioned_docs/version-23.3.0/credentials/google_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.3.0/credentials/google_registry_credentials.mdx
@@ -27,17 +27,17 @@ Create dedicated service account keys that are only used to interact with your r
 
 Administrators can create a service account from the Google Cloud console:
 
-1. Go to the [Create service account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts/create?walkthrough_id=iam--create-service-account) page.
-2. Select a Cloud project.
-3. Enter a service account name and (optional) description.
-4. Select **Create and continue**.
-5. From the **Role** drop-down menu under step 2, select **Artifact Registry > Artifact Registry Reader**, then select **Continue**.
-6. (Optional) Grant other users and admins access to this service account.
-7. Select **Done**.
-8. From the project service accounts page, select the three dots menu icon under **Actions** for the service account you just created, then select **Manage keys**.
-9. On the **Keys** page, select **Add key**.
-10. On the **Create private key** popup, select **JSON** and then **Create**. This triggers a download of a JSON file containing the service account private key and service account details.
-11. Base-64 encode the contents of the JSON key file:
+1.  Go to the [Create service account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts/create?walkthrough_id=iam--create-service-account) page.
+1.  Select a Cloud project.
+1.  Enter a service account name and (optional) description.
+1.  Select **Create and continue**.
+1.  From the **Role** drop-down menu under step 2, select **Artifact Registry > Artifact Registry Reader**, then select **Continue**.
+1.  (Optional) Grant other users and admins access to this service account.
+1.  Select **Done**.
+1.  From the project service accounts page, select the three dots menu icon under **Actions** for the service account you just created, then select **Manage keys**.
+1.  On the **Keys** page, select **Add key**.
+1.  On the **Create private key** popup, select **JSON** and then **Create**. This triggers a download of a JSON file containing the service account private key and service account details.
+1.  Base-64 encode the contents of the JSON key file:
 
 ```bash
         #Linux
@@ -54,16 +54,16 @@ Administrators can create a service account from the Google Cloud console:
 
 Administrators can create a service account from the Google Cloud console:
 
-1. Navigate to the [Create service account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts/create?walkthrough_id=iam--create-service-account) page.
-2. Select a Cloud project.
-3. Enter a service account name and an optional description.
-4. Select **Create and continue**.
-5. From the **Role** drop-down menu under step 2, search for and select **Storage Object Viewer**, then select **Continue**.
-6. (Optional) Grant other users and admins access to this service account under step 3.
-7. Select **Done**.
-8. From the project service accounts page, select the three dots menu icon under **Actions** for the service account you just created, then select **Manage keys**.
-9. On the **Keys** page, select **Add key**.
-10. On the **Create private key** popup, select **JSON** and then **Create**. This triggers a download of a JSON file containing the service account private key and service account details.
+1.  Navigate to the [Create service account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts/create?walkthrough_id=iam--create-service-account) page.
+1.  Select a Cloud project.
+1.  Enter a service account name and an optional description.
+1.  Select **Create and continue**.
+1.  From the **Role** drop-down menu under step 2, search for and select **Storage Object Viewer**, then select **Continue**.
+1.  (Optional) Grant other users and admins access to this service account under step 3.
+1.  Select **Done**.
+1.  From the project service accounts page, select the three dots menu icon under **Actions** for the service account you just created, then select **Manage keys**.
+1.  On the **Keys** page, select **Add key**.
+1.  On the **Create private key** popup, select **JSON** and then **Create**. This triggers a download of a JSON file containing the service account private key and service account details.
 
 ## Add credentials to Seqera
 
@@ -71,7 +71,7 @@ Administrators can create a service account from the Google Cloud console:
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -81,4 +81,4 @@ Administrators can create a service account from the Google Cloud console:
     - **Password**: Specify the JSON key file content. This content is base64-encoded for Artifact Registry. You must remove any line breaks or trailing spaces. For example, `wewogICJ02...9tIgp9Cg==`.
     - **Registry server**: Specify the container registry hostname, excluding the protocol. For example, `<location>-docker.pkg.dev`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/platform_versioned_docs/version-23.3.0/credentials/quay_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.3.0/credentials/quay_registry_credentials.mdx
@@ -15,12 +15,12 @@ For Quay repositories, we recommend using [robot accounts](https://docs.quay.io/
 
 **Create a Quay robot account**
 
-1. Sign in to [quay.io](https://quay.io/).
-2. From the user or organization view, select the **Robot Accounts** tab.
-3. Select **Create Robot Account**.
-4. Enter a robot account name. The username for robot accounts have the format `namespace+accountname`, where `namespace` is the user or organization name and `accountname` is your chosen robot account name.
-5. Grant the robot account repository **Read** permissions from **Settings > User and Robot Permissions** in the repository view.
-6. Select the robot account in your admin panel to retrieve the token value.
+1.  Sign in to [quay.io](https://quay.io/).
+1.  From the user or organization view, select the **Robot Accounts** tab.
+1.  Select **Create Robot Account**.
+1.  Enter a robot account name. The username for robot accounts have the format `namespace+accountname`, where `namespace` is the user or organization name and `accountname` is your chosen robot account name.
+1.  Grant the robot account repository **Read** permissions from **Settings > User and Robot Permissions** in the repository view.
+1.  Select the robot account in your admin panel to retrieve the token value.
 
 ## Add credentials to Seqera
 
@@ -28,7 +28,7 @@ For Quay repositories, we recommend using [robot accounts](https://docs.quay.io/
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -36,4 +36,4 @@ For Quay repositories, we recommend using [robot accounts](https://docs.quay.io/
     - **Password**: Specify your robot account access token. For example, `PasswordFromQuayAdminPanel`.
     - **Registry server**: Specify your container registry hostname. For example, `quay.io`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/platform_versioned_docs/version-23.3.0/credentials/ssh_credentials.mdx
+++ b/platform_versioned_docs/version-23.3.0/credentials/ssh_credentials.mdx
@@ -21,11 +21,11 @@ To use SSH public key authentication:
 To generate an SSH key pair:
 
 1.  From the target machine, open a terminal window and run `ssh-keygen`.
-2.  Follow the prompts to:
+1.  Follow the prompts to:
     - Specify a file path and name (or keep the default).
     - Specify a passphrase (recommended).
-3. Navigate to the target folder (default `/home/user/.ssh/id_rsa`) and open the private key file with a plain text editor.
-4. Copy the private key file contents before navigating to Seqera.
+1.  Navigate to the target folder (default `/home/user/.ssh/id_rsa`) and open the private key file with a plain text editor.
+1.  Copy the private key file contents before navigating to Seqera.
 
 ## Create an SSH credential in Seqera
 
@@ -33,7 +33,7 @@ To generate an SSH key pair:
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     ![](./_images/ssh_credential.png)
 
@@ -44,4 +44,4 @@ To generate an SSH key pair:
     | SSH private key | The SSH private key file contents.                                                                             | `-----BEGIN OPENSSH PRIVATE KEY-----b3BlbnNza....` |
     | Passphrase      | SSH private key passphrase (recommended). If your key pair was created without a passphrase, leave this blank. |                                                    |
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/platform_versioned_docs/version-23.3.0/data/data-explorer.mdx
+++ b/platform_versioned_docs/version-23.3.0/data/data-explorer.mdx
@@ -122,29 +122,29 @@ Apply a [CORS configuration](https://learn.microsoft.com/en-us/rest/api/storages
 
 **Seqera Cloud Azure CORS configuration**
 
-1. From the [Azure portal](https://portal.azure.com), go to the **Storage account** you wish to configure.
-2. Under **Settings** in the left navigation menu, select **Resource sharing (CORS)**.
-3. Add a new entry under **Blob service**:
+1.  From the [Azure portal](https://portal.azure.com), go to the **Storage account** you wish to configure.
+1.  Under **Settings** in the left navigation menu, select **Resource sharing (CORS)**.
+1.  Add a new entry under **Blob service**:
 
 - **Allowed origins**: `https://tower.nf`
 - **Allowed methods**: `GET,POST,PUT,DELETE,HEAD`
 - **Allowed headers**: `x-ms-blob-type,content-type`
 - **Exposed headers**: `x-ms-blob-type`
 
-4. Select **Save** to apply the CORS configuration.
+1.  Select **Save** to apply the CORS configuration.
 
 **Seqera Enterprise Azure CORS configuration**
 
-1. From the [Azure portal](https://portal.azure.com), go to the Storage account you wish to configure.
-2. Under **Settings** in the left navigation menu, select **Resource sharing (CORS)**.
-3. Add a new entry under **Blob service**:
+1.  From the [Azure portal](https://portal.azure.com), go to the Storage account you wish to configure.
+1.  Under **Settings** in the left navigation menu, select **Resource sharing (CORS)**.
+1.  Add a new entry under **Blob service**:
 
 - **Allowed origins**: `https://<your_seqera_instance_url>`
 - **Allowed methods**: `GET,POST,PUT,DELETE,HEAD`
 - **Allowed headers**: `x-ms-blob-type,content-type`
 - **Exposed headers**: `x-ms-blob-type`
 
-4. Select **Save** to apply the CORS configuration.
+1.  Select **Save** to apply the CORS configuration.
 
 ### Google Cloud Storage CORS configuration
 

--- a/platform_versioned_docs/version-23.3.0/data/data-studios.mdx
+++ b/platform_versioned_docs/version-23.3.0/data/data-studios.mdx
@@ -29,12 +29,12 @@ Select the **Data Studios** tab to view all data studios. The list includes the 
 
 ### Add a data studio
 
-1. Select **Add data studio**.
-2. Select a template from the three options provided (JupyterLab, RStudio Server, or Visual Studio Code).
-3. Select a compute environment. Currently, only AWS Batch is supported.
-4. Mount data using Data explorer: Select one or more datasets to mount. Mounted data doesn't need to match the compute environment or region of the cloud provider of the data studio. However, this might cause increased costs or errors.
-5. Optional: Enter CPU and memory allocations. The default values are 2 CPUs and 8192 MB memory (RAM).
-6. Select **Add**.
+1.  Select **Add data studio**.
+1.  Select a template from the three options provided (JupyterLab, RStudio Server, or Visual Studio Code).
+1.  Select a compute environment. Currently, only AWS Batch is supported.
+1.  Mount data using Data explorer: Select one or more datasets to mount. Mounted data doesn't need to match the compute environment or region of the cloud provider of the data studio. However, this might cause increased costs or errors.
+1.  Optional: Enter CPU and memory allocations. The default values are 2 CPUs and 8192 MB memory (RAM).
+1.  Select **Add**.
 
 You'll be returned to the Data Studios landing page that displays the list of data studios in your workspace. The data studio you created will be listed with the status **stopped**.
 

--- a/platform_versioned_docs/version-23.3.0/data/datasets.mdx
+++ b/platform_versioned_docs/version-23.3.0/data/datasets.mdx
@@ -47,11 +47,11 @@ Datasets can point to files stored in various locations, such as Amazon S3 or Gi
 
 All Seqera users have access to the datasets feature in organization workspaces. To create a new dataset:
 
-1. Open the **Datasets** tab in your organization workspace.
-2. Select **New dataset**.
-3. Complete the **Name** and **Description** fields using information relevant to your dataset.
-4. Add the dataset file to your workspace with drag-and-drop or the system file explorer dialog.
-5. For dataset files that use the first row for column names, customize the dataset view with the **First row as header** option.
+1.  Open the **Datasets** tab in your organization workspace.
+1.  Select **New dataset**.
+1.  Complete the **Name** and **Description** fields using information relevant to your dataset.
+1.  Add the dataset file to your workspace with drag-and-drop or the system file explorer dialog.
+1.  For dataset files that use the first row for column names, customize the dataset view with the **First row as header** option.
 
 :::note
 The size of the dataset file must not exceed 10 MB.
@@ -61,9 +61,9 @@ The size of the dataset file must not exceed 10 MB.
 
 Seqera can accommodate multiple versions of a dataset. To add a new version for an existing dataset, follow these steps:
 
-1. Select **Edit** next to the dataset you wish to update.
-2. In the Edit dialog, select **Add a new version**.
-3. Upload the newer version of the dataset and select **Update**.
+1.  Select **Edit** next to the dataset you wish to update.
+1.  In the Edit dialog, select **Add a new version**.
+1.  Upload the newer version of the dataset and select **Update**.
 
 :::caution
 All subsequent versions of a dataset must be the same format (CSV or TSV) as the initial version.
@@ -73,9 +73,9 @@ All subsequent versions of a dataset must be the same format (CSV or TSV) as the
 
 To use a dataset with the saved pipelines in your workspace:
 
-1. Open any pipeline that contains a pipeline schema from the [Launchpad](../launch/launchpad.mdx).
-2. Select the input field for the pipeline, removing any default value.
-3. Pick the dataset to use as input to your pipeline.
+1.  Open any pipeline that contains a pipeline schema from the [Launchpad](../launch/launchpad.mdx).
+1.  Select the input field for the pipeline, removing any default value.
+1.  Pick the dataset to use as input to your pipeline.
 
 :::note
 The input field drop-down menu will only display datasets that match the file type specified in the `nextflow_schema.json` of the chosen pipeline. If the schema specifies `"mimetype": "text/csv"`, no TSV datasets will be available for use with that pipeline, and vice-versa.

--- a/platform_versioned_docs/version-23.3.0/enterprise/_templates/nginx/cert_on_frontend.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/_templates/nginx/cert_on_frontend.mdx
@@ -1,7 +1,7 @@
 title: "cert_on_frontend"
 This example assumes deployment on an Amazon Linux 2 AMI.
 
-1. Install NGINX and other required packages:
+1.  Install NGINX and other required packages:
 
    ```yml
    sudo amazon-linux-extras install nginx1.12
@@ -12,9 +12,9 @@ This example assumes deployment on an Amazon Linux 2 AMI.
    sudo amazon-linux-extras install epel -y
    ```
 
-2. Generate a [private certificate and key](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs).
+1.  Generate a [private certificate and key](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs).
 
-3. Create a `ssl.conf` file.
+1.  Create a `ssl.conf` file.
 
    ```ini
 
@@ -52,15 +52,15 @@ This example assumes deployment on an Amazon Linux 2 AMI.
 
    ```
 
-4. Make a local copy of the `frontend` container's `/etc/nginx/nginx.conf` file.
+1.  Make a local copy of the `frontend` container's `/etc/nginx/nginx.conf` file.
 
-5. Add the following to the `server` block of your local `nginx.conf` file:
+1.  Add the following to the `server` block of your local `nginx.conf` file:
 
    ```ini
    include /etc/nginx/ssl.conf;
    ```
 
-6. Modify the `frontend` container definition in your `docker-compose.yml` file:
+1.  Modify the `frontend` container definition in your `docker-compose.yml` file:
 
    ```yml
    frontend:

--- a/platform_versioned_docs/version-23.3.0/enterprise/advanced-topics/cloudformation.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/advanced-topics/cloudformation.mdx
@@ -14,11 +14,11 @@ This guide assumes that all [prerequisites](../prerequisites/aws.mdx) have been 
 
 ## Set up an ECS cluster
 
-1. Navigate to the ECS console in AWS.
+1.  Navigate to the ECS console in AWS.
 
-2. Select **Create cluster**.
+1.  Select **Create cluster**.
 
-3. Select **Amazon ECS > Clusters > EC2 Linux + Networking**.
+1.  Select **Amazon ECS > Clusters > EC2 Linux + Networking**.
 
 ### ECS Cluster Configuration
 
@@ -47,13 +47,13 @@ This guide assumes that all [prerequisites](../prerequisites/aws.mdx) have been 
 
 ## Deploy Tower
 
-1. Download [aws-ecs-cloudformation.json](../_templates/cloudformation/aws-ecs-cloudformation.json) and [params.json.template](../_templates/cloudformation/params.json.template).
+1.  Download [aws-ecs-cloudformation.json](../_templates/cloudformation/aws-ecs-cloudformation.json) and [params.json.template](../_templates/cloudformation/params.json.template).
 
-2. Rename `params.template.json` to `params.json` and configure for your environment.
+1.  Rename `params.template.json` to `params.json` and configure for your environment.
 
    For more information on configuration, visit the [Configuration](../configuration/overview.mdx) section.
 
-3. Deploy the Tower stack to your ECS cluster:
+1.  Deploy the Tower stack to your ECS cluster:
 
    ```bash
    aws cloudformation create-stack \

--- a/platform_versioned_docs/version-23.3.0/enterprise/advanced-topics/db-docker-to-RDS.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/advanced-topics/db-docker-to-RDS.mdx
@@ -23,9 +23,9 @@ While [Docker Compose](../docker-compose.mdx) is a fast and convenient way to de
 
 Before starting your migration:
 
-1. Create an RDS MySQL-compliant instance and populate it with a [Seqera user and database](../configuration/overview.mdx#seqera-and-redis-databases).
+1.  Create an RDS MySQL-compliant instance and populate it with a [Seqera user and database](../configuration/overview.mdx#seqera-and-redis-databases).
 
-2. Ensure both your database and EC2 instances' Security Group(s) have been configured to allow MySQL traffic (default: Port 3306).
+1.  Ensure both your database and EC2 instances' Security Group(s) have been configured to allow MySQL traffic (default: Port 3306).
 
 ## Migration steps
 
@@ -37,67 +37,67 @@ These migration instructions assume:
 
 :::
 
-1. Connect to the EC2 instance with SSH and navigate to your Seqera instance's `docker-compose` folder.
+1.  Connect to the EC2 instance with SSH and navigate to your Seqera instance's `docker-compose` folder.
 
-2. Shut down the application:
+1.  Shut down the application:
 
    ```bash
    docker-compose down
    ```
 
-3. Mount a new folder into the MySQL container for migration activities:
+1.  Mount a new folder into the MySQL container for migration activities:
 
-   1. Create a new folder to hold migration artefacts:
+   1.  Create a new folder to hold migration artefacts:
 
       ```bash
       mkdir ~/tower_migration
       ```
 
-   2. Back up the database:
+   2.  Back up the database:
 
       ```bash
       sudo tar -zcvf ~/tower_migration/tower_backup.tar.gz ~/.tower/db/mysql
       ```
 
-4. Add a new volume entry for the db container to the Seqera `docker-compose.yml`:
+1.  Add a new volume entry for the db container to the Seqera `docker-compose.yml`:
 
    ```
    $HOME/tower_migration:/tower_migration
    ```
 
-5. Restart the application to confirm your changes were successful:
+1.  Restart the application to confirm your changes were successful:
 
    ```bash
    docker-compose up
    ```
 
-6. Stop all the non-MySQL containers:
+1.  Stop all the non-MySQL containers:
 
    ```bash
    docker container stop <CONTAINER ID>
    ```
 
-7. Exec onto the MySQL container:
+1.  Exec onto the MySQL container:
 
    ```bash
    docker exec -it <CONTAINER ID> /bin/bash
    ```
 
-   1. Dump your data to disk:
+   1.  Dump your data to disk:
 
       ```bash
       mysqldump -u tower -p --databases tower --no-tablespaces --set-gtid-purged=OFF > /tower_migration/tower_dumpfile.sql
       ```
 
-   2. Exit the container.
+   2.  Exit the container.
 
-8. Stop the MySQL container:
+1.  Stop the MySQL container:
 
    ```bash
    docker container stop <CONTAINER ID>
    ```
 
-9. Import the dump file into your new RDS instance:
+1.  Import the dump file into your new RDS instance:
 
    ```bash
    mysql --host <DB-HOST> --port 3306 -u tower -p tower < ~/tower_migration/tower_dumpfile.sql
@@ -106,8 +106,8 @@ These migration instructions assume:
    :::note
    If you encounter an `Access denied; you need (at least one of) the SUPER or SET_USER_ID privilege(s) for this operation` error, do the following:
 
-   1. Create a backup of your MySQL dump file (`tower_dumpfile.sql`).
-   2. Run the following command on the dump file:
+   1.  Create a backup of your MySQL dump file (`tower_dumpfile.sql`).
+   2.  Run the following command on the dump file:
 
    ```bash
    sed 's/\sDEFINER=`[^`]*`@`[^`]*`//g' -i tower_dumpfile.sql
@@ -115,20 +115,20 @@ These migration instructions assume:
 
    :::
 
-10. Log in to the RDS instance and ensure that the Seqera database is populated with tables prefixed by `tw_`.
+1.  Log in to the RDS instance and ensure that the Seqera database is populated with tables prefixed by `tw_`.
 
-11. Modify the `tower.env` config file in the Seqera Docker folder:
+1.  Modify the `tower.env` config file in the Seqera Docker folder:
 
-    1. Comment out the existing `TOWER_DB-*` variables.
-    2. Add new entries [relevant to your database](../configuration/overview.mdx#seqera-and-redis-databases).
-    3. Save and exit.
+    1.  Comment out the existing `TOWER_DB-*` variables.
+    2.  Add new entries [relevant to your database](../configuration/overview.mdx#seqera-and-redis-databases).
+    3.  Save and exit.
 
-12. Restart the application:
+1.  Restart the application:
 
     ```bash
     docker-compose up
     ```
 
-13. Confirm that Seqera Enterprise starts and that your data is available when you log in.
+1.  Confirm that Seqera Enterprise starts and that your data is available when you log in.
 
 The migration is complete and testing can begin.

--- a/platform_versioned_docs/version-23.3.0/enterprise/advanced-topics/manual-aws-batch-setup.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/advanced-topics/manual-aws-batch-setup.mdx
@@ -18,21 +18,21 @@ Batch Forge _automatically creates_ the AWS Batch queues required for your workf
 
 Complete the following procedures to configure AWS Batch manually:
 
-1. Create a user policy.
-2. Create the instance role policy.
-3. Create the AWS Batch service role.
-4. Create an EC2 Instance role.
-5. Create an EC2 SpotFleet role.
-6. Create a launch template.
-7. Create the AWS Batch compute environments.
-8. Create the AWS Batch queue.
+1.  Create a user policy.
+1.  Create the instance role policy.
+1.  Create the AWS Batch service role.
+1.  Create an EC2 Instance role.
+1.  Create an EC2 SpotFleet role.
+1.  Create a launch template.
+1.  Create the AWS Batch compute environments.
+1.  Create the AWS Batch queue.
 
 ### Create a user policy
 
 Create the policy for the user launching Nextflow jobs:
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create policy** from the Policies page.
-1. Create a new policy with the following content:
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create policy** from the Policies page.
+1.  Create a new policy with the following content:
 
    ```json
    {
@@ -58,14 +58,14 @@ Create the policy for the user launching Nextflow jobs:
    }
    ```
 
-1. Save with it the name `seqera-user`.
+1.  Save with it the name `seqera-user`.
 
 ### Create the instance role policy
 
 Create the policy with a role that allows Seqera to submit Batch jobs on your EC2 instances:
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create policy** from the Policies page.
-1. Create a new policy with the following content:
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create policy** from the Policies page.
+1.  Create a new policy with the following content:
 
    ```json
    {
@@ -105,39 +105,39 @@ Create the policy with a role that allows Seqera to submit Batch jobs on your EC
    }
    ```
 
-1. Save it with the name `seqera-batchjob`.
+1.  Save it with the name `seqera-batchjob`.
 
 ### Create the Batch Service role
 
 Create a service role used by AWS Batch to launch EC2 instances on your behalf:
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
-1. Select **AWS service** as the trusted entity type, and **Batch** as the service.
-1. On the next page, the `AWSBatchServiceRole` is already attached. No further permissions are needed for this role.
-1. Enter `seqera-servicerole` as the role name and add an optional description and tags if needed, then select **Create**.
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
+1.  Select **AWS service** as the trusted entity type, and **Batch** as the service.
+1.  On the next page, the `AWSBatchServiceRole` is already attached. No further permissions are needed for this role.
+1.  Enter `seqera-servicerole` as the role name and add an optional description and tags if needed, then select **Create**.
 
 ### Create an EC2 instance role
 
 Create a role that controls which AWS resources the EC2 instances launched by AWS Batch can access:
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
-1. Select AWS service as the trusted entity type, EC2 as the service, and _EC2 - Allows EC2 instances to call AWS services on your behalf_ as the use case.
-1. Select **Next: Permissions**. Search for the following policies to attach to the role:
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
+1.  Select AWS service as the trusted entity type, EC2 as the service, and _EC2 - Allows EC2 instances to call AWS services on your behalf_ as the use case.
+1.  Select **Next: Permissions**. Search for the following policies to attach to the role:
 
-	- `AmazonEC2ContainerServiceforEC2Role`
-	- `AmazonS3FullAccess` (you may want to use a custom policy to allow access only on specific S3 buckets)
-	- `seqera-batchjob` (the instance role policy created above)
+  - `AmazonEC2ContainerServiceforEC2Role`
+  - `AmazonS3FullAccess` (you may want to use a custom policy to allow access only on specific S3 buckets)
+  - `seqera-batchjob` (the instance role policy created above)
 
-1. Enter `seqera-instancerole` as the role name and add an optional description and tags if needed, then select **Create**.
+1.  Enter `seqera-instancerole` as the role name and add an optional description and tags if needed, then select **Create**.
 
 ### Create an EC2 SpotFleet role
 
 The EC2 SpotFleet role allows you to use Spot instances when you run jobs in AWS Batch. Create a role for the creation and launch of Spot fleets — Spot instances with similar compute capabilities (i.e., vCPUs and RAM):
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
-1. Select AWS service as the trusted entity type, EC2 as the service, and _EC2 - Spot Fleet Tagging_ as the use case.
-1. On the next page, the `AmazonEC2SpotFleetTaggingRole` is already attached. No further permissions are needed for this role.
-1. Enter `seqera-fleetrole` as the role name and add an optional description and tags if needed, then select **Create**.
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
+1.  Select AWS service as the trusted entity type, EC2 as the service, and _EC2 - Spot Fleet Tagging_ as the use case.
+1.  On the next page, the `AmazonEC2SpotFleetTaggingRole` is already attached. No further permissions are needed for this role.
+1.  Enter `seqera-fleetrole` as the role name and add an optional description and tags if needed, then select **Create**.
 
 ### Create a launch template
 
@@ -146,8 +146,8 @@ Create a launch template to configure the EC2 instances deployed by Batch jobs:
 <Tabs>
 <TabItem value="AWS Batch with Fusion v2" label="AWS Batch with Fusion v2" default>
 
-  1. In the [EC2 Console](https://console.aws.amazon.com/ec2/v2/home), select **Create launch template** from the Launch templates page.
-  1. Scroll down to **Advanced details** and paste the following in the **User data** field:
+  1.  In the [EC2 Console](https://console.aws.amazon.com/ec2/v2/home), select **Create launch template** from the Launch templates page.
+  1.  Scroll down to **Advanced details** and paste the following in the **User data** field:
 
     ```bash
     MIME-Version: 1.0
@@ -212,14 +212,14 @@ Create a launch template to configure the EC2 instances deployed by Batch jobs:
     --//--
     ```
 
-  1. In the line `| sed 's/$FORGE_ID/<your prefix>/g' \`, replace `<your prefix>` with your desired prefix to be added to the AWS resources created by your compute environment.
-  1. Save the template with the name `seqera-launchtemplate`.
+  1.  In the line `| sed 's/$FORGE_ID/<your prefix>/g' \`, replace `<your prefix>` with your desired prefix to be added to the AWS resources created by your compute environment.
+  1.  Save the template with the name `seqera-launchtemplate`.
 
 </TabItem>
 <TabItem value="AWS Batch without Fusion v2" label="AWS Batch without Fusion v2" default>
 
-  1. In the [EC2 Console](https://console.aws.amazon.com/ec2/v2/home), select **Create launch template** from the Launch templates page.
-  1. Scroll down to **Advanced details** and paste the following in the **User data** field:
+  1.  In the [EC2 Console](https://console.aws.amazon.com/ec2/v2/home), select **Create launch template** from the Launch templates page.
+  1.  Scroll down to **Advanced details** and paste the following in the **User data** field:
 
     ```bash
     MIME-Version: 1.0
@@ -268,8 +268,8 @@ Create a launch template to configure the EC2 instances deployed by Batch jobs:
     --//--
     ```
 
-  1. In the line `| sed 's/$FORGE_ID/<your prefix>/g' \`, replace `<your prefix>` with your desired prefix to be added to the AWS resources created by your compute environment.
-  1. Save the template with the name `seqera-launchtemplate`.
+  1.  In the line `| sed 's/$FORGE_ID/<your prefix>/g' \`, replace `<your prefix>` with your desired prefix to be added to the AWS resources created by your compute environment.
+  1.  Save the template with the name `seqera-launchtemplate`.
 
 </TabItem>
 </Tabs>
@@ -294,37 +294,37 @@ Create a compute environment for each queue in the AWS Batch console:
 
 The head queue requires an on-demand compute environment. Do not select **Use Spot instances** during compute environment creation.
 
-1. In the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home), select **Create** on the Compute environments page.
-1. Select **Amazon EC2** as the compute environment configuration.
+1.  In the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home), select **Create** on the Compute environments page.
+1.  Select **Amazon EC2** as the compute environment configuration.
 
     :::note
     Seqera AWS Batch compute environments created with [Batch Forge](../../compute-envs/aws-batch.md#tower-forge-compute-environment) support using Fargate for the head job, but manual compute environments must use EC2.
     :::
 
-1. Enter a name of your choice, and apply the `seqera-servicerole` and `seqera-instancerole`.
-1. Enter vCPU limits and instance types, if needed.
+1.  Enter a name of your choice, and apply the `seqera-servicerole` and `seqera-instancerole`.
+1.  Enter vCPU limits and instance types, if needed.
 
     :::note
     To use the same queue for both head and compute tasks, you must assign sufficient resources to your compute environment.
     :::
 
-1. Expand **Additional configuration** and select the `seqera-launchtemplate` from the Launch template dropdown.
-1. Configure VPCs, subnets, and security groups on the next page as needed.
-1. Review your configuration and select **Create compute environment**.  
+1.  Expand **Additional configuration** and select the `seqera-launchtemplate` from the Launch template dropdown.
+1.  Configure VPCs, subnets, and security groups on the next page as needed.
+1.  Review your configuration and select **Create compute environment**.  
 
 </TabItem>
 <TabItem value="Compute queue with Spot instances" label="Compute queue with Spot instances" default>
 
 Create this compute environment to use Spot instances for your workflow compute tasks. This compute environment cannot be assigned to the Nextflow head job queue.
 
-1. In the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home), select **Create** on the Compute environments page.
-1. Select **Amazon EC2** as the compute environment configuration.
-1. Enter a name of your choice, and apply the `seqera-servicerole` and `seqera-instancerole`.
-1. Select **Enable using Spot instances** to use Spot instances and save computing costs.  
-1. Select the `seqera-fleetrole` and enter vCPU limits and instance types, if needed.
-1. Expand **Additional configuration** and select the `seqera-launchtemplate` from the Launch template dropdown.
-1. Configure VPCs, subnets, and security groups on the next page as needed.
-1. Review your configuration and select **Create compute environment**.  
+1.  In the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home), select **Create** on the Compute environments page.
+1.  Select **Amazon EC2** as the compute environment configuration.
+1.  Enter a name of your choice, and apply the `seqera-servicerole` and `seqera-instancerole`.
+1.  Select **Enable using Spot instances** to use Spot instances and save computing costs.  
+1.  Select the `seqera-fleetrole` and enter vCPU limits and instance types, if needed.
+1.  Expand **Additional configuration** and select the `seqera-launchtemplate` from the Launch template dropdown.
+1.  Configure VPCs, subnets, and security groups on the next page as needed.
+1.  Review your configuration and select **Create compute environment**.  
 
 </TabItem>
 </Tabs>
@@ -340,18 +340,18 @@ You only need to create one queue if you intend to use on-demand instances for y
 <Tabs>
 <TabItem value="Head queue" label="Head queue" default>
 
-1. Go to the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home).
-2. Create a new queue.
-3. Associate the queue with the head queue compute environment created in the previous section.
-4. Save it with a name of your choice.
+1.  Go to the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home).
+1.  Create a new queue.
+1.  Associate the queue with the head queue compute environment created in the previous section.
+1.  Save it with a name of your choice.
 
 </TabItem>
 <TabItem value="Compute queue" label="Compute queue" default>
 
-1. Go to the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home).
-2. Create a new queue.
-3. Associate the queue with the compute queue environment created in the previous section.
-4. Save it with a name of your choice.
+1.  Go to the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home).
+1.  Create a new queue.
+1.  Associate the queue with the compute queue environment created in the previous section.
+1.  Save it with a name of your choice.
 
 </TabItem>
 </Tabs>

--- a/platform_versioned_docs/version-23.3.0/enterprise/configuration/authentication.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/configuration/authentication.mdx
@@ -42,12 +42,12 @@ The following identity providers are currently supported:
 
 To use GitHub as SSO provider for Seqera:
 
-1. Register your Seqera instance as a [GitHub OAuth App](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app)
+1.  Register your Seqera instance as a [GitHub OAuth App](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app)
    in your organization settings page.
 
-2. When creating the OAuth App, specify the following path as callback URL: `https://<your-deployment-domain-name>/oauth/callback/github` (replace `<your-deployment-domain-name>` with the domain name of your deployment).
+1.  When creating the OAuth App, specify the following path as callback URL: `https://<your-deployment-domain-name>/oauth/callback/github` (replace `<your-deployment-domain-name>` with the domain name of your deployment).
 
-3. Include the following variables in the backend environment configuration:
+1.  Include the following variables in the backend environment configuration:
 
    - `TOWER_GITHUB_CLIENT`: The client ID provided by GitHub when registering the new OAuth App.
    - `TOWER_GITHUB_SECRET`: The client secret provided by GitHub when registering the new OAuth App.
@@ -56,13 +56,13 @@ To use GitHub as SSO provider for Seqera:
 
 To use Google as the identity provider for Seqera:
 
-1. Visit the [Google Cloud console](https://console.developers.google.com) and create a new project.
-2. From the sidebar, select the **Credentials** tab.
-3. Select **Create credentials > OAuth client ID**.
-4. On the next page, select **Web Application** type.
-5. Enter the redirect URL: `https://<your-deployment-domain-name>/oauth/callback/google` (replace `<{your-deployment-domain-name>` with the domain name of your deployment).
-6. Confirm the operation. You'll then receive a `client ID` and `secret ID`.
-7. Include the `client ID` and `secret ID` in the following variables in the Seqera backend environment configuration:
+1.  Visit the [Google Cloud console](https://console.developers.google.com) and create a new project.
+1.  From the sidebar, select the **Credentials** tab.
+1.  Select **Create credentials > OAuth client ID**.
+1.  On the next page, select **Web Application** type.
+1.  Enter the redirect URL: `https://<your-deployment-domain-name>/oauth/callback/google` (replace `<{your-deployment-domain-name>` with the domain name of your deployment).
+1.  Confirm the operation. You'll then receive a `client ID` and `secret ID`.
+1.  Include the `client ID` and `secret ID` in the following variables in the Seqera backend environment configuration:
 
 - `TOWER_GOOGLE_CLIENT`: The client ID provided by Google above.
 - `TOWER_GOOGLE_SECRET`: The client secret provided by Google above.
@@ -71,9 +71,9 @@ To use Google as the identity provider for Seqera:
 
 To use [Keycloak](https://www.keycloak.org/) as the identity provider for Seqera, configure a new client in your Keycloak service with these steps:
 
-1. In the **Realm settings**, ensure the **Endpoints** field includes _OpenID Endpoint Configuration_.
-2. Open the **Client** page and select **Create** to set up a new client for Seqera.
-3. In the **Settings** tag, include the following fields:
+1.  In the **Realm settings**, ensure the **Endpoints** field includes _OpenID Endpoint Configuration_.
+1.  Open the **Client** page and select **Create** to set up a new client for Seqera.
+1.  In the **Settings** tag, include the following fields:
    - **Client Id**: An ID of your choice, e.g., `seqera`
    - **Enabled**: `ON`
    - **Client Protocol**: `openid-connect`
@@ -82,10 +82,10 @@ To use [Keycloak](https://www.keycloak.org/) as the identity provider for Seqera
    - **Implicit Flow Enabled**: `OFF`
    - **Direct Access Grants Enabled**: `ON`
    - **Valid Redirect URIs**: https:///\<YOUR HOST\>//oauth/callback/oidc, e.g., `http://localhost:8000/oauth/callback/oidc`
-4. Select **Save**.
-5. In the **Credentials** tab, note the **Secret** field.
-6. In the **Keys** tab, set the field **Use JWKS URL** to `OFF`.
-7. Complete the setup in Seqera by adding the following environment variables to your configuration:
+1.  Select **Save**.
+1.  In the **Credentials** tab, note the **Secret** field.
+1.  In the **Keys** tab, set the field **Use JWKS URL** to `OFF`.
+1.  Complete the setup in Seqera by adding the following environment variables to your configuration:
 
    - `TOWER_OIDC_CLIENT`: The client ID assigned in step 3 above.
    - `TOWER_OIDC_SECRET`: The contents of the **Secret** field noted in step 5 above.
@@ -95,35 +95,35 @@ To use [Keycloak](https://www.keycloak.org/) as the identity provider for Seqera
 
 To use [Entra ID OIDC](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc) as the identity provider for Seqera, configure a new client in your Entra ID service:
 
-1. Log in to the [Azure portal](https://portal.azure.com/).
-2. Go to the **Entra ID** service.
-3. Select **Manage Tenants**.
-4. Create a new **Tenant**, e.g., `SeqeraOrg`.
-5. Select the new tenant.
-6. Go to **App Registrations**.
-7. Select **New Registration** and specify the following:
+1.  Log in to the [Azure portal](https://portal.azure.com/).
+1.  Go to the **Entra ID** service.
+1.  Select **Manage Tenants**.
+1.  Create a new **Tenant**, e.g., `SeqeraOrg`.
+1.  Select the new tenant.
+1.  Go to **App Registrations**.
+1.  Select **New Registration** and specify the following:
 
-   1. A name for the application.
-   2. The scope of user verification (e.g., single tenant, multi-tenant, personal MSFT accounts, etc).
+   1.  A name for the application.
+   2.  The scope of user verification (e.g., single tenant, multi-tenant, personal MSFT accounts, etc).
 
 :::note
 The Entra ID app must have user consent settings configured to **Allow user consent for apps** to ensure that admin approval is not required for each application login. See [User consent settings](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/configure-user-consent?pivots=portal#configure-user-consent-settings).
 :::
 
-8. Specify the **Redirect** (callback) URI.
+1.  Specify the **Redirect** (callback) URI.
 
 :::note
 This must be an `https://` URI, per Microsoft's requirements.
 :::
 
-9. Open the newly-created app:
+1.  Open the newly-created app:
 
-   1. Note the `Application (client) ID` on the **Essentials** table.
-   2. Generate **Client credentials** on the **Essentials** table.
-   3. Select **Endpoints** and note the OpenID Connect metadata document URI.
+   1.  Note the `Application (client) ID` on the **Essentials** table.
+   2.  Generate **Client credentials** on the **Essentials** table.
+   3.  Select **Endpoints** and note the OpenID Connect metadata document URI.
 
-10. Add users to your tenant as required.
-11. Complete the setup in Seqera by adding the following environment variables to your configuration:
+1.  Add users to your tenant as required.
+1.  Complete the setup in Seqera by adding the following environment variables to your configuration:
 
     ```bash
     TOWER_OIDC_CLIENT=<YOUR_APPLICATION_ID>
@@ -131,26 +131,26 @@ This must be an `https://` URI, per Microsoft's requirements.
     TOWER_OIDC_ISSUER=<YOUR_OIDC_METADATA_URL_UP_TO_"v2.0">   (e.g. https://login.microsoftonline.com/000000-0000-0000-00-0000000000000/v2.0)
     ```
 
-12. Add `auth-oidc` to the `MICRONAUT_ENVIRONMENTS` environment variable for both the `cron` and `backend` services.
+1.  Add `auth-oidc` to the `MICRONAUT_ENVIRONMENTS` environment variable for both the `cron` and `backend` services.
 
 ### Okta identity provider
 
 To use [Okta](https://www.okta.com/) as the identity provider for Seqera:
 
-1. Sign in to your Okta organization with your administrator account.
-2. From the **Admin Console** side navigation, select **Applications > Applications**.
-3. Select **Add Application**.
-4. Select **Create New App**.
-5. Select the **OpenID Connect** sign-on method.
-6. Select **Create**.
-7. Enter a name for your new app integration, e.g., `Seqera`.
-8. In **Configure OpenID Connect**, add the following redirect URIs:
+1.  Sign in to your Okta organization with your administrator account.
+1.  From the **Admin Console** side navigation, select **Applications > Applications**.
+1.  Select **Add Application**.
+1.  Select **Create New App**.
+1.  Select the **OpenID Connect** sign-on method.
+1.  Select **Create**.
+1.  Enter a name for your new app integration, e.g., `Seqera`.
+1.  In **Configure OpenID Connect**, add the following redirect URIs:
 
    - **Sign-in redirect URIs** : `https://<YOUR HOST OR IP>/oauth/callback/oidc`
    - **Sign-out redirect URIs** : `https://<YOUR HOST OR IP>/logout`
 
-9. Select **Save**.
-10. Okta automatically redirects to your new application settings. Complete the setup in Seqera by adding the following environment variables to your configuration:
+1.  Select **Save**.
+1.  Okta automatically redirects to your new application settings. Complete the setup in Seqera by adding the following environment variables to your configuration:
 
     - `TOWER_OIDC_CLIENT`: Copy the **Client ID** value from **General > Client Credentials** for the corresponding app client configuration.
     - `TOWER_OIDC_SECRET`: Copy the **Client secret** value from **General > Client Credentials** for the corresponding app client configuration.

--- a/platform_versioned_docs/version-23.3.0/enterprise/configuration/aws_parameter_store.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/configuration/aws_parameter_store.mdx
@@ -23,10 +23,10 @@ Due to the order of operations when deploying Seqera Enterprise, some configurat
 
 To enable Seqera use AWS Parameter Store values:
 
-1. Grant [AWS Parameter Store permissions](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html) to your Seqera host instance.
-2. Add `TOWER_ENABLE_AWS_SSM=true` in the `tower.env` configuration file.
-3. Create individual parameters in the AWS Parameter Store (see below).
-4. Start your Seqera instance and confirm the following entries appear in the **backend** container log:
+1.  Grant [AWS Parameter Store permissions](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html) to your Seqera host instance.
+1.  Add `TOWER_ENABLE_AWS_SSM=true` in the `tower.env` configuration file.
+1.  Create individual parameters in the AWS Parameter Store (see below).
+1.  Start your Seqera instance and confirm the following entries appear in the **backend** container log:
 
 ```bash
 [main] - INFO  i.m.context.DefaultBeanContext - Reading bootstrap environment configuration
@@ -43,8 +43,8 @@ Seqera does not support StringList parameters. Configuration parameters with mul
 
 To create Seqera configuration parameters in AWS Parameter Store, do the following:
 
-1. Navigate to the **Parameter Store** from the **AWS Systems Manager Service** console.
-2. From the **My parameters** tab, select **Create parameter** and populate as follows:
+1.  Navigate to the **Parameter Store** from the **AWS Systems Manager Service** console.
+1.  From the **My parameters** tab, select **Create parameter** and populate as follows:
 
 | Field | Description |
 | ----- | ----------- |

--- a/platform_versioned_docs/version-23.3.0/enterprise/configuration/overview.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/configuration/overview.mdx
@@ -465,13 +465,13 @@ Simple Email Service (SES) is only supported in Seqera deployments on AWS.
 
 To configure AWS SES as your Seqera email service:
 
-1. Set `TOWER_ENABLE_AWS_SES=true` in your environment variables.
-2. Specify the email address used to send Seqera emails with one of the following:
+1.  Set `TOWER_ENABLE_AWS_SES=true` in your environment variables.
+1.  Specify the email address used to send Seqera emails with one of the following:
     - the `TOWER_CONTACT_EMAIL` environment variable
     - a `mail.from` entry in `tower.yml`
     - a `/config/<application_name>/mail/from` AWS Parameter Store entry
-3. The [AWS SES service](https://docs.aws.amazon.com/ses/index.html) must run in the same region as your Seqera instance.
-4. The [Seqera IAM role](../../compute-envs/aws-batch.mdx#iam) must include the `ses:SendRawEmail` permission.
+1.  The [AWS SES service](https://docs.aws.amazon.com/ses/index.html) must run in the same region as your Seqera instance.
+1.  The [Seqera IAM role](../../compute-envs/aws-batch.mdx#iam) must include the `ses:SendRawEmail` permission.
 
 ## Nextflow launch container
 

--- a/platform_versioned_docs/version-23.3.0/enterprise/configuration/pipeline_optimization.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/configuration/pipeline_optimization.mdx
@@ -17,29 +17,29 @@ Docker Compose makes use of a separate container to set up the pipeline resource
 
 To use the pipeline resource optimization service in a new Docker Compose installation of Seqera Enterprise, use the following steps:
 
-1. To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable in the `tower.env` file. A non-zero value for this environment variable activates the optimization service automatically, so the `TOWER_ENABLE_GROUNDSWELL` variable does not need to be set when you declare a custom URL.
+1.  To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable in the `tower.env` file. A non-zero value for this environment variable activates the optimization service automatically, so the `TOWER_ENABLE_GROUNDSWELL` variable does not need to be set when you declare a custom URL.
 
-2. Set the `TOWER_ENABLE_GROUNDSWELL` environment variable in the `tower.env` file to `true`. This enables the service at the default service URL of `http://groundswell:8090`.
+1.  Set the `TOWER_ENABLE_GROUNDSWELL` environment variable in the `tower.env` file to `true`. This enables the service at the default service URL of `http://groundswell:8090`.
 
-3. In your [docker-compose.yml](../_templates/docker/docker-compose.yml) file, uncomment the `groundswell` section at the bottom.
+1.  In your [docker-compose.yml](../_templates/docker/docker-compose.yml) file, uncomment the `groundswell` section at the bottom.
 
     - To create a schema for the optimization service on the same local MySQL container, uncomment the `init.sql` script in the `volumes` section.
 
-4. Download the [init.sql](../_templates/docker/init.sql) file. Store this file in the mount path of your `docker-compose.yml` file or update the `source: ./init.sql` line in your `docker-compose.yml` with the file path.
+1.  Download the [init.sql](../_templates/docker/init.sql) file. Store this file in the mount path of your `docker-compose.yml` file or update the `source: ./init.sql` line in your `docker-compose.yml` with the file path.
 
-5. When the pipeline resource optimization service is active, pipelines that can be optimized display a lightbulb icon in your Launchpad. Any pipeline with at least one successful run can be optimized.
+1.  When the pipeline resource optimization service is active, pipelines that can be optimized display a lightbulb icon in your Launchpad. Any pipeline with at least one successful run can be optimized.
 
 ### Existing installation
 
 To use the pipeline resource optimization service in an existing Docker Compose installation of Seqera Enterprise, use the following steps:
 
-1. To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable. A non-zero value for this environment variable activates the optimization service automatically, so the `TOWER_ENABLE_GROUNDSWELL` variable does not need to be set when you declare a custom URL.
+1.  To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable. A non-zero value for this environment variable activates the optimization service automatically, so the `TOWER_ENABLE_GROUNDSWELL` variable does not need to be set when you declare a custom URL.
 
-2. Set the `TOWER_ENABLE_GROUNDSWELL` environment variable to `true`. This enables the service at the default service URL `http://groundswell:8090`.
+1.  Set the `TOWER_ENABLE_GROUNDSWELL` environment variable to `true`. This enables the service at the default service URL `http://groundswell:8090`.
 
-3. In your [docker-compose.yml](../_templates/docker/docker-compose.yml) file, uncomment the `groundswell` section at the bottom. If you use a `docker-compose.yml` file older than version 23.3, download a newer version of the file to extract the `groundswell` section.
+1.  In your [docker-compose.yml](../_templates/docker/docker-compose.yml) file, uncomment the `groundswell` section at the bottom. If you use a `docker-compose.yml` file older than version 23.3, download a newer version of the file to extract the `groundswell` section.
 
-4. Log in to your database server and run the following commands:
+1.  Log in to your database server and run the following commands:
 
     ```sql
     CREATE DATABASE IF NOT EXISTS `swell`;
@@ -48,7 +48,7 @@ To use the pipeline resource optimization service in an existing Docker Compose 
     FLUSH PRIVILEGES;
     ```
 
-5. If you use Amazon RDS or other managed database services, run the following commands in your database instance:
+1.  If you use Amazon RDS or other managed database services, run the following commands in your database instance:
 
     ```sql
     CREATE DATABASE IF NOT EXISTS `swell`;
@@ -57,7 +57,7 @@ To use the pipeline resource optimization service in an existing Docker Compose 
     FLUSH PRIVILEGES;
     ```
 
-6. Download the [groundswell.env](../_templates/docker/groundswell.env) file. Store this file in the mount path of your `docker-compose.yml` file. Update the `TOWER_DB_URL` and `SWELL_DB_URL` environment variable values:
+1.  Download the [groundswell.env](../_templates/docker/groundswell.env) file. Store this file in the mount path of your `docker-compose.yml` file. Update the `TOWER_DB_URL` and `SWELL_DB_URL` environment variable values:
 
     ```env
     # Uncomment for container DB instances
@@ -69,17 +69,17 @@ To use the pipeline resource optimization service in an existing Docker Compose 
     # SWELL_DB_URL=mysql://db1.abcdefghijkl.us-east-1.rds.amazonaws.com:3306/swell
     ```
 
-7. When the pipeline resource optimization service is active, pipelines that can be optimized display a lightbulb icon in your Launchpad. Any pipeline with at least one successful run can be optimized.
+1.  When the pipeline resource optimization service is active, pipelines that can be optimized display a lightbulb icon in your Launchpad. Any pipeline with at least one successful run can be optimized.
 
 ## Kubernetes deployment
 
 Kubernetes deployments use an [initContainer](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that runs during pod initialization to set up the pipeline resource optimization service. To use the service in new or existing Kubernetes installations of Seqera Enterprise, do the following:
 
-1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml).
+1.  Download the [groundswell manifest](../_templates/k8s/groundswell.yml).
 
-2. Define a set of credentials for the optimization database. This can be the same database used for Seqera, but in a different schema.
+1.  Define a set of credentials for the optimization database. This can be the same database used for Seqera, but in a different schema.
 
-3. Log in to your database server and run the following commands:
+1.  Log in to your database server and run the following commands:
 
     ```sql
     CREATE DATABASE IF NOT EXISTS `swell`;
@@ -88,7 +88,7 @@ Kubernetes deployments use an [initContainer](https://kubernetes.io/docs/concept
     FLUSH PRIVILEGES;
     ```
 
-4. If you use Amazon RDS or other managed database services, run the following commands in your database instance:
+1.  If you use Amazon RDS or other managed database services, run the following commands in your database instance:
 
     ```sql
     CREATE DATABASE IF NOT EXISTS `swell`;
@@ -97,6 +97,6 @@ Kubernetes deployments use an [initContainer](https://kubernetes.io/docs/concept
     FLUSH PRIVILEGES;
     ```
 
-5. The initContainers process will wait until both the Seqera and pipeline resource optimization service databases are ready before starting the migration in the Seqera database and finally starting the optimization container.
+1.  The initContainers process will wait until both the Seqera and pipeline resource optimization service databases are ready before starting the migration in the Seqera database and finally starting the optimization container.
 
-6. When the pipeline resource optimization service is active, pipelines that can be optimized display a lightbulb icon in your Launchpad. Any pipeline with at least one successful run can be optimized.
+1.  When the pipeline resource optimization service is active, pipelines that can be optimized display a lightbulb icon in your Launchpad. Any pipeline with at least one successful run can be optimized.

--- a/platform_versioned_docs/version-23.3.0/enterprise/configuration/reverse_proxy.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/configuration/reverse_proxy.mdx
@@ -11,13 +11,13 @@ As of January 2024, this configuration guide is not currently recommended for pr
 
 To expose your Seqera instance behind a reverse proxy, complete the following steps:
 
-1. Use the [Seqera frontend unprivileged](../kubernetes.mdx#seqera-frontend-unprivileged) image.
-2. Add `TOWER_BASE_PATH` to the environment variables of the frontend container:
+1.  Use the [Seqera frontend unprivileged](../kubernetes.mdx#seqera-frontend-unprivileged) image.
+1.  Add `TOWER_BASE_PATH` to the environment variables of the frontend container:
    - `TOWER_BASE_PATH: "/myseqera/"` exposes your instance at `https://example.com/myseqera/` (this must match your proxy configuration)
-3. In the backend/cron environment variables or in the Seqera config file, edit the following environment variables:
+1.  In the backend/cron environment variables or in the Seqera config file, edit the following environment variables:
    - Set `TOWER_SERVER_URL` to the complete URL where you want to expose your instance, e.g., `TOWER_SERVER_URL: "https://example.com/myseqera"` (without the trailing slash)
    - Disable/unset `TOWER_LANDING_URL`
-4. Configure your reverse proxy to redirect all Seqera-related links to your Seqera frontend container:
+1.  Configure your reverse proxy to redirect all Seqera-related links to your Seqera frontend container:
 
 - If your frontend container listens on `http://tower-frontend:8080` and you're using Apache HTTP as your reverse proxy, add the following lines at the end of your configuration file (replace `/myseqera/` with the URL you defined in `TOWER_BASE_PATH`):
 

--- a/platform_versioned_docs/version-23.3.0/enterprise/configuration/ssl_tls.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/configuration/ssl_tls.mdx
@@ -18,19 +18,19 @@ If you secure related infrastructure (such as private Git repositories) with cer
 
 **Configure private certificate trust**
 
-1. This guide assumes you're using the original containers supplied by Seqera.
-2. Replace `TARGET_HOSTNAME`, `TARGET_ALIAS`, and `PRIVATE_CERT.pem` with your unique values.
-3. Previous instructions advised using `openssl`. The native `keytool` utility is preferred as it simplifies steps and better accommodates private CA certificates.
+1.  This guide assumes you're using the original containers supplied by Seqera.
+1.  Replace `TARGET_HOSTNAME`, `TARGET_ALIAS`, and `PRIVATE_CERT.pem` with your unique values.
+1.  Previous instructions advised using `openssl`. The native `keytool` utility is preferred as it simplifies steps and better accommodates private CA certificates.
 
 **Use Docker volume**
 
-1. Retrieve the private certificate on your Seqera container host:
+1.  Retrieve the private certificate on your Seqera container host:
 
 ```
 keytool -printcert -rfc -sslserver TARGET_HOSTNAME:443  >  /PRIVATE_CERT.pem
 ```
 
-2. Modify the `backend` and `cron` container configuration blocks in `docker-compose.yml`:
+1.  Modify the `backend` and `cron` container configuration blocks in `docker-compose.yml`:
 
 ```yaml
 CONTAINER_NAME:
@@ -52,19 +52,19 @@ CONTAINER_NAME:
 
 **Use K8s ConfigMap**
 
-1. Retrieve the private certificate on a machine with CLI access to your Kubernetes cluster:
+1.  Retrieve the private certificate on a machine with CLI access to your Kubernetes cluster:
 
 ```bash
 keytool -printcert -rfc -sslserver TARGET_HOSTNAME:443 > /PRIVATE_CERT.pem
 ```
 
-2. Load the certificate as a `ConfigMap` in the same namespace where your Seqera instance will run:
+1.  Load the certificate as a `ConfigMap` in the same namespace where your Seqera instance will run:
 
 ```bash
 kubectl create configmap private-cert-pemstore --from-file=/PRIVATE_CERT.pem
 ```
 
-3. Modify both the `backend` and `cron` Deployment objects:
+1.  Modify both the `backend` and `cron` Deployment objects:
 
 - Define a new volume based on the certificate `ConfigMap`:
 
@@ -110,7 +110,7 @@ kubectl create configmap private-cert-pemstore --from-file=/PRIVATE_CERT.pem
 
 **Download on Pod start**
 
-1. Modify both the `backend` and `cron` Deployment objects to retrieve and load the certificate prior to running your Seqera instance:
+1.  Modify both the `backend` and `cron` Deployment objects to retrieve and load the certificate prior to running your Seqera instance:
 
 ```yaml
 spec:
@@ -133,9 +133,9 @@ If you secure infrastructure such as private Git repositories or your Seqera Ent
 
 **Import private certificates via pre-run script**
 
-1. This configuration assumes you're using the default `nf-launcher` image supplied by Seqera.
-2. Replace `TARGET_HOSTNAME`, `TARGET_ALIAS`, and `PRIVATE_CERT.pem` with your unique values.
-3. Previous instructions advised using `openssl`. The native `keytool` utility is preferred as it simplifies steps and better accommodates private CA certificates.
+1.  This configuration assumes you're using the default `nf-launcher` image supplied by Seqera.
+1.  Replace `TARGET_HOSTNAME`, `TARGET_ALIAS`, and `PRIVATE_CERT.pem` with your unique values.
+1.  Previous instructions advised using `openssl`. The native `keytool` utility is preferred as it simplifies steps and better accommodates private CA certificates.
 
 Add the following to your compute environment [pre-run script](../../launch/advanced.mdx#pre-and-post-run-scripts):
 

--- a/platform_versioned_docs/version-23.3.0/enterprise/docker-compose.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/docker-compose.mdx
@@ -15,25 +15,25 @@ The DB or Redis volume is persistent after a Docker restart by default. Use the 
 
 ## Deploy Seqera Enterprise
 
-1. Download and configure the [tower.env](_templates/docker/tower.env) file. See [Configuration](../enterprise/configuration/overview.mdx#basic-configuration) for detailed instructions.
+1.  Download and configure the [tower.env](_templates/docker/tower.env) file. See [Configuration](../enterprise/configuration/overview.mdx#basic-configuration) for detailed instructions.
 
-2. Download and configure [tower.yml](_templates/docker/tower.yml). See [Configuration](../enterprise/configuration/overview.mdx#basic-configuration) for detailed instructions.
+1.  Download and configure [tower.yml](_templates/docker/tower.yml). See [Configuration](../enterprise/configuration/overview.mdx#basic-configuration) for detailed instructions.
 
-3. Download and configure the [docker-compose.yml](_templates/docker/docker-compose.yml) file:
+1.  Download and configure the [docker-compose.yml](_templates/docker/docker-compose.yml) file:
 
       - The `db` and `mail` containers should only be used for local testing. If you have configured these services elsewhere, you can remove these containers.
 
       - To configure the Seqera pipeline resource optimization service (`groundswell`), see [Pipeline resource optimization](./configuration/pipeline_optimization.mdx).
 
-4. Deploy the application and wait for it to initialize (this process takes a few minutes):
+1.  Deploy the application and wait for it to initialize (this process takes a few minutes):
 
       ```bash
       docker compose up
       ```
 
-5. [Test](./testing.mdx) the application by running an nf-core pipeline with a test profile.
+1.  [Test](./testing.mdx) the application by running an nf-core pipeline with a test profile.
 
-6. After you've confirmed that Seqera Enterprise is correctly configured and you can launch workflows, run `docker compose up -d` to deploy the application as a background process. You can then disconnect from the VM instance.
+1.  After you've confirmed that Seqera Enterprise is correctly configured and you can launch workflows, run `docker compose up -d` to deploy the application as a background process. You can then disconnect from the VM instance.
 
 :::note
 For more information on configuration, see [Configuration options](./configuration/overview.mdx).

--- a/platform_versioned_docs/version-23.3.0/enterprise/index.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/index.mdx
@@ -73,15 +73,15 @@ _Reference architecture diagram of Seqera Platform Enterprise on AWS using Elast
 Seqera Enterprise is distributed as a collection of Docker containers available through the Seqera
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. When you've received your credentials, retrieve the application container images with these steps:
 
-1. Retrieve the `name` and `secret` values from the JSON file you received from Seqera support.
+1.  Retrieve the `name` and `secret` values from the JSON file you received from Seqera support.
 
-2. Authenticate to the registry by using the `name` and `secret` values copied in the previous step:
+1.  Authenticate to the registry by using the `name` and `secret` values copied in the previous step:
 
    ```bash
    docker login -u '<NAME>' -p '<SECRET>' cr.seqera.io
    ```
 
-3. Pull the application container images:
+1.  Pull the application container images:
 
    ```bash
    docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v23.3.0

--- a/platform_versioned_docs/version-23.3.0/enterprise/kubernetes.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/kubernetes.mdx
@@ -19,13 +19,13 @@ Complete the following procedures to install Seqera Enterprise on a Kubernetes c
 
 Create a namespace for the Seqera resources.
 
-1. Create the namespace (e.g., `seqera-nf`):
+1.  Create the namespace (e.g., `seqera-nf`):
 
     ```bash
     kubectl create namespace seqera-nf
     ```
 
-2. Switch to the namespace:
+1.  Switch to the namespace:
 
     ```bash
     kubectl config set-context --current --namespace=seqera-nf
@@ -35,9 +35,9 @@ Create a namespace for the Seqera resources.
 
 Seqera Platform Enterprise is distributed as a collection of Docker containers available through the Seqera container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. After you've received your credentials, grant your cluster access to the registry:
 
-1. Retrieve the `name` and `secret` values from the JSON file that you received from Seqera support.
+1.  Retrieve the `name` and `secret` values from the JSON file that you received from Seqera support.
 
-2. Create a [secret](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/) with the `name` and `secret` values retrieved in the previous step:
+1.  Create a [secret](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/) with the `name` and `secret` values retrieved in the previous step:
 
     ```bash
     kubectl create secret docker-registry cr.seqera.io \
@@ -48,7 +48,7 @@ Seqera Platform Enterprise is distributed as a collection of Docker containers a
 
     The credential `name` contains a dollar `$` character. To prevent the Linux shell from interpreting this value as an environment variable, you must wrap it in single quotes.
 
-3. Configure the Seqera cron service and the application frontend and backend to use the secret created in the previous step (see [tower-cron.yml](./_templates/k8s/tower-cron.yml) and [tower-svc.yml](./_templates/k8s/tower-svc.yml)):
+1.  Configure the Seqera cron service and the application frontend and backend to use the secret created in the previous step (see [tower-cron.yml](./_templates/k8s/tower-cron.yml) and [tower-svc.yml](./_templates/k8s/tower-svc.yml)):
 
     ```yaml
     imagePullSecrets:
@@ -59,9 +59,9 @@ Seqera Platform Enterprise is distributed as a collection of Docker containers a
 
 ### Seqera ConfigMap
 
-1. Download and configure a [ConfigMap](_templates/k8s/configmap.yml) as detailed on the [configuration](configuration/overview.mdx) page.
+1.  Download and configure a [ConfigMap](_templates/k8s/configmap.yml) as detailed on the [configuration](configuration/overview.mdx) page.
 
-2. Deploy the ConfigMap to your cluster:
+1.  Deploy the ConfigMap to your cluster:
 
     ```bash
     kubectl apply -f configmap.yml
@@ -77,7 +77,7 @@ Seqera Enterprise requires a Redis database for caching purposes. Configure Redi
 
 **Deploy a Redis manifest to your cluster**
 
-1. Download the appropriate manifest for your infrastructure:
+1.  Download the appropriate manifest for your infrastructure:
 
     - [Azure AKS](_templates/k8s/redis.aks.yml)
 
@@ -85,7 +85,7 @@ Seqera Enterprise requires a Redis database for caching purposes. Configure Redi
 
     - [Google Kubernetes Engine](_templates/k8s/redis.gke.yml)
 
-2. Deploy to your cluster:
+1.  Deploy to your cluster:
 
     ```bash
     kubectl apply -f redis.*.yml
@@ -137,9 +137,9 @@ If you run the Redis service as a container as part of your Docker or Kubernetes
 
 ### Seqera cron service
 
-1. Download the [cron service manifest](_templates/k8s/tower-cron.yml) file.
+1.  Download the [cron service manifest](_templates/k8s/tower-cron.yml) file.
 
-2. Deploy the manifest to your cluster:
+1.  Deploy the manifest to your cluster:
 
   ```bash
   kubectl apply -f tower-cron.yml
@@ -151,9 +151,9 @@ This container creates the required database schema the first time it instantiat
 
 ### Seqera frontend and backend
 
-1. Download the [manifest](_templates/k8s/tower-svc.yml).
+1.  Download the [manifest](_templates/k8s/tower-svc.yml).
 
-2. Deploy the manifest to your cluster:
+1.  Deploy the manifest to your cluster:
 
   ```bash
   kubectl apply -f tower-svc.yml
@@ -241,21 +241,21 @@ kubectl get pods
 
 To confirm that Seqera Enterprise is properly configured, follow these steps:
 
-1. Log in to your Seqera instance.
+1.  Log in to your Seqera instance.
 
-2. Create an **organization**.
+1.  Create an **organization**.
 
-3. Create a **workspace** within that organization.
+1.  Create a **workspace** within that organization.
 
-4. Create a new **Compute environment**. See [Compute environments](../compute-envs/overview.mdx) for detailed instructions.
+1.  Create a new **Compute environment**. See [Compute environments](../compute-envs/overview.mdx) for detailed instructions.
 
-5. Select **Quick Launch** from the **Launchpad** tab in your workspace.
+1.  Select **Quick Launch** from the **Launchpad** tab in your workspace.
 
-6. Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
+1.  Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
 
-7. In the **Config profiles** dropdown, select the `test` profile.
+1.  In the **Config profiles** dropdown, select the `test` profile.
 
-8. In **Pipeline parameters**, change the output directory to a location based on your compute environment:
+1.  In **Pipeline parameters**, change the output directory to a location based on your compute environment:
 
     ```yaml
     # save to S3 bucket
@@ -265,7 +265,7 @@ To confirm that Seqera Enterprise is properly configured, follow these steps:
     outdir: /scratch/results
     ```
 
-9. Select **Launch**; you'll be redirected to the **Runs** tab for the workflow. After a few minutes, progress logs will be listed in that workflow's **Execution log** tab.
+1.  Select **Launch**; you'll be redirected to the **Runs** tab for the workflow. After a few minutes, progress logs will be listed in that workflow's **Execution log** tab.
 
 ## Optional addons
 
@@ -281,19 +281,19 @@ The initContainers will wait until both the Seqera and resource optimization dat
 
 The included [dbconsole.yml](_templates/k8s/dbconsole.yml) manifest can be used to deploy a simple web frontend to the Seqera database. Though not required, this can be useful for administrative purposes.
 
-1. Deploy the database console:
+1.  Deploy the database console:
 
   ```bash
   kubectl apply -f dbconsole.yml
   ```
 
-2. Enable a port-forward for the database console to your local machine:
+1.  Enable a port-forward for the database console to your local machine:
 
   ```bash
   kubectl port-forward deployment/dbconsole 8080:8080
   ```
 
-3. Access the database console in a web browser at `http://localhost:8080`.
+1.  Access the database console in a web browser at `http://localhost:8080`.
 
 ### High availability
 

--- a/platform_versioned_docs/version-23.3.0/enterprise/prerequisites/aws.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/prerequisites/aws.mdx
@@ -60,8 +60,8 @@ If you're installing Seqera Enterprise with Kubernetes, an [Elastic Kubernetes S
 
 **The ingress that we provide for EKS assumes that your cluster supports:**
 
-1. ALB provisioning via the [AWS Load Balancer Controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
-2. ALB integration with the [Amazon Certificate Manager](https://aws.amazon.com/certificate-manager/)
+1.  ALB provisioning via the [AWS Load Balancer Controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
+1.  ALB integration with the [Amazon Certificate Manager](https://aws.amazon.com/certificate-manager/)
 
 Additionally, the ingress assumes the presence of SSL certificates, DNS resolution, and ALB logging. If you've chosen not to use some or all of these features, you'll need to modify the manifest accordingly before applying it to the cluster.
 
@@ -70,15 +70,15 @@ Additionally, the ingress assumes the presence of SSL certificates, DNS resoluti
 Seqera Platform Enterprise is distributed as a collection of Docker containers available through the Seqera
 container registry ([cr.seqera.io](https://cr.seqera.io)). Contact [support](https://support.seqera.io) to get your container access credentials. Once you've received your credentials, retrieve the Seqera container images:
 
-1. Retrieve the **username** and **password** you received from Seqera support.
+1.  Retrieve the **username** and **password** you received from Seqera support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    ```bash
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
    ```
 
-3. Pull the Seqera container images with the following commands:
+1.  Pull the Seqera container images with the following commands:
 
    ```bash
    docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v23.3.0
@@ -96,17 +96,17 @@ This section provides step-by-step instructions for some commonly used AWS servi
 
 From version 23.1, you can retrieve Seqera Enterprise configuration values remotely from the AWS Parameter Store:
 
-1. Configure [AWS authentication](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html) to grant AWS Parameter Store access on your local host.
-2. Retrieve the Seqera container images and install the application using the instructions at the top of this page.
-3. The default value for `tower.application.name` is `tower-app`. This can be changed in your `tower.yml` configuration file. Note that your application name must be specified in the path to your configuration values in AWS Parameter Store (see step 5 below).
-4. Set the `TOWER_ENABLE_AWS_SSM` environment variable to `true`.
-5. Add configuration parameters to the AWS Parameter Store individually, using the format `/config/<application_name>/<cfg_path> : <cfg_value>`. For example:
+1.  Configure [AWS authentication](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html) to grant AWS Parameter Store access on your local host.
+1.  Retrieve the Seqera container images and install the application using the instructions at the top of this page.
+1.  The default value for `tower.application.name` is `tower-app`. This can be changed in your `tower.yml` configuration file. Note that your application name must be specified in the path to your configuration values in AWS Parameter Store (see step 5 below).
+1.  Set the `TOWER_ENABLE_AWS_SSM` environment variable to `true`.
+1.  Add configuration parameters to the AWS Parameter Store individually, using the format `/config/<application_name>/<cfg_path> : <cfg_value>`. For example:
 
    ```bash
    /config/tower-app/tower.logger.levels.com.amazonaws : "WARN"
    ```
 
-6. Start or restart your Seqera instance to confirm that the configuration value is fetched. The following entries should appear in your backend log:
+1.  Start or restart your Seqera instance to confirm that the configuration value is fetched. The following entries should appear in your backend log:
 
    ```bash
    [main] - INFO  i.m.context.DefaultBeanContext - Reading bootstrap environment configuration
@@ -119,25 +119,25 @@ From version 23.1, you can retrieve Seqera Enterprise configuration values remot
 If you use Simple Email Service in sandbox mode, both the _sender_ and the _receiver_ email addresses must be verified via AWS SES. Sandbox is not recommended for production use. See the [AWS docs](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) for instructions to move out of the sandbox.
 :::
 
-1. Go to the [**Amazon Simple Email Service**](https://us-east-2.console.aws.amazon.com/ses) console.
+1.  Go to the [**Amazon Simple Email Service**](https://us-east-2.console.aws.amazon.com/ses) console.
 
-2. In the navigation menu, select **SMTP Settings**.
+1.  In the navigation menu, select **SMTP Settings**.
 
-3. Select **Create my SMTP Credentials**
+1.  Select **Create my SMTP Credentials**
 
-4. Select **Create**.
+1.  Select **Create**.
 
-5. Select **Show User SMTP Credentials** to copy your credentials, or select **Download Credentials**.
+1.  Select **Show User SMTP Credentials** to copy your credentials, or select **Download Credentials**.
 
 **The credentials (username and password) will not be shown to you again after this instance.**
 
-6. You will be automatically redirected to the IAM dashboard. Log back in to the [Amazon SES Console](https://us-east-2.console.aws.amazon.com/ses).
+1.  You will be automatically redirected to the IAM dashboard. Log back in to the [Amazon SES Console](https://us-east-2.console.aws.amazon.com/ses).
 
-7. Select **Email Addresses** in the navigation menu. Then, select **Verify a new Email Address**.
+1.  Select **Email Addresses** in the navigation menu. Then, select **Verify a new Email Address**.
 
-8. A pop-up asking for your email should automatically appear. Once you type in your email address and select **Verify This Email Address**, you should receive a confirmation email from Amazon SES to confirm email address ownership.
+1.  A pop-up asking for your email should automatically appear. Once you type in your email address and select **Verify This Email Address**, you should receive a confirmation email from Amazon SES to confirm email address ownership.
 
-9. Open the verification link in the message.
+1.  Open the verification link in the message.
 
 **The verification link is **only valid for 24 hours** after your original request for verification.**
 
@@ -149,76 +149,76 @@ See the AWS documentation for more options, such as setting up an [Easy DKIM for
 
 ### Amazon RDS
 
-1. Open the [Amazon RDS console](https://console.aws.amazon.com/rds/).
+1.  Open the [Amazon RDS console](https://console.aws.amazon.com/rds/).
 
-2. Select **Create database > Standard create > MySQL**.
+1.  Select **Create database > Standard create > MySQL**.
 
-3. Under **Edition**, select **MySQL Community** and any version under **5.7.x**, or **8.0.x**.
+1.  Under **Edition**, select **MySQL Community** and any version under **5.7.x**, or **8.0.x**.
 
-4. Enter the **DB cluster identifier** (e.g., `tower-db`).
+1.  Enter the **DB cluster identifier** (e.g., `tower-db`).
 
-5. Enter the **Master username**, or keep the default.
+1.  Enter the **Master username**, or keep the default.
 
-6. Enter the **Master password**.
+1.  Enter the **Master password**.
 
    - To use an automatically generated master password, select **Auto generate a password**.
    - To use a custom master password, deselect **Auto generate a password** and enter your password in **Master password** and **Confirm password**.
 
-7. Under **Instance configuration**, select the **DB instance class** and instance type.
+1.  Under **Instance configuration**, select the **DB instance class** and instance type.
 
-8. Under **Connectivity**, select the correct **VPC security group**. Confirm this with your AWS administrator.
+1.  Under **Connectivity**, select the correct **VPC security group**. Confirm this with your AWS administrator.
 
-9. Under **Additional configuration**, enter the **Initial database name** (e.g., `tower`).
+1.  Under **Additional configuration**, enter the **Initial database name** (e.g., `tower`).
 
-10. Select **Create database**.
+1.  Select **Create database**.
 
 After your database is created:
 
-1. Update the inbound rules for the underlying EC2 instance to allow MySQL connections.
+1.  Update the inbound rules for the underlying EC2 instance to allow MySQL connections.
 
-2. Update `TOWER_DB_URL` in your configuration value with the database hostname.
+1.  Update `TOWER_DB_URL` in your configuration value with the database hostname.
 
 ### Amazon EC2
 
 If you've never set up an Amazon EC2 instance for Linux, see [this guide](https://aws.amazon.com/ec2/getting-started/) to get started.
 
-1. Open the [AWS Management console](https://us-east-2.console.aws.amazon.com/console/home).
+1.  Open the [AWS Management console](https://us-east-2.console.aws.amazon.com/console/home).
 
-2. Log in as an IAM user with your credentials.
+1.  Log in as an IAM user with your credentials.
 
-3. Under **AWS services**, select **All Services**.
+1.  Under **AWS services**, select **All Services**.
 
-4. Under **Compute**, select **EC2**.
+1.  Under **Compute**, select **EC2**.
 
-5. Select **Instances**, then **Launch instances**.
+1.  Select **Instances**, then **Launch instances**.
 
-6. You will be asked to choose an Amazon Machine Image (AMI). Scroll to the middle of the page and select **Amazon Linux 2**.
+1.  You will be asked to choose an Amazon Machine Image (AMI). Scroll to the middle of the page and select **Amazon Linux 2**.
 
-7. Once you choose **Select**, you'll be redirected to **Step 2: Choose an Instance Type**.
+1.  Once you choose **Select**, you'll be redirected to **Step 2: Choose an Instance Type**.
 
-8. Scroll down and select either **c5a.xlarge** or **c5.large** — these provide 4 CPUs and 8 GB of RAM.
+1.  Scroll down and select either **c5a.xlarge** or **c5.large** — these provide 4 CPUs and 8 GB of RAM.
 
-9. Select **Next: Configure Instance Details**.
+1.  Select **Next: Configure Instance Details**.
 
-10. If required, configure the instance details settings. Then, select **Next: Add Storage**.
+1.  If required, configure the instance details settings. Then, select **Next: Add Storage**.
 
-11. The root storage should be 20GB. Configure this under **Size (GiB)**.
+1.  The root storage should be 20GB. Configure this under **Size (GiB)**.
 
-12. Select **Add Tags** (if required) to add case-sensitive key-value pairs (e.g., `key = Name` and `value = Webserver`).
+1.  Select **Add Tags** (if required) to add case-sensitive key-value pairs (e.g., `key = Name` and `value = Webserver`).
 
-13. Select **Next: Configure Security Group**.
+1.  Select **Next: Configure Security Group**.
 
-14. Enter `tower-sg` as the Security Group name.
+1.  Enter `tower-sg` as the Security Group name.
 
-15. Optionally, you can enter a description for your Security Group's name.
+1.  Optionally, you can enter a description for your Security Group's name.
 
-16. Configure the type of protocol settings. Note that the security group port must be configured to 8000.
+1.  Configure the type of protocol settings. Note that the security group port must be configured to 8000.
 
-17. Select **Review and Launch**.
+1.  Select **Review and Launch**.
 
-18. Once you have reviewed your instance, select **Launch**.
+1.  Once you have reviewed your instance, select **Launch**.
 
-19. Select an existing key pair or create a new one in the pop-up that appears.
+1.  Select an existing key pair or create a new one in the pop-up that appears.
 
     If you already have an existing key pair, select **Choose an existing key pair** and choose from the available options in the drop-down menu.
 
@@ -226,11 +226,11 @@ If you've never set up an Amazon EC2 instance for Linux, see [this guide](https:
 
     **Note:** Once you download the key pair, store it in a secure and accessible location. You won't be able to download the file again after it is created.
 
-20. Select **Launch Instances**.
+1.  Select **Launch Instances**.
 
-21. Use the key pair to connect to the server using SSH and its public IP address. Terminal-based SSH is easier to use than browser-based SSH for copying and pasting text.
+1.  Use the key pair to connect to the server using SSH and its public IP address. Terminal-based SSH is easier to use than browser-based SSH for copying and pasting text.
 
-22. Use the following commands to set up `docker` and `docker-compose`:
+1.  Use the following commands to set up `docker` and `docker-compose`:
 
     ```bash
     # Install and start the docker engine
@@ -245,4 +245,4 @@ If you've never set up an Amazon EC2 instance for Linux, see [this guide](https:
     sudo mv /usr/local/bin/docker-compose /bin/docker-compose
     ```
 
-23. Configure AWS CLI and retrieve the [Seqera container images](#seqera-container-images). AWS CLI v1 is pre-installed in Amazon Linux.
+1.  Configure AWS CLI and retrieve the [Seqera container images](#seqera-container-images). AWS CLI v1 is pre-installed in Amazon Linux.

--- a/platform_versioned_docs/version-23.3.0/enterprise/prerequisites/azure.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/prerequisites/azure.mdx
@@ -29,10 +29,10 @@ From version 22.1.1, HTTP-only implementations **must** set the `TOWER_ENABLE_UN
 
 While there are many ways to implement DNS and TLS-termination, Seqera recommends using the specialized native services offered by your cloud provider. In the case of Azure:
 
--   Use **Application Gateway** for TLS-termination and load-balancing.
--   Use [**App Service Domains**](https://docs.microsoft.com/en-us/azure/dns/dns-overview) for domain acquisition.
--   Use **Azure DNS** for domain record management.
--   Use **Azure Vault** for PKI certificate storage.
+- Use **Application Gateway** for TLS-termination and load-balancing.
+- Use [**App Service Domains**](https://docs.microsoft.com/en-us/azure/dns/dns-overview) for domain acquisition.
+- Use **Azure DNS** for domain record management.
+- Use **Azure Vault** for PKI certificate storage.
 
 These decisions should be made before you continue as they impact how Seqera configuration files are updated.
 
@@ -60,14 +60,14 @@ To customize your cluster's Ingress Controller to support HTTPS redirects and TL
 Seqera Platform Enterprise is distributed as a collection of Docker containers available through the Seqera
 container registry ([cr.seqera.io](https://cr.seqera.io)). Contact [support](https://support.seqera.io) to get your container access credentials. Once you've received your credentials, retrieve the Seqera container images:
 
-1. Retrieve the **username** and **password** you received from Seqera support.
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Retrieve the **username** and **password** you received from Seqera support.
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    ```bash
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
    ```
 
-3. Pull the Seqera container images with the following commands:
+1.  Pull the Seqera container images with the following commands:
 
    ```bash
    docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v23.3.0
@@ -83,13 +83,13 @@ This section provides step-by-step instructions for some commonly used Azure ser
 
 ### Azure Resource Group
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
+1.  Sign in to the [Azure portal](https://portal.azure.com).
 
-2. Select **Resource groups**.
+1.  Select **Resource groups**.
 
-3. Select **Add**.
+1.  Select **Add**.
 
-4. Enter the following values:
+1.  Enter the following values:
 
    - **Subscription**: Select your Azure subscription.
 
@@ -97,19 +97,19 @@ This section provides step-by-step instructions for some commonly used Azure ser
 
    - **Region**: Select the region where your assets will exist (e.g., `East US`).
 
-5. Select **Review and Create**.
+1.  Select **Review and Create**.
 
-6. Select **Create**.
+1.  Select **Create**.
 
 ### Azure Storage Account
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
+1.  Sign in to the [Azure portal](https://portal.azure.com).
 
-2. Select **Storage accounts**.
+1.  Select **Storage accounts**.
 
-3. Select **Create**.
+1.  Select **Create**.
 
-4. Enter the following values:
+1.  Enter the following values:
 
    - **Subscription**: Select your Azure subscription.
 
@@ -123,71 +123,71 @@ This section provides step-by-step instructions for some commonly used Azure ser
 
    - **Redundancy**: Select `Geo-redundant storage (GRS)`.
 
-5. Select **Review + create**. Note that the default values are used in the other tabs. See the [Azure documentation](https://docs.microsoft.com/en-ca/azure/storage/common/storage-account-create?tabs=azure-portal#create-a-storage-account-1) for further details on each setting.
+1.  Select **Review + create**. Note that the default values are used in the other tabs. See the [Azure documentation](https://docs.microsoft.com/en-ca/azure/storage/common/storage-account-create?tabs=azure-portal#create-a-storage-account-1) for further details on each setting.
 
-6. Select **Create**.
+1.  Select **Create**.
 
 ### Azure Linux VM
 
 We recommend the following VM settings:
 
-1. Use **default values** unless otherwise specified.
-2. Provision at least **2 CPUS** and **8GB RAM**.
-3. Use the **Ubuntu Server 20.04 LTS - Gen2** image.
-4. Ensure your VM is **accessible by SSH**.
-5. Do not implement DNS or Load Balancing directly against the VM (do so via Azure Application Gateway instead).
+1.  Use **default values** unless otherwise specified.
+1.  Provision at least **2 CPUS** and **8GB RAM**.
+1.  Use the **Ubuntu Server 20.04 LTS - Gen2** image.
+1.  Ensure your VM is **accessible by SSH**.
+1.  Do not implement DNS or Load Balancing directly against the VM (do so via Azure Application Gateway instead).
 
 To create a VM:
 
-1. Configure the **Basics** tab:
+1.  Configure the **Basics** tab:
 
    - Ensure your **Region** is the same as your **Resource group**.
    - Do not set the VM as an **Azure Spot instance**.
    - Ensure your Security Group allows ingress on **Port 8000**.
 
-2. Configure the **Disks** tab:
+1.  Configure the **Disks** tab:
 
    - Ensure your OS disk type is **Standard SSD**.
 
-3. Configure the **Network** tab:
+1.  Configure the **Network** tab:
 
    - Ensure that a **Public IP** is assigned to the VM.
    - Do not place the VM in the backend pool of an existing load balancing solution.
 
-4. Select **Review + create**.
+1.  Select **Review + create**.
 
-5. Select **Create**.
+1.  Select **Create**.
 
 To make the VM's IP address static:
 
-1. Enter **Public IP addresses** in the search.
+1.  Enter **Public IP addresses** in the search.
 
-2. Under **Services**, select **Public IP addresses**.
+1.  Under **Services**, select **Public IP addresses**.
 
-3. On the **Public IP addresses** page, select the entry containing your VM name. A page opens with that IP's details.
+1.  On the **Public IP addresses** page, select the entry containing your VM name. A page opens with that IP's details.
 
-4. Select **Configuration** from the left-hand navigation panel.
+1.  Select **Configuration** from the left-hand navigation panel.
 
-5. Ensure that your IP address assignment is **Static**.
+1.  Ensure that your IP address assignment is **Static**.
 
-6. Do not add a custom DNS name label to the VM.
+1.  Do not add a custom DNS name label to the VM.
 
 To allow ingress on port 8000:
 
-1. Enter **Virtual Machines** in the search bar.
+1.  Enter **Virtual Machines** in the search bar.
 
-2. Under **Services**, select **Virtual machines**.
+1.  Under **Services**, select **Virtual machines**.
 
-3. On the **Virtual machines** page, select your VM name to navigate to the VM details.
+1.  On the **Virtual machines** page, select your VM name to navigate to the VM details.
 
-4. Select **Networking** from the left-hand navigation panel.
+1.  Select **Networking** from the left-hand navigation panel.
 
-5. **Add inbound port rule** for port 8000.
+1.  **Add inbound port rule** for port 8000.
 
 To install Docker:
 
 1.  Complete the steps for the [Install using the apt repository][docker] instructions.
-2.  Confirm that Docker Compose is installed:
+1.  Confirm that Docker Compose is installed:
 
     ```bash
     docker compose version

--- a/platform_versioned_docs/version-23.3.0/enterprise/prerequisites/gcp.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/prerequisites/gcp.mdx
@@ -37,13 +37,13 @@ From version 22.1.1, HTTP-only implementations **must** set the `TOWER_ENABLE_UN
 
 - **(Optional) Public IP address**: A public IP address can be reserved for the Seqera ingress to keep the IP address constant across restarts. If you don't reserve an IP address, the ingress will create one for you automatically, but it will be different every time you deploy the ingress. Reserve a public IP address with the following steps:
 
-  1. Got to **VPC network > External IP addresses** and select **Reserve Static Address**.
+  1.  Got to **VPC network > External IP addresses** and select **Reserve Static Address**.
 
-  2. Assign a name (e.g., `tower-ip`). This name will be used later to configure the ingress.
+  2.  Assign a name (e.g., `tower-ip`). This name will be used later to configure the ingress.
 
-  3. Select the region where your GKE cluster is deployed.
+  3.  Select the region where your GKE cluster is deployed.
 
-  4. Select **Reserve**.
+  4.  Select **Reserve**.
 
 ### Prerequisites for Docker
 
@@ -62,15 +62,15 @@ Seqera doesn't currently support GKE Autopilot due to a privilege issue with the
 Seqera Platform Enterprise is distributed as a collection of Docker containers available through the Seqera
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. Once you've received your credentials, retrieve the Seqera container images:
 
-1. Retrieve the **username** and **password** you received from Seqera support.
+1.  Retrieve the **username** and **password** you received from Seqera support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    ```bash
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
    ```
 
-3. Pull the Seqera container images with the following commands:
+1.  Pull the Seqera container images with the following commands:
 
    ```bash
    docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v23.3.0
@@ -88,37 +88,37 @@ This section provides step-by-step instructions for some commonly used GCP servi
 
 ### Google CloudSQL
 
-1. Browse to **Cloud SQL** and select **Create Instance**.
+1.  Browse to **Cloud SQL** and select **Create Instance**.
 
-2. Select **MySQL** (you may need to enable the API).
+1.  Select **MySQL** (you may need to enable the API).
 
-3. Change to **Single zone** availability, unless you require high availability.
+1.  Change to **Single zone** availability, unless you require high availability.
 
-4. Update the **Region** and **Zone** to match the location of your Seqera deployment.
+1.  Update the **Region** and **Zone** to match the location of your Seqera deployment.
 
-5. Expand **Show configuration options** and update the **Machine type** and **Storage** settings. The recommended machine type and disk size depends on the number of parallel pipelines you expect to run. In this guide, we use the **Standard** machine type with **1 vCPU**, and **20 GB SSD** storage.
+1.  Expand **Show configuration options** and update the **Machine type** and **Storage** settings. The recommended machine type and disk size depends on the number of parallel pipelines you expect to run. In this guide, we use the **Standard** machine type with **1 vCPU**, and **20 GB SSD** storage.
 
-6. Expand **Connections**, disable **Public IP**, and enable **Private IP**.
+1.  Expand **Connections**, disable **Public IP**, and enable **Private IP**.
 
-7. Select the **Network** (usually **default**). You may need to set up a **Private services access connection** for this VPC if you have not done so already. Enable the API and select **Use an automatically allocated IP range**. Select **Continue**, then **Create Connection**.
+1.  Select the **Network** (usually **default**). You may need to set up a **Private services access connection** for this VPC if you have not done so already. Enable the API and select **Use an automatically allocated IP range**. Select **Continue**, then **Create Connection**.
 
-8. Select **Create Instance**.
+1.  Select **Create Instance**.
 
-9. Once the database has been created, select the instance, then **Databases**. Create a new database named _tower_.
+1.  Once the database has been created, select the instance, then **Databases**. Create a new database named _tower_.
 
-10. Note the Private IP address of the instance as it must be supplied to the `TOWER_DB_URL` environment variable.
+1.  Note the Private IP address of the instance as it must be supplied to the `TOWER_DB_URL` environment variable.
 
 ### Google Compute Engine
 
-1. From the Navigation menu of the Google Cloud console, select **Compute Engine** to create a new VM instance. Select the machine name, region/zone, and machine type. In this example we have used an `e2-standard-2` instance (2 vCPUs, 8 GB memory). We recommend using the [container-optimized OS](https://cloud.google.com/community/tutorials/docker-compose-on-container-optimized-os) for the VM.
+1.  From the Navigation menu of the Google Cloud console, select **Compute Engine** to create a new VM instance. Select the machine name, region/zone, and machine type. In this example we have used an `e2-standard-2` instance (2 vCPUs, 8 GB memory). We recommend using the [container-optimized OS](https://cloud.google.com/community/tutorials/docker-compose-on-container-optimized-os) for the VM.
 
-2. Enable HTTP traffic. By default, the frontend is exposed to port 8000, so you will need to add a firewall rule to the underlying VPC network to allow port 8000 (after VM creation).
+1.  Enable HTTP traffic. By default, the frontend is exposed to port 8000, so you will need to add a firewall rule to the underlying VPC network to allow port 8000 (after VM creation).
 
-3. Connect to the machine using SSH. If you run into issues with SSH, or would like to set up IAP SSH, refer to the documentation for [TCP forward to IAP](https://cloud.google.com/iap/docs/using-tcp-forwarding).
+1.  Connect to the machine using SSH. If you run into issues with SSH, or would like to set up IAP SSH, refer to the documentation for [TCP forward to IAP](https://cloud.google.com/iap/docs/using-tcp-forwarding).
 
-4. Install [Docker](https://docs.docker.com/engine/install/debian/) if it is not already installed.
+1.  Install [Docker](https://docs.docker.com/engine/install/debian/) if it is not already installed.
 
-5. Test Docker by running the [Docker Compose](https://hub.docker.com/r/docker/compose/tags/) image:
+1.  Test Docker by running the [Docker Compose](https://hub.docker.com/r/docker/compose/tags/) image:
 
 :::note
 If Docker doesn't have sufficient permissions, use [these steps](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) to run it without root, or use `sudo`.
@@ -133,7 +133,7 @@ If Docker doesn't have sufficient permissions, use [these steps](https://docs.do
 
 :::
 
-6. Create an alias for `docker-compose`:
+1.  Create an alias for `docker-compose`:
 
    ```bash
    echo alias docker-compose="'"'docker run --rm \
@@ -145,4 +145,4 @@ If Docker doesn't have sufficient permissions, use [these steps](https://docs.do
    source .bashrc
    ```
 
-7. Configure `gcloud` and retrieve the [Seqera container images](#seqera-container-images).
+1.  Configure `gcloud` and retrieve the [Seqera container images](#seqera-container-images).

--- a/platform_versioned_docs/version-23.3.0/enterprise/prerequisites/on-prem.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/prerequisites/on-prem.mdx
@@ -34,15 +34,15 @@ From version 22.1.1, HTTP-only implementations **must** set the `TOWER_ENABLE_UN
 Seqera Platform Enterprise is distributed as a collection of Docker containers available through the Seqera
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. Once you've received your credentials, retrieve the Seqera container images:
 
-1. Retrieve the **username** and **password** you received from Seqera support.
+1.  Retrieve the **username** and **password** you received from Seqera support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    ```bash
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
    ```
 
-3. Pull the Seqera container images with the following commands:
+1.  Pull the Seqera container images with the following commands:
 
    ```bash
    docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v23.3.0

--- a/platform_versioned_docs/version-23.3.0/enterprise/release_notes/22.1.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/release_notes/22.1.mdx
@@ -76,13 +76,13 @@ We've also implemented a first version of a much requested feature from HPC user
 
 This Tower version requires a database schema update. Follow these steps to update your DB instance and the Tower installation.
 
-1. Make a backup of the Tower database.
-2. Download and update your container versions to:
+1.  Make a backup of the Tower database.
+2.  Download and update your container versions to:
 
-    * `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v22.1.5`
-    * `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v22.1.5`
+    - `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v22.1.5`
+    - `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v22.1.5`
 
-3. Redeploy the Tower application:
+3.  Redeploy the Tower application:
 
     **docker-compose**:
 

--- a/platform_versioned_docs/version-23.3.0/enterprise/release_notes/22.2.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/release_notes/22.2.mdx
@@ -51,8 +51,8 @@ Available reports are listed in a Reports tab on the Runs page. Users can select
 
 ## Notes
 
-1. As of version 22.1.x, Nextflow Tower Enterprise will follow a three month release cadence, using the following version number scheme: `YY.Q.PATCH`, where `YY` represents the year, `Q` represents the quarter and `PATCH` the incremental patch number.
-2. As of version 21.02.x, a license key must be provided to enable the Tower deployment feature. The license key should be specified using the configuration variable `TOWER_LICENSE`. If you don't have a license key, contact sales@seqera.io.
+1.  As of version 22.1.x, Nextflow Tower Enterprise will follow a three month release cadence, using the following version number scheme: `YY.Q.PATCH`, where `YY` represents the year, `Q` represents the quarter and `PATCH` the incremental patch number.
+2.  As of version 21.02.x, a license key must be provided to enable the Tower deployment feature. The license key should be specified using the configuration variable `TOWER_LICENSE`. If you don't have a license key, contact sales@seqera.io.
 
 ## Warnings
 
@@ -64,13 +64,13 @@ Available reports are listed in a Reports tab on the Runs page. Users can select
 
 This Tower version requires a database schema update. Follow these steps to update your DB instance and the Tower installation.
 
-1. Make a backup of the Tower database.
-2. Download and update your container versions to:
+1.  Make a backup of the Tower database.
+2.  Download and update your container versions to:
 
-    * `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v22.2.1`
-    * `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v22.2.1`
+    - `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v22.2.1`
+    - `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v22.2.1`
 
-3. Redeploy the Tower application:
+3.  Redeploy the Tower application:
 
     **docker-compose**:
 

--- a/platform_versioned_docs/version-23.3.0/enterprise/release_notes/22.3.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/release_notes/22.3.mdx
@@ -113,9 +113,9 @@ This feature is currently only available on Tower Cloud (tower.nf). For more inf
 
 This Tower version requires a database schema update. Follow these steps to update your DB instance and the Tower installation.
 
-1. Make a backup of the Tower database.
-2. Download and update your container versions.
-3. Redeploy the Tower application:
+1.  Make a backup of the Tower database.
+2.  Download and update your container versions.
+3.  Redeploy the Tower application:
 
     **docker-compose**:
 

--- a/platform_versioned_docs/version-23.3.0/enterprise/release_notes/22.4.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/release_notes/22.4.mdx
@@ -15,12 +15,12 @@ In Nextflow Tower 22.3, Seqera Labs introduced [resource labels](../../resource-
 
 In Tower Enterprise 22.4, an administrator can now:
 
--   Override and save the resource labels automatically assigned to a pipeline.
-  -   The pipeline will have a different resource label set from its associated compute environment. Resource labels added to the pipeline propagate to the cloud provider, without being permanently associated with the compute environment in Tower.
-  -   If a maintainer edits a pipeline and changes the compute environment, the resource labels field is updated with the resource labels of the new compute environment.
--   Override and save the resource labels associated with an action, following the same logic as pipelines above.
--   Override the resource labels associated with a workflow run before launch, enabling job-level tagging.
-  -   The resource labels tied to a workflow run are associated with specific cloud resources that do not include all resources tagged when a compute environment is created.
+- Override and save the resource labels automatically assigned to a pipeline.
+- The pipeline will have a different resource label set from its associated compute environment. Resource labels added to the pipeline propagate to the cloud provider, without being permanently associated with the compute environment in Tower.
+- If a maintainer edits a pipeline and changes the compute environment, the resource labels field is updated with the resource labels of the new compute environment.
+- Override and save the resource labels associated with an action, following the same logic as pipelines above.
+- Override the resource labels associated with a workflow run before launch, enabling job-level tagging.
+- The resource labels tied to a workflow run are associated with specific cloud resources that do not include all resources tagged when a compute environment is created.
 
 ### All runs view
 
@@ -64,8 +64,8 @@ The only requirement is that the new compute environment has access to the origi
 
 ### Warnings
 
-1. The default `nf-launcher` image includes a `curl` command which will fail if your Tower is secured with a private TLS certificate. To mitigate this problem, please see [these instructions](../configuration/ssl_tls.mdx).
-2. This version requires all database connections to use the following configuration value: `TOWER_DB_DRIVER=org.mariadb.jdbc.Driver`. Please update your configuration if you are upgrading. All other database configuration values should remain unchanged.
+1.  The default `nf-launcher` image includes a `curl` command which will fail if your Tower is secured with a private TLS certificate. To mitigate this problem, please see [these instructions](../configuration/ssl_tls.mdx).
+2.  This version requires all database connections to use the following configuration value: `TOWER_DB_DRIVER=org.mariadb.jdbc.Driver`. Please update your configuration if you are upgrading. All other database configuration values should remain unchanged.
 3.  This version expects the use of HTTPS by default for all browser client connections. If your Tower installation requires the use of unsecured HTTP, set the following environment variable in the infrastructure hosting the Tower application: `TOWER_ENABLE_UNSAFE_MODE=true`.
 4.  If you're upgrading from a version of Tower prior to `21.04.x`, please update your implementation to `21.04.x` before installing this release.
 
@@ -76,9 +76,9 @@ This Tower version requires a database schema update. Follow these steps to upda
 !!! warning
     To ensure no data loss, the database volume must be persistent on the local machine. Use the `volumes` key in the `db` or `redis` section of your `docker-compose.yml` file to specify a local path to the DB or Redis instance.
 
-1. Make a backup of the Tower database.
-2. Download and update your container versions.
-3. Redeploy the Tower application:
+1.  Make a backup of the Tower database.
+2.  Download and update your container versions.
+3.  Redeploy the Tower application:
 
     **docker-compose**:
 

--- a/platform_versioned_docs/version-23.3.0/enterprise/release_notes/23.1.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/release_notes/23.1.mdx
@@ -59,9 +59,9 @@ This Tower version requires a database schema update. Follow these steps to upda
 !!! warning ""
     To ensure no data loss, the database volume must be persistent on the local machine. Use the `volumes` key in the `db` or `redis` section of your `docker-compose.yml` file to specify a local path to the DB or Redis instance.
 
-1. Make a backup of the Tower database.
-2. Download and update your container versions.
-3. Redeploy the Tower application:
+1.  Make a backup of the Tower database.
+2.  Download and update your container versions.
+3.  Redeploy the Tower application:
 
     **docker-compose**:
 

--- a/platform_versioned_docs/version-23.3.0/enterprise/release_notes/23.2.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/release_notes/23.2.mdx
@@ -62,9 +62,9 @@ This Tower version requires a database schema update. Follow these steps to upda
 !!! warning ""
     To ensure no data loss, the database volume must be persistent on the local machine. Use the `volumes` key in the `db` or `redis` section of your docker-compose.yml file to specify a local path to the DB or Redis instance.
 
-1. Make a backup of the Tower database.
-2. Download and update your container versions.
-3. Redeploy the Tower application:
+1.  Make a backup of the Tower database.
+2.  Download and update your container versions.
+3.  Redeploy the Tower application:
 
     **docker-compose**:
 
@@ -84,8 +84,8 @@ This Tower version requires a database schema update. Follow these steps to upda
 
 If you must host your nf-launcher container image on a private image registry:
 
-1. Copy the [nf-launcher image](https://quay.io/seqeralabs/nf-launcher:j17-23.04.2-up3) to your private registry.
-2. Update your `tower.env` with the launch container environment variable:
+1.  Copy the [nf-launcher image](https://quay.io/seqeralabs/nf-launcher:j17-23.04.2-up3) to your private registry.
+2.  Update your `tower.env` with the launch container environment variable:
 
     `TOWER_LAUNCH_CONTAINER=<FULL_PATH_TO_YOUR_PRIVATE_IMAGE>`
 

--- a/platform_versioned_docs/version-23.3.0/enterprise/release_notes/changelog.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/release_notes/changelog.mdx
@@ -420,7 +420,7 @@ tags: [changelog]
 - Chore: Upgrade to Micronaut 3.4.x
 - Chore: Typography sync between tower and design
 
-* Full Changelog: v22.1.5-enterprise...v22.2.0-rc0-enterprise
+- Full Changelog: v22.1.5-enterprise...v22.2.0-rc0-enterprise
 
 #### 22.1.6 - 15 Jul 2022
 

--- a/platform_versioned_docs/version-23.3.0/enterprise/release_notes/enterprise_latest.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/release_notes/enterprise_latest.mdx
@@ -78,9 +78,9 @@ This version requires a database schema update. Follow these steps to update you
 To ensure no data loss, the database volume must be persistent on the local machine. Use the `volumes` key in the `db` or `redis` section of your `docker-compose.yml` file to specify a local path to the DB or Redis instance.
 :::
 
-1. Make a backup of the Seqera Platform database.
-2. Download and update your container versions.
-3. Redeploy the application:
+1.  Make a backup of the Seqera Platform database.
+2.  Download and update your container versions.
+3.  Redeploy the application:
 
 **Docker Compose**:
 

--- a/platform_versioned_docs/version-23.3.0/enterprise/testing.mdx
+++ b/platform_versioned_docs/version-23.3.0/enterprise/testing.mdx
@@ -7,23 +7,23 @@ tags: [testing, deployment]
 
 After your [Docker Compose](./docker-compose.mdx) or [Kubernetes](./kubernetes.mdx) installation is complete, follow these steps to test whether the application is running as expected:
 
-1. Log in to the application.
+1.  Log in to the application.
 
-2. Create an [organization](../orgs-and-teams/organizations.mdx).
+1.  Create an [organization](../orgs-and-teams/organizations.mdx).
 
-3. Create a [workspace](../orgs-and-teams/workspace-management.mdx) within the organization.
+1.  Create a [workspace](../orgs-and-teams/workspace-management.mdx) within the organization.
 
-4. Create a new [compute environment](../compute-envs/overview.mdx).
+1.  Create a new [compute environment](../compute-envs/overview.mdx).
 
-5. Add your [GitHub credentials](../git/overview.mdx).
+1.  Add your [GitHub credentials](../git/overview.mdx).
 
-6. Select **Quick Launch** from the **Launchpad** tab in your workspace.
+1.  Select **Quick Launch** from the **Launchpad** tab in your workspace.
 
-7. Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
+1.  Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
 
-8. In the **Config profiles** drop-down menu, select the `test` profile.
+1.  In the **Config profiles** drop-down menu, select the `test` profile.
 
-9. In **Pipeline parameters**, change the output directory to a location based on your compute environment:
+1.  In **Pipeline parameters**, change the output directory to a location based on your compute environment:
 
     ```yaml
     # Uncomment to save to an S3 bucket
@@ -33,4 +33,4 @@ After your [Docker Compose](./docker-compose.mdx) or [Kubernetes](./kubernetes.m
     # outdir: /scratch/results
     ```
 
-10. Select **Launch**; you'll be redirected to the **Runs** tab for the workflow. After a few minutes, progress logs will be listed in that workflow's **Execution log** tab.
+1.  Select **Launch**; you'll be redirected to the **Runs** tab for the workflow. After a few minutes, progress logs will be listed in that workflow's **Execution log** tab.

--- a/platform_versioned_docs/version-23.3.0/faqs.mdx
+++ b/platform_versioned_docs/version-23.3.0/faqs.mdx
@@ -41,9 +41,9 @@ Attempting to launch a pipeline without specifying a `launch.id` in the API payl
 
 Launch users must add a `launch.id` to pipeline launch requests:
 
-1. Query the list of pipelines via the `/pipelines` endpoint. Find the `pipelineId` of the pipeline you intend to launch.
-2. Call the `/pipelines/{pipelineId}/launch` API to retrieve the pipeline's `launch.id`.
-3. Include the `launch.id` in your request to the `/workflow/launch` API endpoint:
+1.  Query the list of pipelines via the `/pipelines` endpoint. Find the `pipelineId` of the pipeline you intend to launch.
+1.  Call the `/pipelines/{pipelineId}/launch` API to retrieve the pipeline's `launch.id`.
+1.  Include the `launch.id` in your request to the `/workflow/launch` API endpoint:
 
    ```
    {
@@ -68,9 +68,9 @@ GitHub imposes [rate limits](https://docs.github.com/en/rest/overview/resources-
 
 Try the following:
 
-1. Ensure there's at least one GitHub credential in your workspace's **Credentials** tab.
-2. Ensure that the **Access token** field of all GitHub credential objects is populated with a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) value and **not** a user password. GitHub PATs are typically longer than passwords and include a `ghp_` prefix. For example:`ghp*IqIMNOZH6zOwIEB4T9A2g4EHMy8Ji42q4HA`
-3. Confirm that your PAT is providing the elevated threshold and transactions are being charged against it:
+1.  Ensure there's at least one GitHub credential in your workspace's **Credentials** tab.
+1.  Ensure that the **Access token** field of all GitHub credential objects is populated with a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) value and **not** a user password. GitHub PATs are typically longer than passwords and include a `ghp_` prefix. For example:`ghp*IqIMNOZH6zOwIEB4T9A2g4EHMy8Ji42q4HA`
+1.  Confirm that your PAT is providing the elevated threshold and transactions are being charged against it:
 
    `curl -H "Authorization: token ghp_LONG_ALPHANUMERIC_PAT" -H "Accept: application/vnd.github.v3+json" https://api.github.com/rate_limit`
 
@@ -80,14 +80,14 @@ This error can occur if incorrect configuration values are assigned to the `back
 
 Please verify the following:
 
-1. The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `backend` container:
+1.  The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `backend` container:
    - Contains `prod,redis,ha`
    - Does not contain `cron`
-2. The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `cron` container:
+1.  The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `cron` container:
    - Contains `prod,redis,cron`
    - Does not contain `ha`
-3. You don't have another copy of the `MICRONAUT_ENVIRONMENTS` environment variable defined elsewhere in your application (such as a `tower.env` file or Kubernetes `ConfigMap`).
-4. If you're using a separate container/pod to execute `migrate-db.sh`, ensure there's no `MICRONAUT_ENVIRONMENTS` environment variable assigned to it.
+1.  You don't have another copy of the `MICRONAUT_ENVIRONMENTS` environment variable defined elsewhere in your application (such as a `tower.env` file or Kubernetes `ConfigMap`).
+1.  If you're using a separate container/pod to execute `migrate-db.sh`, ensure there's no `MICRONAUT_ENVIRONMENTS` environment variable assigned to it.
 
 **_No such variable_ error**
 
@@ -133,8 +133,8 @@ Clients who use Amazon Aurora as their database solution may encounter a _java.s
 
 Please modify the Seqera Enterprise configuration as follows to try resolving the problem:
 
-1. Ensure your `TOWER_DB_DRIVER` uses the specified MariaDB URI.
-2. Modify your `TOWER_DB_URL` to: `TOWER_DB_URL=jdbc:mysql://YOUR_DOMAIN:YOUR_PORT/YOUR_TOWER_DB?usePipelineAuth=false&useBatchMultiSend=false`
+1.  Ensure your `TOWER_DB_DRIVER` uses the specified MariaDB URI.
+1.  Modify your `TOWER_DB_URL` to: `TOWER_DB_URL=jdbc:mysql://YOUR_DOMAIN:YOUR_PORT/YOUR_TOWER_DB?usePipelineAuth=false&useBatchMultiSend=false`
 
 ## Datasets
 
@@ -142,10 +142,10 @@ Please modify the Seqera Enterprise configuration as follows to try resolving th
 
 When uploading datasets via the Seqera UI or CLI, some steps are automatically done on your behalf. To upload datasets via the Seqera API, additional steps are required:
 
-1. Explicitly define the MIME type of the file being uploaded.
-2. Make two calls to the API:
-   1. Create a dataset object.
-   2. Upload the samplesheet to the dataset object.
+1.  Explicitly define the MIME type of the file being uploaded.
+1.  Make two calls to the API:
+   1.  Create a dataset object.
+   2.  Upload the samplesheet to the dataset object.
 
 Example:
 
@@ -193,13 +193,13 @@ TLS connection errors can occur due to variability in the [default TLS version s
 
 To fix the problem, try the following:
 
-1. Set a JDK environment variable to force Nextflow and Seqera containers to use TLSv1.2 by default:
+1.  Set a JDK environment variable to force Nextflow and Seqera containers to use TLSv1.2 by default:
 
     ```
     export JAVA_OPTIONS="-Dmail.smtp.ssl.protocols=TLSv1.2"
     ```
 
-2. Add this parameter to your [nextflow.config file](./launch/advanced.mdx#nextflow-config-file):
+1.  Add this parameter to your [nextflow.config file](./launch/advanced.mdx#nextflow-config-file):
 
     ```
     mail {
@@ -207,10 +207,10 @@ To fix the problem, try the following:
     }
     ```
 
-3. Ensure these values are also set for Nextflow and/or Seqera:
+1.  Ensure these values are also set for Nextflow and/or Seqera:
 
-    -   `mail.smtp.starttls.enable=true`
-    -   `mail.smtp.starttls.required=true`
+    - `mail.smtp.starttls.enable=true`
+    - `mail.smtp.starttls.required=true`
 
 ## Git integration
 
@@ -260,9 +260,9 @@ Users with email addresses other than the `trustedEmails` list will undergo an a
 
 :::note
 
-1. You must rebuild your containers (`docker compose down`) to force Seqera to implement this change. Ensure your database is persistent before issuing the teardown command. See [here](./enterprise/docker-compose.mdx) for more information.
-2. All login attempts are visible to the root user at **Profile > Admin panel > Users**.
-3. Any user logged in prior to the restriction will not be subject to the new restriction. An admin of the organization should remove users that have previously logged in via (untrusted) email from the Admin panel users list. This will restart the approval process before they can log in via email.
+1.  You must rebuild your containers (`docker compose down`) to force Seqera to implement this change. Ensure your database is persistent before issuing the teardown command. See [here](./enterprise/docker-compose.mdx) for more information.
+1.  All login attempts are visible to the root user at **Profile > Admin panel > Users**.
+1.  Any user logged in prior to the restriction will not be subject to the new restriction. An admin of the organization should remove users that have previously logged in via (untrusted) email from the Admin panel users list. This will restart the approval process before they can log in via email.
 
 :::
 
@@ -298,7 +298,7 @@ Mount the APM solution's JAR file in Seqera's `backend` container and set the ag
 
 Although it's not possible to directly download the trace logs via Seqera, you can configure your workflow to export the file to persistent storage:
 
-1. Set this block in your [`nextflow.config`](./launch/advanced.mdx#nextflow-config-file):
+1.  Set this block in your [`nextflow.config`](./launch/advanced.mdx#nextflow-config-file):
 
    ```nextflow
    trace {
@@ -306,7 +306,7 @@ Although it's not possible to directly download the trace logs via Seqera, you c
    }
    ```
 
-2. Add a copy command to your pipeline's **Advanced options > Post-run script** field:
+1.  Add a copy command to your pipeline's **Advanced options > Post-run script** field:
 
    ```
    # Example: Export the generated trace file to an S3 bucket
@@ -521,9 +521,9 @@ Runs will fail if your Nextflow script or Nextflow config contain illegal charac
 
 The Groovy shell used by Nextflow to execute your workflow has a hard limit on string size (64KiB). Check the size of your scripts with the `ls -llh` command. If the size is greater than 65,535 bytes, consider these mitigation techniques:
 
-1. Remove any unnecessary code or comments from the script.
-2. Move long script bodies into a separate script file in the pipeline `/bin` directory.
-3. Consider using DSL2 so you can move each function, process, and workflow definition into its own script and include these scripts as [modules](https://www.nextflow.io/docs/latest/dsl2.html#modules).
+1.  Remove any unnecessary code or comments from the script.
+1.  Move long script bodies into a separate script file in the pipeline `/bin` directory.
+1.  Consider using DSL2 so you can move each function, process, and workflow definition into its own script and include these scripts as [modules](https://www.nextflow.io/docs/latest/dsl2.html#modules).
 
 ## Nextflow Launcher
 
@@ -744,9 +744,9 @@ Docker Hub imposes a rate limit of 100 anonymous pulls per 6 hours. Add the foll
 
 If your run fails with an _Essential container in task exited - CannotInspectContainerError: Could not transition to inspecting; timed out after waiting 30s_ error, try the following:
 
-1. Upgrade your [ECS Agent](https://github.com/aws/amazon-ecs-agent/releases) to [1.54.1](https://github.com/aws/amazon-ecs-agent/pull/2940) or newer. See [here](https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/ECS/latest-agent-version.html) for instructions to check your ECS Agent version.
-2. Provision more storage for your EC2 instance (preferably via EBS-autoscaling to ensure scalability).
-3. If the error is accompanied by _command exit status: 123_ and a _permissions denied_ error tied to a system command, ensure that the ECS Agent binary is set to be executable (`chmod u+x`).
+1.  Upgrade your [ECS Agent](https://github.com/aws/amazon-ecs-agent/releases) to [1.54.1](https://github.com/aws/amazon-ecs-agent/pull/2940) or newer. See [here](https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/ECS/latest-agent-version.html) for instructions to check your ECS Agent version.
+1.  Provision more storage for your EC2 instance (preferably via EBS-autoscaling to ensure scalability).
+1.  If the error is accompanied by _command exit status: 123_ and a _permissions denied_ error tied to a system command, ensure that the ECS Agent binary is set to be executable (`chmod u+x`).
 
 ### Queues
 
@@ -778,7 +778,7 @@ process {
 
 If you need to save files to an S3 bucket with a policy that [enforces AES256 server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html), the [nf-launcher](https://quay.io/repository/seqeralabs/nf-launcher?tab=tags) script which invokes the Nextflow head job requires additional configuration:
 
-1. Add the following configuration to the **Advanced options > Nextflow config file** textbox of the **Launch Pipeline** screen:
+1.  Add the following configuration to the **Advanced options > Nextflow config file** textbox of the **Launch Pipeline** screen:
 
    ```
    aws {
@@ -788,7 +788,7 @@ If you need to save files to an S3 bucket with a policy that [enforces AES256 se
    }
    ```
 
-2. Add the following configuration to the **Advanced options > Pre-run script** textbox of the **Launch Pipeline** screen:
+1.  Add the following configuration to the **Advanced options > Pre-run script** textbox of the **Launch Pipeline** screen:
 
    ```bash
    export TOWER_AWS_SSE=AES256
@@ -804,12 +804,12 @@ If you need to save files to an S3 bucket with a policy that [enforces AES256 se
 
 The default Azure Batch implementation in Seqera Platform uses a single pool for head and compute nodes. This means that all jobs spawn dedicated/on-demand VMs by default. To save cloud costs by using low priority VMs for compute jobs, specify separate pools for head and compute jobs:
 
-1. Create two Batch pools in Azure:
+1.  Create two Batch pools in Azure:
     - One Dedicated
     - One [Low priority](https://learn.microsoft.com/en-us/azure/batch/batch-spot-vms#differences-between-spot-and-low-priority-vms).
-2. Create a manual [Azure Batch](./compute-envs/azure-batch.mdx#manual) compute environment in Seqera Platform.
-3. In **Compute pool name** (step 10 in the guide linked above), specify your dedicated Batch pool.
-4. Specify the Low priority pool using the `process.queue` [directive](https://www.nextflow.io/docs/latest/process.html#queue) in your `nextflow.config` file (either via the launch form, or your pipeline repository's `nextflow.config` file).
+1.  Create a manual [Azure Batch](./compute-envs/azure-batch.mdx#manual) compute environment in Seqera Platform.
+1.  In **Compute pool name** (step 10 in the guide linked above), specify your dedicated Batch pool.
+1.  Specify the Low priority pool using the `process.queue` [directive](https://www.nextflow.io/docs/latest/process.html#queue) in your `nextflow.config` file (either via the launch form, or your pipeline repository's `nextflow.config` file).
 
 ### AKS
 
@@ -858,10 +858,10 @@ process {
 
 The following roles must be granted to the `nextflow-service-account`:
 
-1. Cloud Life Sciences Workflows Runner
-2. Service Account User
-3. Service Usage Consumer
-4. Storage Object Admin
+1.  Cloud Life Sciences Workflows Runner
+1.  Service Account User
+1.  Service Usage Consumer
+1.  Storage Object Admin
 
 For detailed information, see [this guide](https://cloud.google.com/life-sciences/docs/tutorials/nextflow#create_a_service_account_and_add_roles).
 
@@ -907,24 +907,24 @@ Nextflow is trying to use the Java VM defined for the following environment vari
 
 Possible reasons for this error:
 
-1. The queue where the Nextflow head job runs is in a different environment/node than your login node userspace.
-2. If your HPC cluster uses modules, the Java module may not be loaded by default.
+1.  The queue where the Nextflow head job runs is in a different environment/node than your login node userspace.
+1.  If your HPC cluster uses modules, the Java module may not be loaded by default.
 
 To troubleshoot:
 
-1. Open an interactive session with the head job queue.
-2. Launch the Nextflow job from the interactive session.
-3. If your cluster uses modules:
+1.  Open an interactive session with the head job queue.
+1.  Launch the Nextflow job from the interactive session.
+1.  If your cluster uses modules:
    - Add `module load <your_java_module>` in the **Advanced Features > Pre-run script** field when creating your HPC compute environment in Seqera.
-4. If your cluster doesn't use modules:
-   1. Source an environment with Java and Nextflow using the **Advanced Features > Pre-run script** field when creating your HPC compute environment in Seqera.
+1.  If your cluster doesn't use modules:
+   1.  Source an environment with Java and Nextflow using the **Advanced Features > Pre-run script** field when creating your HPC compute environment in Seqera.
 
 **Pipeline submissions to HPC clusters fail for some users**
 
 Nextflow launcher scripts will fail if processed by a non-Bash shell (e.g., `zsh`, `tcsh`). This problem can be identified from certain error entries:
 
-1. Your _.nextflow.log_ contains an error like _Invalid workflow status - expected: SUBMITTED; current: FAILED_.
-2. Your Seqera **Error report** tab contains an error like:
+1.  Your _.nextflow.log_ contains an error like _Invalid workflow status - expected: SUBMITTED; current: FAILED_.
+1.  Your Seqera **Error report** tab contains an error like:
 
 ```yaml
 Slurm job submission failed
@@ -935,6 +935,6 @@ Slurm job submission failed
 
 Connect to the head node via SSH and run `ps -p $$` to verify your default shell. If you see an entry other than Bash, fix as follows:
 
-1. Check which shells are available to you: `cat /etc/shells`
-2. Change your shell: `chsh -s /usr/bin/bash` (the path to the binary may differ, depending on your HPC configuration)
-3. If submissions continue to fail after this shell change, ask your Seqera Platform admin to restart the **backend** and **cron** containers, then submit again.
+1.  Check which shells are available to you: `cat /etc/shells`
+1.  Change your shell: `chsh -s /usr/bin/bash` (the path to the binary may differ, depending on your HPC configuration)
+1.  If submissions continue to fail after this shell change, ask your Seqera Platform admin to restart the **backend** and **cron** containers, then submit again.

--- a/platform_versioned_docs/version-23.3.0/getting-started/community-showcase.mdx
+++ b/platform_versioned_docs/version-23.3.0/getting-started/community-showcase.mdx
@@ -29,15 +29,15 @@ The Community Showcase includes [pipeline secrets](../secrets/overview.mdx) that
 
 ## Run pipeline with sample data
 
-1. From the [Launchpad](../launch/launchpad.mdx), select a pipeline to view the pipeline detail page. _nf-core-rnaseq_ is a good first pipeline example.
-2. (Optional) Select the URL under **Workflow repository** to view the pipeline code repository in another tab.
-3. Select **Launch** from the pipeline detail page.
-4. On the **Launch pipeline** page, enter a unique **Workflow run name** or use the pre-filled random name.
-5. (Optional) Enter labels to be assigned to the run in the **Labels** field.
-6. Under **Input/output options**, select the dataset named after your chosen pipeline from the drop-down menu under **input**.
-7. Under **outdir**, specify an output directory where run results will be saved. This must be an absolute path to storage on cloud infrastructure and defaults to `./results`.
-8. Under **email**, enter an email address where you wish to receive the run completion summary.
-9. Under **multiqc_title**, enter a title for the MultiQC report. This is used as both the report page header and filename.
+1.  From the [Launchpad](../launch/launchpad.mdx), select a pipeline to view the pipeline detail page. _nf-core-rnaseq_ is a good first pipeline example.
+1.  (Optional) Select the URL under **Workflow repository** to view the pipeline code repository in another tab.
+1.  Select **Launch** from the pipeline detail page.
+1.  On the **Launch pipeline** page, enter a unique **Workflow run name** or use the pre-filled random name.
+1.  (Optional) Enter labels to be assigned to the run in the **Labels** field.
+1.  Under **Input/output options**, select the dataset named after your chosen pipeline from the drop-down menu under **input**.
+1.  Under **outdir**, specify an output directory where run results will be saved. This must be an absolute path to storage on cloud infrastructure and defaults to `./results`.
+1.  Under **email**, enter an email address where you wish to receive the run completion summary.
+1.  Under **multiqc_title**, enter a title for the MultiQC report. This is used as both the report page header and filename.
 
 The remaining launch form fields will vary depending on the pipeline you have selected. Parameters required for the pipeline to run are pre-filled by default, and empty fields are optional.
 

--- a/platform_versioned_docs/version-23.3.0/getting-started/deployment-options.mdx
+++ b/platform_versioned_docs/version-23.3.0/getting-started/deployment-options.mdx
@@ -34,14 +34,14 @@ You can access your Seqera instance through the UI, the [API](../api/overview.md
 
 ### Seqera Platform UI
 
-1. Create an account and log in to Seqera at [cloud.tower.nf](https://cloud.tower.nf).
+1.  Create an account and log in to Seqera at [cloud.tower.nf](https://cloud.tower.nf).
 
    :::note
    Platform login sessions remain active as long as the application browser window remains open and active. When the browser window is terminated, automatic logout occurs within 6 hours by default.
    :::
 
-2. Create and configure a new [compute environment](../compute-envs/overview.mdx).
-3. Start [launching pipelines](../launch/launchpad.mdx).
+1.  Create and configure a new [compute environment](../compute-envs/overview.mdx).
+1.  Start [launching pipelines](../launch/launchpad.mdx).
 
 ### Seqera API
 
@@ -55,17 +55,17 @@ See [CLI](../cli/cli.mdx).
 
 If you have an existing environment where you run Nextflow directly, you can still leverage Seqera Platform capabilities by executing your Nextflow run with a `with-tower` flag:
 
-1. Create an account and log in to Seqera.
-2. From your personal workspace: Go to the user menu and select **Settings > Your tokens**.
-3. Select **Add token**.
-4. Enter a unique name for your token, then select **Add**.
-5. Copy and store your token securely.
+1.  Create an account and log in to Seqera.
+1.  From your personal workspace: Go to the user menu and select **Settings > Your tokens**.
+1.  Select **Add token**.
+1.  Enter a unique name for your token, then select **Add**.
+1.  Copy and store your token securely.
 
 :::caution
 The access token is displayed only once. Save the token value before closing the **Personal Access Token** window.
 :::
 
-6. Open a terminal window and create environment variables to store the Seqera access token and Nextflow version. Replace `<your access token>` with your newly-created token.
+1.  Open a terminal window and create environment variables to store the Seqera access token and Nextflow version. Replace `<your access token>` with your newly-created token.
 
    ```bash
    export TOWER_ACCESS_TOKEN=<your access token>
@@ -76,7 +76,7 @@ The access token is displayed only once. Save the token value before closing the
 Bearer token support requires Nextflow version 20.10.0 or later. Set with the `NXF_VER` environment variable.
 :::
 
-7. To submit a pipeline to a [workspace](../orgs-and-teams/workspace-management.mdx) using Nextflow, add the workspace ID to your environment:
+1.  To submit a pipeline to a [workspace](../orgs-and-teams/workspace-management.mdx) using Nextflow, add the workspace ID to your environment:
 
    ```bash
    export TOWER_WORKSPACE_ID=000000000000000
@@ -84,7 +84,7 @@ Bearer token support requires Nextflow version 20.10.0 or later. Set with the `N
 
    To find your workspace ID, select your organization in Seqera and navigate to the **Workspaces** tab.
 
-8. Run your Nextflow pipeline with the `-with-tower` flag:
+1.  Run your Nextflow pipeline with the `-with-tower` flag:
 
    ```bash
    nextflow run main.nf -with-tower

--- a/platform_versioned_docs/version-23.3.0/git/overview.mdx
+++ b/platform_versioned_docs/version-23.3.0/git/overview.mdx
@@ -35,13 +35,13 @@ Credentials are encrypted with the AES-256 cypher before secure storage and are 
 
 When you have multiple stored credentials, Seqera selects the most relevant credential for your repository in the following order:
 
-1. Seqera evaluates all the stored credentials available to the current workspace.
+1.  Seqera evaluates all the stored credentials available to the current workspace.
 
-2. Credentials are filtered by Git provider (GitHub, GitLab, Bitbucket, etc.)
+1.  Credentials are filtered by Git provider (GitHub, GitLab, Bitbucket, etc.)
 
-3. Seqera selects the credential with a **Repository base URL** most similar to the target repository.
+1.  Seqera selects the credential with a **Repository base URL** most similar to the target repository.
 
-4. If no **Repository base URL** values are specified in the workspace credentials, the most long-lived credential is selected.
+1.  If no **Repository base URL** values are specified in the workspace credentials, the most long-lived credential is selected.
 
 **Credential filtering example**
 
@@ -89,15 +89,15 @@ Once you have created and copied your access token, create a new credential in S
 
 **Create AzureDevOps credentials**
 
-1. From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
+1.  From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select _Azure DevOps_ as the **Provider**.
+1.  Select _Azure DevOps_ as the **Provider**.
 
-5. Enter your **Username** and **Access token**.
+1.  Enter your **Username** and **Access token**.
 
-6. (Recommended) Enter the **Repository base URL** for which the credentials should be applied. This option is used to apply the provided credentials to a specific repository, e.g., `https://dev.azure.com/<your organization>/<your project>`.
+1.  (Recommended) Enter the **Repository base URL** for which the credentials should be applied. This option is used to apply the provided credentials to a specific repository, e.g., `https://dev.azure.com/<your organization>/<your project>`.
 
 ### GitHub
 
@@ -115,15 +115,15 @@ After you've created and copied your access token, create a new credential in Se
 
 **Create GitHub credentials**
 
-1. From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
+1.  From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
 
-2. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-3. Select _GitHub_ as the **Provider**.
+1.  Select _GitHub_ as the **Provider**.
 
-4. Enter your **Username** and **Access token**.
+1.  Enter your **Username** and **Access token**.
 
-5. (Recommended) Enter the **Repository base URL** for which the credentials should be applied. This option is used to apply the provided credentials to a specific repository, e.g., `https://github.com/seqeralabs`.
+1.  (Recommended) Enter the **Repository base URL** for which the credentials should be applied. This option is used to apply the provided credentials to a specific repository, e.g., `https://github.com/seqeralabs`.
 
 ### GitLab
 
@@ -133,17 +133,17 @@ After you have created and copied your access token, create a new credential in 
 
 **Create GitLab credentials**
 
-1. From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
+1.  From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
 
-2. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-3. Select _GitLab_ as the **Provider**.
+1.  Select _GitLab_ as the **Provider**.
 
-4. Enter your **Username**. For Group and Project access tokens, the username can be any non-empty value.
+1.  Enter your **Username**. For Group and Project access tokens, the username can be any non-empty value.
 
-5. Enter your token value in both the **Password** and **Access token** fields.
+1.  Enter your token value in both the **Password** and **Access token** fields.
 
-6. Enter the **Repository base URL** (recommended). This option is used to apply the credentials to a specific repository, e.g. `https://gitlab.com/seqeralabs`.
+1.  Enter the **Repository base URL** (recommended). This option is used to apply the credentials to a specific repository, e.g. `https://gitlab.com/seqeralabs`.
 
 ### Gitea
 
@@ -151,17 +151,17 @@ To connect to a private [Gitea](https://gitea.io/) repository, use your Gitea us
 
 **Create Gitea credentials**
 
-1. From an organization workspace, go to the **Credentials** tab and select **Add Credentials**. From your personal workspace, select **Your credentials** from the user menu, then select **Add credentials**.
+1.  From an organization workspace, go to the **Credentials** tab and select **Add Credentials**. From your personal workspace, select **Your credentials** from the user menu, then select **Add credentials**.
 
-2. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-3. Select _Gitea_ as the **Provider**.
+1.  Select _Gitea_ as the **Provider**.
 
-4. Enter your **Username**.
+1.  Enter your **Username**.
 
-5. Enter your **Password**.
+1.  Enter your **Password**.
 
-6. Enter your **Repository base URL** (required).
+1.  Enter your **Repository base URL** (required).
 
 ### Bitbucket
 
@@ -169,15 +169,15 @@ To connect to a private BitBucket repository, see the [BitBucket documentation](
 
 **Create BitBucket credentials**
 
-1. From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
+1.  From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
 
-2. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-3. Select _BitBucket_ as the **Provider**.
+1.  Select _BitBucket_ as the **Provider**.
 
-4. Enter your **Username** and **Password**.
+1.  Enter your **Username** and **Password**.
 
-5. Enter the **Repository base URL** (recommended). This option can be used to apply the credentials to a specific repository, e.g., `https://bitbucket.org/seqeralabs`.
+1.  Enter the **Repository base URL** (recommended). This option can be used to apply the credentials to a specific repository, e.g., `https://bitbucket.org/seqeralabs`.
 
 ### AWS CodeCommit
 
@@ -185,15 +185,15 @@ To connect to a private AWS CodeCommit repository, see the [AWS documentation](h
 
 **Create AWS CodeCommit credentials**
 
-1. From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
+1.  From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
 
-2. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-3. Select _CodeCommit_ as the **Provider**.
+1.  Select _CodeCommit_ as the **Provider**.
 
-4. Enter the **Access key** and **Secret key** of the AWS IAM account that will be used to access the target CodeCommit repository.
+1.  Enter the **Access key** and **Secret key** of the AWS IAM account that will be used to access the target CodeCommit repository.
 
-5. Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the credentials to a specific region, e.g., `https://git-codecommit.eu-west-1.amazonaws.com`.
+1.  Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the credentials to a specific region, e.g., `https://git-codecommit.eu-west-1.amazonaws.com`.
 
 ### Self-hosted Git
 

--- a/platform_versioned_docs/version-23.3.0/launch/cache-resume.mdx
+++ b/platform_versioned_docs/version-23.3.0/launch/cache-resume.mdx
@@ -8,11 +8,11 @@ tags: [cache, launch, resume, relaunch]
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Nextflow maintains a [cache](https://www.nextflow.io/docs/latest/cache-and-resume.html) directory where it stores the intermediate results and metadata from workflow runs. Workflows executed in Seqera Platform use this caching mechanism to enable users to relaunch or resume failed or otherwise interrupted runs as needed. This eliminates the need to re-execute successfully completed tasks when a workflow is executed again due to task failures or other interruptions. 
+Nextflow maintains a [cache](https://www.nextflow.io/docs/latest/cache-and-resume.html) directory where it stores the intermediate results and metadata from workflow runs. Workflows executed in Seqera Platform use this caching mechanism to enable users to relaunch or resume failed or otherwise interrupted runs as needed. This eliminates the need to re-execute successfully completed tasks when a workflow is executed again due to task failures or other interruptions.
 
 ## Cache directory
 
-Nextflow stores all task executions to the task cache automatically, whether or not the resume or relaunch option is used. This makes it possible to resume or relaunch runs later if needed. Platform HPC and local compute environments use the default Nextflow cache directory (`.nextflow/cache`) to store the task cache. Cloud compute environments use the [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) mechanism to store the task cache in a sub-folder of the pipeline work directory. 
+Nextflow stores all task executions to the task cache automatically, whether or not the resume or relaunch option is used. This makes it possible to resume or relaunch runs later if needed. Platform HPC and local compute environments use the default Nextflow cache directory (`.nextflow/cache`) to store the task cache. Cloud compute environments use the [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) mechanism to store the task cache in a sub-folder of the pipeline work directory.
 
 To override the default cloud cache location in cloud compute environments, specify an alternate directory with the [cache](https://www.nextflow.io/docs/latest/process.html#process-cache) directive in your Nextflow configuration file (either in the **Advanced options > Nextflow config file** field on the launch form, or in the `nextflow.config` file in your pipeline repository).
 
@@ -21,44 +21,42 @@ To override the default cloud cache location in cloud compute environments, spec
 
 To customize the cache location used in your AWS Batch and Amazon EKS compute environments, specify an alternate cache directory in your Nextflow configuration:
 
-```groovy 
+```groovy
 cloudcache {
    enabled = true
    path = 's3://your-bucket/.cache'
    }
 ```
 
-The new cache directory must be accessible with the credentials associated with your compute environment. An alternate cloud storage location can be specified if you include the necessary credentials for that location in your Nextflow configuration. **This is not recommended for production environments**. 
+The new cache directory must be accessible with the credentials associated with your compute environment. An alternate cloud storage location can be specified if you include the necessary credentials for that location in your Nextflow configuration. **This is not recommended for production environments**.
 
 </TabItem>
 <TabItem value="Azure Batch" label="Azure Batch" default>
 
 To customize the cache location used in your Azure Batch compute environments, specify an alternate cache directory in your Nextflow configuration:
 
-```groovy 
+```groovy
 cloudcache {
    enabled = true
    path = 'az://your-container/.cache'
    }
 ```
 
-The new cache directory must be accessible with the credentials associated with your compute environment. An alternate cloud storage location can be specified if you include the necessary credentials for that location in your Nextflow configuration. **This is not recommended for production environments**. 
-
+The new cache directory must be accessible with the credentials associated with your compute environment. An alternate cloud storage location can be specified if you include the necessary credentials for that location in your Nextflow configuration. **This is not recommended for production environments**.
 
 </TabItem>
 <TabItem value="Google Cloud Batch and Google GKE" label="Google Cloud Batch and Google GKE " default>
 
 To customize the cache location used in your Google Cloud Batch and Google GKE compute environments, specify an alternate cache directory in your Nextflow configuration:
 
-```groovy 
+```groovy
 cloudcache {
    enabled = true
    path = 'gs://your-bucket/.cache'
    }
 ```
 
-The new cache directory must be accessible with the credentials associated with your compute environment. An alternate cloud storage location can be specified if you include the necessary credentials for that location in your Nextflow configuration. **This is not recommended for production environments**. 
-
+The new cache directory must be accessible with the credentials associated with your compute environment. An alternate cloud storage location can be specified if you include the necessary credentials for that location in your Nextflow configuration. **This is not recommended for production environments**.
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes" default>
@@ -124,7 +122,7 @@ Kubernetes compute environments do not use cloud cache by default. To specify a 
          path = 'gs://your-bucket/.cache'
          }
       ```
-   
+
    </details>
 
 </TabItem>

--- a/platform_versioned_docs/version-23.3.0/launch/launchpad.mdx
+++ b/platform_versioned_docs/version-23.3.0/launch/launchpad.mdx
@@ -47,24 +47,24 @@ For more information on relaunch and resume, see [Cache and resume](./cache-resu
 
 **Quick launch an unconfigured pipeline**
 
-1. Select **launch a run without configuration** below the Launchpad heading.
-2. On the **Launch** form, enter an optional **Workflow run name** (or keep the randomly assigned default) and assign optional labels to the run.
-3. Select a **Compute environment** from the available options. See [Compute environments](../compute-envs/overview.mdx) to learn how to create an environment for your preferred execution platform.
-4. Enter a repository URL for the **Pipeline to launch** (e.g., `https://github.com/nf-core/rnaseq.git`).
+1.  Select **launch a run without configuration** below the Launchpad heading.
+1.  On the **Launch** form, enter an optional **Workflow run name** (or keep the randomly assigned default) and assign optional labels to the run.
+1.  Select a **Compute environment** from the available options. See [Compute environments](../compute-envs/overview.mdx) to learn how to create an environment for your preferred execution platform.
+1.  Enter a repository URL for the **Pipeline to launch** (e.g., `https://github.com/nf-core/rnaseq.git`).
 
 :::note
 Nextflow pipelines are Git repositories that can reside on any public or private Git-hosting platform. See [Git integration](../git/overview.mdx) in the Seqera docs and [Pipeline sharing](https://www.nextflow.io/docs/latest/sharing.html) in the Nextflow docs for more details.
 :::
 
-5. Select a **Revision number** to use a specific version of the pipeline (optional). The Git default branch (e.g. main or master) or `manifest.defaultBranch` in the Nextflow configuration will be used by default.
-6. Enter the **Work directory**, which corresponds to the Nextflow work directory. You can also **Browse** for a cloud storage directory with Data Explorer. The default work directory of the compute environment will be used by default.
+1.  Select a **Revision number** to use a specific version of the pipeline (optional). The Git default branch (e.g. main or master) or `manifest.defaultBranch` in the Nextflow configuration will be used by default.
+1.  Enter the **Work directory**, which corresponds to the Nextflow work directory. You can also **Browse** for a cloud storage directory with Data Explorer. The default work directory of the compute environment will be used by default.
 
 :::note
 The credentials associated with the compute environment must have access to the work directory (e.g., an S3 bucket).
 :::
 
-7. Select any **Config profiles** you wish to use. See [Nextflow Config profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) for more details.
-8. Enter any **Pipeline parameters** in YAML or JSON format:
+1.  Select any **Config profiles** you wish to use. See [Nextflow Config profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) for more details.
+1.  Enter any **Pipeline parameters** in YAML or JSON format:
 
 ```
 reads: 's3://nf-bucket/exome-data/ERR013140_{1,2}.fastq.bz2'
@@ -75,7 +75,7 @@ paired_end: true
 In YAML, quotes should be used for paths but not for numbers or Boolean values.
 :::
 
-9. Once you have filled the necessary launch form details, select **Launch**. The **Runs** tab shows your new run in a **submitted** status on the top of the list. Select the run name to navigate to the run detail page and view the configuration, parameters, status of individual tasks, and run report.
+1.  Once you have filled the necessary launch form details, select **Launch**. The **Runs** tab shows your new run in a **submitted** status on the top of the list. Select the run name to navigate to the run detail page and view the configuration, parameters, status of individual tasks, and run report.
 
 :::note
 For more information on relaunch and resume, see [Cache and resume](./cache-resume.mdx).

--- a/platform_versioned_docs/version-23.3.0/orgs-and-teams/organizations.mdx
+++ b/platform_versioned_docs/version-23.3.0/orgs-and-teams/organizations.mdx
@@ -13,10 +13,10 @@ You can also add external collaborators to an organization.
 
 ### Create an organization
 
-1. Go to [Your organizations](https://tower.nf/orgs) and select **Add Organization**.
-2. Enter a **Name** and **Full name** for your organization.
-3. Enter any other optional fields as needed: **Description**, **Location**, **Website URL** and **Logo**.
-4. Select **Add**.
+1.  Go to [Your organizations](https://tower.nf/orgs) and select **Add Organization**.
+1.  Enter a **Name** and **Full name** for your organization.
+1.  Enter any other optional fields as needed: **Description**, **Location**, **Website URL** and **Logo**.
+1.  Select **Add**.
 
 ### Edit an organization
 
@@ -42,9 +42,9 @@ Seqera provides access control for members of an organization by classifying the
 
 To add a new member to an organization:
 
-1. Go to the **Members** tab of the organization menu.
-2. Select **Add member**.
-3. Enter the name or email address of the user you'd like to add to the organization.
+1.  Go to the **Members** tab of the organization menu.
+1.  Select **Add member**.
+1.  Enter the name or email address of the user you'd like to add to the organization.
 
 An email invitiation will be sent to the user. Once they accept the invitation, they can switch to the organization (or organization workspace) using their workspace drop-down.
 
@@ -56,11 +56,11 @@ An email invitiation will be sent to the user. Once they accept the invitation, 
 
 To create a new team within an organization:
 
-1. Go to the **Teams** tab of the organization menu.
-2. Select **Add Team**.
-3. Enter the **Name** of team.
-4. Optionally, add the **Description** and the team's **Avatar**.
-5. Select **Add**.
+1.  Go to the **Teams** tab of the organization menu.
+1.  Select **Add Team**.
+1.  Enter the **Name** of team.
+1.  Optionally, add the **Description** and the team's **Avatar**.
+1.  Select **Add**.
 
 To start adding members to your team, select **Edit > Members of team > Add member** and type in the name or email address of the organization members or collaborators.
 

--- a/platform_versioned_docs/version-23.3.0/orgs-and-teams/workspace-management.mdx
+++ b/platform_versioned_docs/version-23.3.0/orgs-and-teams/workspace-management.mdx
@@ -19,12 +19,12 @@ A workspace participant may be a member of the workspace organization or a colla
 
 Organization owners and admins can create a new workspace within an organization:
 
-1. Go to the **Workspaces** tab of the organization page.
-2. Select **Add Workspace**.
-3. Enter the **Name** and **Full name** for the workspace.
-4. Optionally, add a **Description** for the workspace.
-5. Under **Visibility**, select either **Private** or **Shared**. Private visibility means that workspace pipelines are only accessible to workspace participants.
-6. Select **Add**.
+1.  Go to the **Workspaces** tab of the organization page.
+1.  Select **Add Workspace**.
+1.  Enter the **Name** and **Full name** for the workspace.
+1.  Optionally, add a **Description** for the workspace.
+1.  Under **Visibility**, select either **Private** or **Shared**. Private visibility means that workspace pipelines are only accessible to workspace participants.
+1.  Select **Add**.
 
 :::tip
 Optional workspace fields can be modified after workspace creation, either with the **Edit** option on an organization's workspaces list or the **Settings** tab within the workspace page, provided that you are the workspace **owner**.
@@ -44,10 +44,10 @@ Open the **Settings** tab on the workspace page and select **Edit Workspace**. M
 
 A new workspace participant can be an existing organization member, team, or collaborator. To add a new participant to a workspace:
 
-1. Go to the **Participants** tab in the workspace menu.
-2. Select **Add participant**.
-3. Enter the **Name** of the new participant.
-4. Optionally, update the participant **role**. For more information on **roles**, see [participant roles](#participant-roles).
+1.  Go to the **Participants** tab in the workspace menu.
+1.  Select **Add participant**.
+1.  Enter the **Name** of the new participant.
+1.  Optionally, update the participant **role**. For more information on **roles**, see [participant roles](#participant-roles).
 
 ## Participant roles
 
@@ -59,11 +59,11 @@ You can group **members** and **collaborators** into **teams** and apply a role 
 
 There are five roles available for every workspace participant:
 
-1. **Owner**: The participant has full permissions for all resources within the workspace, including the workspace settings.
-2. **Admin**: The participant has full permissions for resources associated with the workspace. They can create, modify, and delete pipelines, compute environments, actions, and credentials. They can add/remove users to the workspace and edit workspace settings, but cannot delete it.
-3. **Maintain**: The participant can launch pipelines and modify pipeline executions (e.g., they can change the pipeline launch compute environments, parameters, pre/post-run scripts, and Nextflow configuration) and create new pipelines in the Launchpad. Users with maintain permissions cannot modify compute environments and credentials.
-4. **Launch**: The participant can launch pipelines and modify the pipeline input/output parameters in the Launchpad. They cannot modify the launch configuration or other resources.
-5. **View**: The participant can view workspace pipelines and runs in read-only mode.
+1.  **Owner**: The participant has full permissions for all resources within the workspace, including the workspace settings.
+1.  **Admin**: The participant has full permissions for resources associated with the workspace. They can create, modify, and delete pipelines, compute environments, actions, and credentials. They can add/remove users to the workspace and edit workspace settings, but cannot delete it.
+1.  **Maintain**: The participant can launch pipelines and modify pipeline executions (e.g., they can change the pipeline launch compute environments, parameters, pre/post-run scripts, and Nextflow configuration) and create new pipelines in the Launchpad. Users with maintain permissions cannot modify compute environments and credentials.
+1.  **Launch**: The participant can launch pipelines and modify the pipeline input/output parameters in the Launchpad. They cannot modify the launch configuration or other resources.
+1.  **View**: The participant can view workspace pipelines and runs in read-only mode.
 
 ## Workspace run monitoring
 

--- a/platform_versioned_docs/version-23.3.0/pipeline-actions/overview.mdx
+++ b/platform_versioned_docs/version-23.3.0/pipeline-actions/overview.mdx
@@ -17,12 +17,12 @@ You must sign in to Seqera using GitHub authentication to create a GitHub webhoo
 
 To create a new action, select the **Actions** tab and select **Add Action**.
 
-1. Enter a **Name** for your action.
-2. Select **GitHub webhook** as the **Event source**.
-3. Select the **Compute environment** where the pipeline will be executed.
-4. Select the **Pipeline to launch** and (optionally) the **Revision number**.
-5. Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
-6. Select **Add**.
+1.  Enter a **Name** for your action.
+1.  Select **GitHub webhook** as the **Event source**.
+1.  Select the **Compute environment** where the pipeline will be executed.
+1.  Select the **Pipeline to launch** and (optionally) the **Revision number**.
+1.  Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
+1.  Select **Add**.
 
 The pipeline action is now set up. When a new commit occurs for the selected repository and revision, an event is triggered and the pipeline is launched.
 
@@ -40,12 +40,12 @@ A **Tower launch hook** creates a custom endpoint URL which can be used to trigg
 
 To create a new action, select the **Actions** tab and select **Add Action**.
 
-1. Enter a **Name** for your action.
-2. Select **Tower launch hook** as the event source.
-3. Select the **Compute environment** to execute your pipeline.
-4. Enter the **Pipeline to launch** and (optionally) the **Revision number**.
-5. Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
-6. Select **Add**.
+1.  Enter a **Name** for your action.
+1.  Select **Tower launch hook** as the event source.
+1.  Select the **Compute environment** to execute your pipeline.
+1.  Enter the **Pipeline to launch** and (optionally) the **Revision number**.
+1.  Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
+1.  Select **Add**.
 
 The pipeline action is now set up and the new endpoint can be used to launch the corresponding pipeline programmatically.
 

--- a/platform_versioned_docs/version-23.3.0/pipeline-optimization/overview.mdx
+++ b/platform_versioned_docs/version-23.3.0/pipeline-optimization/overview.mdx
@@ -21,19 +21,19 @@ On the **Launchpad**, you'll see a lightbulb icon on each pipeline that can be o
 
 ![optimizable runs](./_images/optimization_launchpad.png)
 
-1. Select the lightbulb icon to open the pipeline resource optimization configuration menu.
+1.  Select the lightbulb icon to open the pipeline resource optimization configuration menu.
 
 ![optimization profile menu](./_images/optimization_profile.png)
 
-2. Select a previous run from the dropdown. You can select any successful run.
+1.  Select a previous run from the dropdown. You can select any successful run.
 
-3. Select which **Targets** to optimize.
+1.  Select which **Targets** to optimize.
 
-4. Enable **Retry with dynamic resources** for failed tasks to be retried with increased resources. This option is useful if an optimized setting is too low and causes a task to fail.
+1.  Enable **Retry with dynamic resources** for failed tasks to be retried with increased resources. This option is useful if an optimized setting is too low and causes a task to fail.
 
-5. Select the **Optimized configuration** tab to preview your configuration.
+1.  Select the **Optimized configuration** tab to preview your configuration.
 
-6. Select **Save** to save the optimized configuration and enable it for the pipeline. All subsequent launches of the pipeline will use the optimized configuration.
+1.  Select **Save** to save the optimized configuration and enable it for the pipeline. All subsequent launches of the pipeline will use the optimized configuration.
 
 You can also toggle the optimized profile from the pipeline detail page.
 
@@ -57,10 +57,10 @@ However, it's common for a pipeline to process input files that vary widely in s
 
 The best way to handle this variation is to create multiple optimized profiles for specific ranges of input sizes. Here is an example strategy:
 
-1. Separate your input files into "bins" based on their size, e.g., _small_, _medium_, and _large_. Duplicate your pipeline in the **Launchpad** for each bin.
+1.  Separate your input files into "bins" based on their size, e.g., _small_, _medium_, and _large_. Duplicate your pipeline in the **Launchpad** for each bin.
 
-2. For each bin, run the pipeline with a few representative samples from that bin. When the run completes, Seqera automatically creates an optimized profile for it.
+1.  For each bin, run the pipeline with a few representative samples from that bin. When the run completes, Seqera automatically creates an optimized profile for it.
 
-3. Configure and enable the optimized profile for each pipeline.
+1.  Configure and enable the optimized profile for each pipeline.
 
 You now have multiple optimized profiles to handle a variety of input sizes. Although this example uses three bins, you can use as many or as few bins as you need to handle the variation of your input data.

--- a/platform_versioned_docs/version-23.3.0/reports/overview.mdx
+++ b/platform_versioned_docs/version-23.3.0/reports/overview.mdx
@@ -21,8 +21,8 @@ You can download a report directly or from the provided file path. Reports large
 
 Create a config file that defines the paths to a selection of output files published by the pipeline for Seqera to render reports. There are 2 ways to provide the config file, both of which have to be in YAML format:
 
-1. **Pipeline repository**: If a file called `tower.yml` exists in the root of the pipeline repository then this will be fetched automatically before the pipeline execution.
-2. **Seqera Platform interface**: Provide the YAML definition within the **Advanced options > Seqera Cloud config file** box when:
+1.  **Pipeline repository**: If a file called `tower.yml` exists in the root of the pipeline repository then this will be fetched automatically before the pipeline execution.
+1.  **Seqera Platform interface**: Provide the YAML definition within the **Advanced options > Seqera Cloud config file** box when:
    - Creating a pipeline in the Launchpad.
    - Amending the launch settings during pipeline launch. This is available to users with the **Maintain** role only.
 

--- a/platform_versioned_docs/version-23.3.0/resource-labels/overview.mdx
+++ b/platform_versioned_docs/version-23.3.0/resource-labels/overview.mdx
@@ -107,8 +107,8 @@ Under **Find resources to tag**, search for the resource label key and value in 
 
 To include the cost information associated with your resource labels in your AWS billing reports:
 
-1. [Activate](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activating-tags.html) the associated tags in the **AWS Billing and Cost Management console**. Newly-applied tags may take up to 24 hours to appear on your cost allocation tags page.
-2. When your tags are activated and displayed in **Billing and Cost Management > Cost allocation tags**, you can apply them when you create [cost allocation reports](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/configurecostallocreport.html#allocation-viewing).
+1.  [Activate](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activating-tags.html) the associated tags in the **AWS Billing and Cost Management console**. Newly-applied tags may take up to 24 hours to appear on your cost allocation tags page.
+1.  When your tags are activated and displayed in **Billing and Cost Management > Cost allocation tags**, you can apply them when you create [cost allocation reports](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/configurecostallocreport.html#allocation-viewing).
 
 #### AWS limits
 

--- a/platform_versioned_docs/version-23.3.0/secrets/overview.mdx
+++ b/platform_versioned_docs/version-23.3.0/secrets/overview.mdx
@@ -70,8 +70,8 @@ The ECS Agent uses the [Batch Execution role](https://docs.aws.amazon.com/batch/
 
 **IAM permissions**
 
-1. Add the [`AmazonECSTaskExecutionRolePolicy` managed policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonECSTaskExecutionRolePolicy.html).
-2. Add this inline policy:
+1.  Add the [`AmazonECSTaskExecutionRolePolicy` managed policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonECSTaskExecutionRolePolicy.html).
+1.  Add this inline policy:
 
 ```json
     {

--- a/platform_versioned_docs/version-23.3.0/supported_software/agent/agent.mdx
+++ b/platform_versioned_docs/version-23.3.0/supported_software/agent/agent.mdx
@@ -13,22 +13,22 @@ Tower Agent is a standalone process that runs on a node that can submit jobs to 
 
 Tower Agent is distributed as a single executable file to simply download and execute.
 
-1. Download the latest release from [GitHub](https://github.com/seqeralabs/tower-agent) and make the file executable:
+1.  Download the latest release from [GitHub](https://github.com/seqeralabs/tower-agent) and make the file executable:
 
    ```bash
    curl -fSL https://github.com/seqeralabs/tower-agent/releases/latest/download/tw-agent-linux-x86_64 > tw-agent
    chmod +x ./tw-agent
    ```
 
-2. (Optional) Move it to a folder that's in your $PATH.
+1.  (Optional) Move it to a folder that's in your $PATH.
 
 ### Quickstart
 
 Before running the Agent:
 
-1. Create a [**personal access token**](../../api/overview.mdx#authentication).
+1.  Create a [**personal access token**](../../api/overview.mdx#authentication).
 
-2. Create [Tower Agent credentials](../../credentials/agent_credentials.mdx) in a Seqera Platform workspace.
+1.  Create [Tower Agent credentials](../../credentials/agent_credentials.mdx) in a Seqera Platform workspace.
 
 :::note
 To share a single Tower Agent instance with all members of a workspace, create a Tower Agent credential with **Shared agent** enabled.

--- a/platform_versioned_docs/version-23.3.0/supported_software/dragen/overview.mdx
+++ b/platform_versioned_docs/version-23.3.0/supported_software/dragen/overview.mdx
@@ -27,9 +27,9 @@ To deploy the pipeline on your own AWS cloud infrastructure, follow the instruct
 
 DRAGEN is a commercial technology provided by Illumina, so you will need to purchase a license from them. To run on Seqera, you will need to obtain the following information from Illumina:
 
-1. DRAGEN AWS private AMI ID
-2. DRAGEN license username
-3. DRAGEN license password
+1.  DRAGEN AWS private AMI ID
+1.  DRAGEN license username
+1.  DRAGEN license password
 
 Batch Forge automates most of the tasks required to set up an AWS Batch compute environment. See [AWS Batch](../../compute-envs/aws-batch.mdx) for more details.
 
@@ -47,7 +47,7 @@ The Region you select must contain DRAGEN F1 instances.
 
 See the [dragen.nf](https://github.com/seqeralabs/nf-dragen/blob/master/modules/local/dragen.nf) module implemented in the [nf-dragen](https://github.com/seqeralabs/nf-dragen) pipeline for reference. Any Nextflow processes that run DRAGEN must:
 
-1. Define the `dragen` label in your Nextflow process:
+1.  Define the `dragen` label in your Nextflow process:
 
    The `label` directive allows you to annotate a process with mnemonic identifiers of your choice. Seqera will use the `dragen` label to determine which processes need to be executed on DRAGEN F1 instances.
 
@@ -61,7 +61,7 @@ See the [dragen.nf](https://github.com/seqeralabs/nf-dragen/blob/master/modules/
 
    See the [Nextflow label docs](https://www.nextflow.io/docs/latest/process.html?highlight=label#label) for more information.
 
-2. Define secrets in Seqera:
+1.  Define secrets in Seqera:
 
    At Seqera, we use secrets to safely encrypt sensitive information when running licensed software via Nextflow. This enables our team to use the DRAGEN software safely via the `nf-dragen` pipeline without the need to configure the license key. These secrets will be provided securely to the `--lic-server` option when running DRAGEN on the CLI to validate the license.
 

--- a/platform_versioned_docs/version-23.3.0/supported_software/fusion/fusion.mdx
+++ b/platform_versioned_docs/version-23.3.0/supported_software/fusion/fusion.mdx
@@ -29,11 +29,11 @@ Fusion v2 improves pipeline throughput for containerized tasks by simplifying di
 
 We recommend using Fusion with AWS NVMe instances (fast instance storage) as this delivers the fastest performance when compared to environments using only AWS EBS (Elastic Block Store).
 
-1. For this configuration, use Seqera Platform version 23.1 or later.
-2. Create an [AWS Batch compute environment](../../compute-envs/aws-batch.mdx#tower-forge).
-3. Enable Wave containers, Fusion v2, and fast instance storage.
-4. Select the **Batch Forge** config mode.
-5. Select your **Instance types** under Advanced options:
+1.  For this configuration, use Seqera Platform version 23.1 or later.
+1.  Create an [AWS Batch compute environment](../../compute-envs/aws-batch.mdx#tower-forge).
+1.  Enable Wave containers, Fusion v2, and fast instance storage.
+1.  Select the **Batch Forge** config mode.
+1.  Select your **Instance types** under Advanced options:
    - If unspecified, Seqera will select the following NVMe-based instance type families: `'c5ad', 'c5d', 'c6id', 'i3', 'i4i', 'm5ad', 'm5d', 'm6id', 'r5ad', 'r5d', 'r6id'`
    - To specify an NVMe instance family type, select from the following:
      - Intel: `'c5ad', 'c5d', 'c6id', 'dl1', 'f1', 'g4ad', 'g4dn', 'g5', 'i3', 'i3en', 'i4i', 'm5ad', 'm5d', 'm5dn', 'm6id', 'p3dn', 'p4d', 'p4de', 'r5ad', 'r5d', 'r5dn', 'r6id', 'x2idn', 'x2iedn', 'z1d'`
@@ -47,17 +47,17 @@ When enabling fast instance storage, do not select the `optimal` instance type f
 We recommend selecting 8xlarge or above for large and long-lived production pipelines. Dedicated networking ensures a guaranteed network speed service level compared with "burstable" instances. See [Instance network bandwidth](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-network-bandwidth.html) for more information.
 :::
 
-6. Use an S3 bucket as the pipeline work directory.
+1.  Use an S3 bucket as the pipeline work directory.
 
 #### Batch Forge AWS compute environments with Fusion only
 
 To use Fusion in AWS environments without NVMe instances, enable Wave containers and Fusion v2 when creating a new compute environment without enabling fast instance storage. This option configures an AWS EBS (Elastic Bucket Store) disk with settings optimized for the Fusion file system.
 
-1. For this configuration, use Seqera Platform version 23.1 or later.
-2. Create an [AWS Batch compute environment](../../compute-envs/aws-batch.mdx#tower-forge).
-3. Enable Wave containers and Fusion v2.
-4. Select the **Batch Forge** config mode.
-5. When you enable Fusion v2 without fast instance storage, the following settings are applied:
+1.  For this configuration, use Seqera Platform version 23.1 or later.
+1.  Create an [AWS Batch compute environment](../../compute-envs/aws-batch.mdx#tower-forge).
+1.  Enable Wave containers and Fusion v2.
+1.  Select the **Batch Forge** config mode.
+1.  When you enable Fusion v2 without fast instance storage, the following settings are applied:
 
    - `process.scratch = false` is added to the Nextflow configuration file
    - EBS autoscaling is disabled
@@ -65,7 +65,7 @@ To use Fusion in AWS environments without NVMe instances, enable Wave containers
    - EBS boot disk type is changed to GP3
    - EBS boot disk throughput is increased to 325MB/s
 
-6. Use an S3 bucket as the pipeline work directory.
+1.  Use an S3 bucket as the pipeline work directory.
 
 #### Fusion in manual compute environments
 

--- a/platform_versioned_docs/version-23.4.0/administration/overview.mdx
+++ b/platform_versioned_docs/version-23.4.0/administration/overview.mdx
@@ -63,16 +63,16 @@ The **Users** tab lists all the users in your account.
 
 There are a number of different user roles in Seqera:
 
-* **Owner**: After an organization is created, the user who created the organization is the default owner of that organization. Owners have full read/write access to modify members, teams, collaborators, and settings within an organization.
-* **Member**: A member is a user who is internal to the organization. Members have an organization role and can operate in one or more organization workspaces. In each workspace, members can have a participant role that defines the permissions granted to them within that workspace.
+- **Owner**: After an organization is created, the user who created the organization is the default owner of that organization. Owners have full read/write access to modify members, teams, collaborators, and settings within an organization.
+- **Member**: A member is a user who is internal to the organization. Members have an organization role and can operate in one or more organization workspaces. In each workspace, members can have a participant role that defines the permissions granted to them within that workspace.
 
 You can apply one of the following roles to workspace participants:
 
-1. **Owner**: The participant has full permissions for all resources within the workspace, including the workspace settings.
-2. **Admin**: The participant has full permissions for resources associated with the workspace. They can create, modify, and delete pipelines, compute environments, actions, and credentials. They can add/remove users to the workspace and edit workspace settings, but cannot delete the workspace.
-3. **Maintain**: The participant can launch pipelines and modify pipeline executions (e.g., they can change the pipeline launch compute environments, parameters, pre/post-run scripts, and Nextflow configuration) and create new pipelines in the Launchpad. Users with maintain permissions cannot modify compute environments and credentials.
-4. **Launch**: The participant can launch pipelines and modify the pipeline input/output parameters in the Launchpad. They cannot modify the launch configuration or other resources.
-5. **View**: The participant can view workspace pipelines and runs in read-only mode.
+1.  **Owner**: The participant has full permissions for all resources within the workspace, including the workspace settings.
+1.  **Admin**: The participant has full permissions for resources associated with the workspace. They can create, modify, and delete pipelines, compute environments, actions, and credentials. They can add/remove users to the workspace and edit workspace settings, but cannot delete the workspace.
+1.  **Maintain**: The participant can launch pipelines and modify pipeline executions (e.g., they can change the pipeline launch compute environments, parameters, pre/post-run scripts, and Nextflow configuration) and create new pipelines in the Launchpad. Users with maintain permissions cannot modify compute environments and credentials.
+1.  **Launch**: The participant can launch pipelines and modify the pipeline input/output parameters in the Launchpad. They cannot modify the launch configuration or other resources.
+1.  **View**: The participant can view workspace pipelines and runs in read-only mode.
 
 ## Team administration
 

--- a/platform_versioned_docs/version-23.4.0/compute-envs/aws-batch.mdx
+++ b/platform_versioned_docs/version-23.4.0/compute-envs/aws-batch.mdx
@@ -11,8 +11,8 @@ This guide assumes you have an existing [Amazon Web Service (AWS)](https://aws.a
 
 There are two ways to create a Seqera Platform compute environment for AWS Batch:
 
-1. [**Batch Forge**](#tower-forge): This option automatically creates the AWS Batch resources in your AWS account. This eliminates the need to set up your AWS Batch infrastructure manually.
-2. [**Manual**](#manual): This option allows Seqera to use existing AWS Batch resources.
+1.  [**Batch Forge**](#tower-forge): This option automatically creates the AWS Batch resources in your AWS account. This eliminates the need to set up your AWS Batch infrastructure manually.
+1.  [**Manual**](#manual): This option allows Seqera to use existing AWS Batch resources.
 
 ## Batch Forge
 
@@ -30,32 +30,32 @@ We recommend that you create separate IAM policies for Batch Forge and launch pe
 
 **Create Seqera IAM policies**
 
-1. Open the [AWS IAM console](https://console.aws.amazon.com/iam).
-2. From the left navigation menu, select **Policies** under **Access management**.
-3. Select **Create policy**.
-4. On the **Create policy** page, select the **JSON** tab.
-5. Copy the contents of your policy JSON file ([Forge](https://github.com/seqeralabs/nf-tower-aws/blob/master/forge/forge-policy.json) or [Launch](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/launch-policy.json), depending on the policy being created) and replace the default text in the policy editor area under the JSON tab. To create a Launch user, you must also create the [S3 bucket write policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) separately to attach to your Launch user.
-6. Select **Next: Tags**.
-7. Select **Next: Review**.
-8. Enter a name and description for the policy on the **Review policy** page, then select **Create policy**.
-9. Repeat these steps for both the `forge-policy.json` and `launch-policy.json` files. For a Launch user, also create the `s3-bucket-write-policy.json` listed in step 5 above.
+1.  Open the [AWS IAM console](https://console.aws.amazon.com/iam).
+1.  From the left navigation menu, select **Policies** under **Access management**.
+1.  Select **Create policy**.
+1.  On the **Create policy** page, select the **JSON** tab.
+1.  Copy the contents of your policy JSON file ([Forge](https://github.com/seqeralabs/nf-tower-aws/blob/master/forge/forge-policy.json) or [Launch](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/launch-policy.json), depending on the policy being created) and replace the default text in the policy editor area under the JSON tab. To create a Launch user, you must also create the [S3 bucket write policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) separately to attach to your Launch user.
+1.  Select **Next: Tags**.
+1.  Select **Next: Review**.
+1.  Enter a name and description for the policy on the **Review policy** page, then select **Create policy**.
+1.  Repeat these steps for both the `forge-policy.json` and `launch-policy.json` files. For a Launch user, also create the `s3-bucket-write-policy.json` listed in step 5 above.
 
 **Create an IAM user**
 
-1. From the [AWS IAM console](https://console.aws.amazon.com/iam), select **Users** in the left navigation menu, then select **Add User** at the top right of the page.
-2. Enter a name for your user (e.g., _seqera_) and select the **Programmatic access** type.
-3. Select **Next: Permissions**.
-4. Select **Next: Tags > Next: Review > Create User**.
+1.  From the [AWS IAM console](https://console.aws.amazon.com/iam), select **Users** in the left navigation menu, then select **Add User** at the top right of the page.
+1.  Enter a name for your user (e.g., _seqera_) and select the **Programmatic access** type.
+1.  Select **Next: Permissions**.
+1.  Select **Next: Tags > Next: Review > Create User**.
 
 :::note
 For the time being, you can ignore the "user has no permissions" warning. Permissions will be applied using the **IAM Policy**.
 :::
 
-5. Save the **Access key ID** and **Secret access key** in a secure location as you will use these when creating credentials in Seqera.
-6. After you have saved the keys, select **Close**.
-7. Back in the users table, select the newly created user, then select **Add permissions** under the **Permissions** tab.
-8. Select **Attach existing policies**, then search for and select each of the policies created above.
-9. Select **Next: Review > Add permissions**.
+1.  Save the **Access key ID** and **Secret access key** in a secure location as you will use these when creating credentials in Seqera.
+1.  After you have saved the keys, select **Close**.
+1.  Back in the users table, select the newly created user, then select **Add permissions** under the **Permissions** tab.
+1.  Select **Attach existing policies**, then search for and select each of the policies created above.
+1.  Select **Next: Review > Add permissions**.
 
 ### S3 Bucket
 
@@ -63,17 +63,17 @@ S3 (Simple Storage Service) is a type of **object storage**. To access files and
 
 **Create an S3 bucket**
 
-1. Navigate to the [S3 service](https://console.aws.amazon.com/s3/home).
-2. Select **Create New Bucket**.
-3. Enter a unique name for your bucket and select a region.
+1.  Navigate to the [S3 service](https://console.aws.amazon.com/s3/home).
+1.  Select **Create New Bucket**.
+1.  Enter a unique name for your bucket and select a region.
 
 :::note
 To maximize data transfer resilience and minimize cost, storage should be in the same region as compute.
 :::
 
-4. Select the default options in **Configure options**.
-5. Select the default options in **Set permissions**.
-6. Review and select **Create bucket**.
+1.  Select the default options in **Configure options**.
+1.  Select the default options in **Set permissions**.
+1.  Review and select **Create bucket**.
 
 :::note
 S3 is used by Nextflow for the storage of intermediate files. In production pipelines, this can amount to a lot of data. To reduce costs, consider using a retention policy when creating a bucket, such as automatically deleting intermediate files after 30 days. See [here](https://aws.amazon.com/premiumsupport/knowledge-center/s3-empty-bucket-lifecycle-rule/) for more information.
@@ -85,32 +85,32 @@ Batch Forge automates the configuration of an [AWS Batch](https://aws.amazon.com
 
 **Create a Batch Forge AWS Batch compute environment**
 
-1. In a workspace, select **Compute environments > New environment**.
-2. Enter a descriptive name for this environment, e.g., _AWS Batch Spot (eu-west-1)_.
-3. Select **AWS Batch** as the target platform.
-4. From the **Credentials** drop-down, select existing AWS credentials, or select **+** to add new credentials. If you're using existing credentials, skip to step 8.
+1.  In a workspace, select **Compute environments > New environment**.
+1.  Enter a descriptive name for this environment, e.g., _AWS Batch Spot (eu-west-1)_.
+1.  Select **AWS Batch** as the target platform.
+1.  From the **Credentials** drop-down, select existing AWS credentials, or select **+** to add new credentials. If you're using existing credentials, skip to step 8.
 
 :::note
 You can create multiple credentials in your Seqera environment. See [Credentials](../credentials/overview.mdx).
 :::
 
-5. Enter a name, e.g., _AWS Credentials_.
-6. Add the **Access key** and **Secret key**. These are the keys you saved previously when you created the Seqera IAM user.
-7. (Optional) Under **Assume role**, specify the IAM role to be assumed by the Seqera IAM user to access the compute environment's AWS resources.
+1.  Enter a name, e.g., _AWS Credentials_.
+1.  Add the **Access key** and **Secret key**. These are the keys you saved previously when you created the Seqera IAM user.
+1.  (Optional) Under **Assume role**, specify the IAM role to be assumed by the Seqera IAM user to access the compute environment's AWS resources.
 
 :::note
 When using AWS keys without an assumed role, the associated AWS user account must have [Launch](https://github.com/seqeralabs/nf-tower-aws/tree/master/launch) and [Forge](https://github.com/seqeralabs/nf-tower-aws/tree/master/forge) permissions. When an assumed role is provided, the keys are only used to retrieve temporary credentials impersonating the role specified. In this case, [Launch](https://github.com/seqeralabs/nf-tower-aws/tree/master/launch) and [Forge](https://github.com/seqeralabs/nf-tower-aws/tree/master/forge) permissions must be granted to the role instead of the user account.
 :::
 
-8. Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
-9. Enter your S3 bucket path in the **Pipeline work directory** field, e.g., `s3://seqera-bucket`. This bucket must be in the same region chosen in the previous step.
+1.  Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
+1.  Enter your S3 bucket path in the **Pipeline work directory** field, e.g., `s3://seqera-bucket`. This bucket must be in the same region chosen in the previous step.
 
     :::note
     When you specify an S3 bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. Seqera adds a `cloudcache` block to the Nextflow configuration file for all runs executed with this compute environment. This block includes the path to a `cloudcache` folder in your work directory, e.g., `s3://seqera-bucket/cloudcache/.cache`. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
     :::
 
-10. Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
-11. Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled. See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
+1.  Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
+1.  Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled. See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
 
 When using Fusion v2 without fast instance storage (see below), the following EBS settings are applied to optimize file system performance:
 
@@ -121,64 +121,64 @@ When using Fusion v2 without fast instance storage (see below), the following EB
 
 Extensive benchmarking of Fusion v2 has demonstrated that the increased cost associated with these settings are generally outweighed by the costs saved due to decreased run time.
 
-12. Select **Enable fast instance storage** to use NVMe instance storage to speed up I/O and disk access operations. NVMe instance storage requires Fusion v2 to be enabled.
+1.  Select **Enable fast instance storage** to use NVMe instance storage to speed up I/O and disk access operations. NVMe instance storage requires Fusion v2 to be enabled.
 
 :::note
 Fast instance storage requires an EC2 instance type that uses NVMe disks. Seqera validates any instance types you specify (from **Advanced options > Instance types**) during compute environment creation. If you do not specify an instance type, a standard EC2 instance with NVMe disks will be used (`'c5ad', 'c5d', 'c6id', 'i3', 'i4i', 'm5ad', 'm5d', 'm6id', 'r5ad', 'r5d', 'r6id'` EC2 instance families) for fast storage.
 :::
 
-13. Set the **Config mode** to **Batch Forge**.
-14. Select a **Provisioning model**. In most cases, this will be **Spot**. You can specify an allocation strategy and instance types under [**Advanced options**](#advanced-options). If advanced options are omitted, Seqera Platform 23.2 and later versions default to `BEST_FIT_PROGRESSIVE` for on-demand and `SPOT_CAPACITY_OPTIMIZED` for spot compute environments.
+1.  Set the **Config mode** to **Batch Forge**.
+1.  Select a **Provisioning model**. In most cases, this will be **Spot**. You can specify an allocation strategy and instance types under [**Advanced options**](#advanced-options). If advanced options are omitted, Seqera Platform 23.2 and later versions default to `BEST_FIT_PROGRESSIVE` for on-demand and `SPOT_CAPACITY_OPTIMIZED` for spot compute environments.
 
 :::note
 You can create a compute environment that launches either spot or on-demand instances. Spot instances can cost as little as 20% of on-demand instances, and with Nextflow's ability to automatically relaunch failed tasks, spot is almost always the recommended provisioning model. Note, however, that when choosing spot instances, Seqera will also create a dedicated queue for running the main Nextflow job using a single on-demand instance to prevent any execution interruptions.
 :::
 
-15. Enter the **Max CPUs**, e.g., `64`. This is the maximum number of combined CPUs (the sum of all instances' CPUs) AWS Batch will provision at any time.
-16. Select **EBS Auto scale** to allow the EC2 virtual machines to dynamically expand the amount of available disk space during task execution.
+1.  Enter the **Max CPUs**, e.g., `64`. This is the maximum number of combined CPUs (the sum of all instances' CPUs) AWS Batch will provision at any time.
+1.  Select **EBS Auto scale** to allow the EC2 virtual machines to dynamically expand the amount of available disk space during task execution.
 
 :::note
 When you run large AWS Batch clusters (hundreds of compute nodes or more), EC2 API rate limits may cause the deletion of unattached EBS volumes to fail. You should delete volumes that remain active after Nextflow jobs have completed to avoid additional costs. Monitor your AWS account for any orphaned EBS volumes via the EC2 console, or with a Lambda function. See [here](https://aws.amazon.com/blogs/mt/controlling-your-aws-costs-by-deleting-unused-amazon-ebs-volumes/) for more information.
 :::
 
-17. With the optional **Enable Fusion mounts (deprecated)** feature enabled, S3 buckets specified in **Pipeline work directory** and **Allowed S3 Buckets** are mounted as file system volumes in the EC2 instances carrying out the Batch job execution. These buckets can then be accessed at `/fusion/s3/<bucket-name>`. For example, if the bucket name is `s3://imputation-gp2`, your pipeline will access it using the file system path `/fusion/s3/imputation-gp2`. **Note:** This feature has been deprecated. Consider using Fusion v2 (see above) for enhanced performance and stability.
+1.  With the optional **Enable Fusion mounts (deprecated)** feature enabled, S3 buckets specified in **Pipeline work directory** and **Allowed S3 Buckets** are mounted as file system volumes in the EC2 instances carrying out the Batch job execution. These buckets can then be accessed at `/fusion/s3/<bucket-name>`. For example, if the bucket name is `s3://imputation-gp2`, your pipeline will access it using the file system path `/fusion/s3/imputation-gp2`. **Note:** This feature has been deprecated. Consider using Fusion v2 (see above) for enhanced performance and stability.
 
 :::note
 You do not need to modify your pipeline or files to take advantage of this feature. Nextflow will automatically recognize and replace any reference to files prefixed with `s3://` with the corresponding Fusion mount paths.
 :::
 
-18. Select **Enable Fargate for head job** to run the Nextflow head job with the [AWS Fargate](https://aws.amazon.com/fargate/) container service and speed up pipeline launch. Fargate is a serverless compute engine that enables users to run containers without the need to provision servers or clusters in advance. AWS takes a few minutes to spin up an EC2 instance, whereas jobs can be launched with Fargate in under a minute (depending on container size). We recommend Fargate for most pipeline deployments, but EC2 is more suitable for environments that use GPU instances, custom AMIs, or that require more than 16 vCPUs. If you specify a custom AMI ID in the [Advanced options](#advanced-options) below, this will not be applied to the Fargate-enabled head job. See [here](https://docs.aws.amazon.com/batch/latest/userguide/fargate.html#when-to-use-fargate) for more information on Fargate's limitations.
+1.  Select **Enable Fargate for head job** to run the Nextflow head job with the [AWS Fargate](https://aws.amazon.com/fargate/) container service and speed up pipeline launch. Fargate is a serverless compute engine that enables users to run containers without the need to provision servers or clusters in advance. AWS takes a few minutes to spin up an EC2 instance, whereas jobs can be launched with Fargate in under a minute (depending on container size). We recommend Fargate for most pipeline deployments, but EC2 is more suitable for environments that use GPU instances, custom AMIs, or that require more than 16 vCPUs. If you specify a custom AMI ID in the [Advanced options](#advanced-options) below, this will not be applied to the Fargate-enabled head job. See [here](https://docs.aws.amazon.com/batch/latest/userguide/fargate.html#when-to-use-fargate) for more information on Fargate's limitations.
 
 :::note
 Fargate requires the Fusion v2 file system and a **spot** provisioning model. Fargate is not compatible with EFS and FSx file systems.
 :::
 
-19. Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. See [GPU usage](./overview.mdx#aws-batch) for more information.
-20. Select **Use Graviton CPU architecture** to execute on Graviton-based EC2 instances (i.e., ARM64 CPU architecture). When enabled, `m6g`, `r6g`, and `c6g` instance types are used by default for compute jobs, but 3rd-generation Graviton [instances](https://www.amazonaws.cn/en/ec2/graviton/) are also supported. You can specify your own **Instance types** under [**Advanced options**](#advanced-options).
+1.  Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. See [GPU usage](./overview.mdx#aws-batch) for more information.
+1.  Select **Use Graviton CPU architecture** to execute on Graviton-based EC2 instances (i.e., ARM64 CPU architecture). When enabled, `m6g`, `r6g`, and `c6g` instance types are used by default for compute jobs, but 3rd-generation Graviton [instances](https://www.amazonaws.cn/en/ec2/graviton/) are also supported. You can specify your own **Instance types** under [**Advanced options**](#advanced-options).
 
 :::note
 Graviton requires Fargate, Wave containers, and Fusion v2 file system to be enabled. This feature is not compatible with GPU-based architecture.
 :::
 
-21. Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.
-22. To use **EFS**, you can either select **Use existing EFS file system** and specify an existing EFS instance, or select **Create new EFS file system** to create one. To use the EFS file system as your work directory, specify `<your_EFS_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
+1.  Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.
+1.  To use **EFS**, you can either select **Use existing EFS file system** and specify an existing EFS instance, or select **Create new EFS file system** to create one. To use the EFS file system as your work directory, specify `<your_EFS_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
 
 - To use an existing EFS file system, enter the **EFS file system id** and **EFS mount path**. This is the path where the EFS volume is accessible to the compute environment. For simplicity, we recommend that you use `/mnt/efs` as the EFS mount path.
 - To create a new EFS file system, enter the **EFS mount path**. We advise that you specify `/mnt/efs` as the EFS mount path.
 - EFS file systems created by Batch Forge are automatically tagged in AWS with `Name=TowerForge-<id>`, with `<id>` being the compute environment ID. Any manually-added resource label with the key `Name` (capital N) will override the automatically-assigned `TowerForge-<id>` label.
 
- 23. To use **FSx for Lustre**, you can either select **Use existing FSx file system** and specify an existing FSx instance, or select **Create new FSx file system** to create one. To use the FSx file system as your work directory, specify `<your_FSx_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
+ 23.  To use **FSx for Lustre**, you can either select **Use existing FSx file system** and specify an existing FSx instance, or select **Create new FSx file system** to create one. To use the FSx file system as your work directory, specify `<your_FSx_mount_path>/work` in the **Pipeline work directory** field (step 8 of this guide).
 
 - To use an existing FSx file system, enter the **FSx DNS name** and **FSx mount path**. The FSx mount path is the path where the FSx volume is accessible to the compute environment. For simplicity, we recommend that you use `/mnt/fsx` as the FSx mount path.
 - To create a new FSx file system, enter the **FSx size** (in GB) and the **FSx mount path**. We advise that you specify `/mnt/fsx` as the FSx mount path.
 - FSx file systems created by Batch Forge are automatically tagged in AWS with `Name=TowerForge-<id>`, with `<id>` being the compute environment ID. Any manually-added resource label with the key `Name` (capital N) will override the automatically-assigned `TowerForge-<id>` label.
 
-24. Select **Dispose resources** to automatically delete these AWS resources if you delete the compute environment in Seqera Platform.
-25. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-26. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-27. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
-28. Configure any advanced options described in the next section, as needed.
-29. Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before you are ready to [launch pipelines](../launch/launchpad.mdx).
+1.  Select **Dispose resources** to automatically delete these AWS resources if you delete the compute environment in Seqera Platform.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1.  Configure any advanced options described in the next section, as needed.
+1.  Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before you are ready to [launch pipelines](../launch/launchpad.mdx).
 
 ### Advanced options
 
@@ -246,11 +246,11 @@ Seqera can use S3 to store the intermediate files and output data generated by p
 
 **Assign an S3 access policy to Seqera IAM users**
 
-1. Go to the IAM User table in the [IAM service](https://console.aws.amazon.com/iam/home).
-2. Select the IAM user.
-3. Select **Add inline policy**.
-4. Copy the contents of [this policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) into the **JSON** tab. Replace `YOUR-BUCKET-NAME` (lines 10 and 21) with your bucket name.
-5. Name your policy and select **Create policy**.
+1.  Go to the IAM User table in the [IAM service](https://console.aws.amazon.com/iam/home).
+1.  Select the IAM user.
+1.  Select **Add inline policy**.
+1.  Copy the contents of [this policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/launch/s3-bucket-write.json) into the **JSON** tab. Replace `YOUR-BUCKET-NAME` (lines 10 and 21) with your bucket name.
+1.  Name your policy and select **Create policy**.
 
 ### Seqera manual compute environment
 
@@ -258,30 +258,30 @@ With your AWS environment and resources set up and your user permissions configu
 
 **Create a manual Seqera compute environment**
 
-1. In a workspace, select **Compute environments > New environment**.
-2. Enter a descriptive name for this environment, e.g., _AWS Batch Manual (eu-west-1)_.
-3. Select **AWS Batch** as the target platform.
-4. Select **+** to add new credentials.
-5. Enter a name for the credentials, e.g., _AWS Credentials_.
-6. Enter the **Access key** and **Secret key** for your IAM user.
+1.  In a workspace, select **Compute environments > New environment**.
+1.  Enter a descriptive name for this environment, e.g., _AWS Batch Manual (eu-west-1)_.
+1.  Select **AWS Batch** as the target platform.
+1.  Select **+** to add new credentials.
+1.  Enter a name for the credentials, e.g., _AWS Credentials_.
+1.  Enter the **Access key** and **Secret key** for your IAM user.
 
 :::note
 You can create multiple credentials in your Seqera environment. See [Credentials](../credentials/overview.mdx).
 :::
 
-7. Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
-8. Enter an S3 bucket path for the **Pipeline work directory**, e.g., `s3://seqera-bucket`. This bucket must be in the same region chosen in the previous step.
+1.  Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
+1.  Enter an S3 bucket path for the **Pipeline work directory**, e.g., `s3://seqera-bucket`. This bucket must be in the same region chosen in the previous step.
 
     :::note
     When you specify an S3 bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. Seqera adds a `cloudcache` block to the Nextflow configuration file for all runs executed with this compute environment. This block includes the path to a `cloudcache` folder in your work directory, e.g., `s3://seqera-bucket/cloudcache/.cache`. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
     :::
 
-9. Set the **Config mode** to **Manual**.
-10. Enter the **Head queue**, which is the name of the AWS Batch queue that the Nextflow main job will run.
-11. Enter the **Compute queue**, which is the name of the AWS Batch queue where tasks will be submitted.
-12. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
-13. Configure any advanced options described in the next section, as needed.
-14. Select **Create** to finalize the compute environment setup.
+1.  Set the **Config mode** to **Manual**.
+1.  Enter the **Head queue**, which is the name of the AWS Batch queue that the Nextflow main job will run.
+1.  Enter the **Compute queue**, which is the name of the AWS Batch queue where tasks will be submitted.
+1.  Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1.  Configure any advanced options described in the next section, as needed.
+1.  Select **Create** to finalize the compute environment setup.
 
 ### Advanced options
 

--- a/platform_versioned_docs/version-23.4.0/compute-envs/azure-batch.mdx
+++ b/platform_versioned_docs/version-23.4.0/compute-envs/azure-batch.mdx
@@ -37,11 +37,11 @@ A resource group in Azure is a unit of related resources in Azure. As a rule of 
 
 ### Create a resource group
 
-1. Log in to your Azure account, go to the [Create Resource group][az-create-rg] page, and select **Create new resource group**.
-2. Enter a name for the resource group, e.g., _towerrg_.
-3. Choose the preferred region.
-4. Select **Review and Create** to proceed.
-5. Select **Create**.
+1.  Log in to your Azure account, go to the [Create Resource group][az-create-rg] page, and select **Create new resource group**.
+1.  Enter a name for the resource group, e.g., _towerrg_.
+1.  Choose the preferred region.
+1.  Select **Review and Create** to proceed.
+1.  Select **Create**.
 
 ## Storage account
 
@@ -49,30 +49,30 @@ After creating a resource group, set up an [Azure storage account][az-learn-stor
 
 ### Create a storage account
 
-1. Log in to your Azure account, go to the [Create storage account][az-create-storage] page, and select **Create a storage account**.
+1.  Log in to your Azure account, go to the [Create storage account][az-create-storage] page, and select **Create a storage account**.
 
     :::note
     If you haven't created a resource group, you can do so now.
     :::
 
-2. Enter a name for the storage account (e.g., _towerrgstorage_).
-3. Choose the preferred region (same as the Batch account).
-4. The platform supports any performance or redundancy settings — select the most appropriate settings for your use case.
-5. Select **Next: Advanced**.
-6. Enable _storage account key access_.
-7. Select **Next: Networking**.
+1.  Enter a name for the storage account (e.g., _towerrgstorage_).
+1.  Choose the preferred region (same as the Batch account).
+1.  The platform supports any performance or redundancy settings — select the most appropriate settings for your use case.
+1.  Select **Next: Advanced**.
+1.  Enable _storage account key access_.
+1.  Select **Next: Networking**.
    - Enable public access from all networks. You can enable public access from selected virtual networks and IP addresses, but you will be unable to use Forge to create compute resources. Disabling public access is not supported.
-8. Select **Data protection**.
+1.  Select **Data protection**.
     - Configure appropriate settings. All settings are supported by the platform.
-9. Select **Encryption**.
+1.  Select **Encryption**.
     - Only Microsoft-managed keys (MMK) are supported.
-10. In **tags**, add any required tags for the storage account.
-11. Select **Review and Create**.
-12. Select **Create** to create the Azure Storage account.
-13. You will need at least one blob storage container to act as a working directory for Nextflow.
-14. Go to your new storage account and select **+ Container** to create a new Blob storage container. A new container dialogue will open. Enter a suitable name, e.g., _towerrgstorage-container_.
-15. Go to the **Access Keys** section of your new storage account (_towerrgstorage_ in this example).
-16. Store the access keys for your Azure Storage account, to be used when you create a Seqera compute environment.
+1.  In **tags**, add any required tags for the storage account.
+1.  Select **Review and Create**.
+1.  Select **Create** to create the Azure Storage account.
+1.  You will need at least one blob storage container to act as a working directory for Nextflow.
+1.  Go to your new storage account and select **+ Container** to create a new Blob storage container. A new container dialogue will open. Enter a suitable name, e.g., _towerrgstorage-container_.
+1.  Go to the **Access Keys** section of your new storage account (_towerrgstorage_ in this example).
+1.  Store the access keys for your Azure Storage account, to be used when you create a Seqera compute environment.
 
 :::caution
 Blob container storage credentials are associated with the Batch pool configuration. Avoid changing these credentials in your Seqera instance after you have created the compute environment.
@@ -84,27 +84,27 @@ After you have created a resource group and storage account, create a [Batch acc
 
 ### Create a Batch account
 
-1. Log in to your Azure account and select **Create a batch account** on [this page][az-create-batch].
-2. Select the existing resource group or create a new one.
-3. Enter a name for the Batch account, e.g., _towerrgbatch_.
-4. Choose the preferred region (same as the storage account).
-5. Select **Advanced**.
-6. For _Pool allocation mode_, select Batch service.
-7. For _Authentication mode_, ensure _Shared Key_ is selected.
-8. Select **Networking**. Ensure networking access is sufficient for the platform and any additional required resources.
-9. In **tags**, add any required tags for the Batch account.
-10. Select **Review and Create**.
-11. Select **Create**.
-12. Go to your new Batch account, then select **Access Keys**.
-13. Store the access keys for your Azure Batch account, to be used when you create a Seqera compute environment.
+1.  Log in to your Azure account and select **Create a batch account** on [this page][az-create-batch].
+1.  Select the existing resource group or create a new one.
+1.  Enter a name for the Batch account, e.g., _towerrgbatch_.
+1.  Choose the preferred region (same as the storage account).
+1.  Select **Advanced**.
+1.  For _Pool allocation mode_, select Batch service.
+1.  For _Authentication mode_, ensure _Shared Key_ is selected.
+1.  Select **Networking**. Ensure networking access is sufficient for the platform and any additional required resources.
+1.  In **tags**, add any required tags for the Batch account.
+1.  Select **Review and Create**.
+1.  Select **Create**.
+1.  Go to your new Batch account, then select **Access Keys**.
+1.  Store the access keys for your Azure Batch account, to be used when you create a Seqera compute environment.
 
     :::caution
     A newly-created Azure Batch account may not be entitled to create virtual machines without making a service request to Azure.
     See [Azure Batch service quotas and limits][az-batch-quotas] for more information.
     :::
 
-14. Select the **+ Quotas** tab of the Azure Batch account to check and increase existing quotas if necessary.
-15. Select **+ Request quota increase** and add the quantity of resources you require. Here is a brief guideline:
+1.  Select the **+ Quotas** tab of the Azure Batch account to check and increase existing quotas if necessary.
+1.  Select **+ Request quota increase** and add the quantity of resources you require. Here is a brief guideline:
 
     - **Active jobs and schedules**: Each Nextflow process will require an active Azure Batch job per pipeline while running, so increase this number to a high level. See [here][az-learn-jobs] to learn more about jobs in Azure Batch.
     - **Pools**: Each platform compute environment requires one Azure Batch pool. Each pool is composed of multiple machines of one virtual machine size.
@@ -128,41 +128,41 @@ There are two ways to create an Azure Batch compute environment in Seqera Platfo
 
 Create a Batch Forge Azure Batch compute environment:
 
-1. In a workspace, select **Compute Environments > New Environment**.
-2. Enter a descriptive name, e.g., _Azure Batch (east-us)_.
-3. Select **Azure Batch** as the target platform.
-4. Choose existing Azure credentials or add a new credential. If you are using existing credentials, skip to step 7.
+1.  In a workspace, select **Compute Environments > New Environment**.
+1.  Enter a descriptive name, e.g., _Azure Batch (east-us)_.
+1.  Select **Azure Batch** as the target platform.
+1.  Choose existing Azure credentials or add a new credential. If you are using existing credentials, skip to step 7.
 
     :::tip
     You can create multiple credentials in your Seqera environment.
     :::
 
-5. Enter a name for the credentials, e.g., _Azure Credentials_.
-6. Add the **Batch account** and **Blob Storage** account names and access keys.
-7. Select a **Region**, e.g., _eastus_.
-8. In the **Pipeline work directory** field, enter the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
+1.  Enter a name for the credentials, e.g., _Azure Credentials_.
+1.  Add the **Batch account** and **Blob Storage** account names and access keys.
+1.  Select a **Region**, e.g., _eastus_.
+1.  In the **Pipeline work directory** field, enter the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
 
     :::note
     When you specify a Blob Storage bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
     :::
 
-9. Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers][wave-docs] for more information.
-10. Select **Enable Fusion v2** to allow access to your Azure Blob Storage data via the [Fusion v2][nf-fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled. See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
-11. Set the **Config mode** to **Batch Forge**.
-12. Enter the default **VMs type**, depending on your quota limits set previously. The default is _Standard_D4_v3_.
-13. Enter the **VMs count**. If autoscaling is enabled (default), this is the maximum number of VMs you wish the pool to scale up to. If autoscaling is disabled, this is the fixed number of virtual machines in the pool.
-14. Enable **Autoscale** to scale up and down automatically, based on the number of pipeline tasks. The number of VMs will vary from **0** to **VMs count**.
-15. Enable **Dispose resources** for Seqera to automatically delete the Batch pool if the compute environment is deleted on the platform.
-16. Select or create [**Container registry credentials**](../credentials/azure_registry_credentials.mdx) to authenticate a registry (used by the [Wave containers](https://www.nextflow.io/docs/latest/wave.html) service). It is recommended to use an [Azure Container registry](https://azure.microsoft.com/en-gb/products/container-registry) within the same region for maximum performance.
-17. Apply [**Resource labels**](../resource-labels/overview.mdx). This will populate the **Metadata** fields of the Azure Batch pool.
-18. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre-and-post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-19. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
-20. Configure any advanced options you need:
+1.  Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers][wave-docs] for more information.
+1.  Select **Enable Fusion v2** to allow access to your Azure Blob Storage data via the [Fusion v2][nf-fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled. See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
+1.  Set the **Config mode** to **Batch Forge**.
+1.  Enter the default **VMs type**, depending on your quota limits set previously. The default is _Standard_D4_v3_.
+1.  Enter the **VMs count**. If autoscaling is enabled (default), this is the maximum number of VMs you wish the pool to scale up to. If autoscaling is disabled, this is the fixed number of virtual machines in the pool.
+1.  Enable **Autoscale** to scale up and down automatically, based on the number of pipeline tasks. The number of VMs will vary from **0** to **VMs count**.
+1.  Enable **Dispose resources** for Seqera to automatically delete the Batch pool if the compute environment is deleted on the platform.
+1.  Select or create [**Container registry credentials**](../credentials/azure_registry_credentials.mdx) to authenticate a registry (used by the [Wave containers](https://www.nextflow.io/docs/latest/wave.html) service). It is recommended to use an [Azure Container registry](https://azure.microsoft.com/en-gb/products/container-registry) within the same region for maximum performance.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx). This will populate the **Metadata** fields of the Azure Batch pool.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre-and-post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1.  Configure any advanced options you need:
 
     - Use **Jobs cleanup policy** to control how Nextflow process jobs are deleted on completion. Active jobs consume the quota of the Azure Batch account. By default, jobs are terminated by Nextflow and removed from the quota when all tasks succesfully complete. If set to _Always_, all jobs are deleted by Nextflow after pipeline completion. If set to _Never_, jobs are never deleted. If set to _On success_, successful tasks are removed but failed tasks will be left for debugging purposes.
     - Use **Token duration** to control the duration of the SAS token generated by Nextflow. This must be as long as the longest period of time the pipeline will run.
 
-21. Select **Add** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before the compute environment is ready to launch pipelines.
+1.  Select **Add** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before the compute environment is ready to launch pipelines.
 
 **See [Launch pipelines](../launch/launchpad.mdx) to start executing workflows in your Azure Batch compute environment.**
 
@@ -172,38 +172,38 @@ This section is for users with a pre-configured Azure Batch pool. This requires 
 
 **Create a manual Seqera Azure Batch compute environment**
 
-1. In a workspace, select **Compute Environments > New Environment**.
-2. Enter a descriptive name for this environment, e.g., _Azure Batch (east-us)_.
-3. Select **Azure Batch** as the target platform.
-4. Select your existing Azure credentials or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
+1.  In a workspace, select **Compute Environments > New Environment**.
+1.  Enter a descriptive name for this environment, e.g., _Azure Batch (east-us)_.
+1.  Select **Azure Batch** as the target platform.
+1.  Select your existing Azure credentials or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
 
     :::tip
     You can create multiple credentials in your Seqera environment.
     :::
 
-5. Enter a name, e.g., _Azure Credentials_.
-6. Add the **Batch account** and **Blob Storage** credentials you created previously.
-7. Select a **Region**, e.g., _eastus (East US)_.
-8. In the **Pipeline work directory** field, add the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
+1.  Enter a name, e.g., _Azure Credentials_.
+1.  Add the **Batch account** and **Blob Storage** credentials you created previously.
+1.  Select a **Region**, e.g., _eastus (East US)_.
+1.  In the **Pipeline work directory** field, add the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
 
     :::note
     When you specify a Blob Storage bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
     :::
 
-9. Set the **Config mode** to **Manual**.
-10. Enter the **Compute Pool name**. This is the name of the Azure Batch pool you created previously in the Azure Batch account.
+1.  Set the **Config mode** to **Manual**.
+1.  Enter the **Compute Pool name**. This is the name of the Azure Batch pool you created previously in the Azure Batch account.
 
     :::note
     The default Azure Batch implementation uses a single pool for head and compute nodes. To use separate pools for head and compute nodes (e.g., to use low-priority VMs for compute jobs), see [this FAQ entry](../faqs.mdx#azure).
     :::
 
-11. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
-12. Configure any advanced options you need:
+1.  Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1.  Configure any advanced options you need:
 
     - Use **Jobs cleanup policy** to control how Nextflow process jobs are deleted on completion. Active jobs consume the quota of the Azure Batch account. By default, jobs are terminated by Nextflow and removed from the quota when all tasks succesfully complete. If set to _Always_, all jobs are deleted by Nextflow after pipeline completion. If set to _Never_, jobs are never deleted. If set to _On success_, successful tasks are removed but failed tasks will be left for debugging purposes.
     - Use **Token duration** to control the duration of the SAS token generated by Nextflow. This must be as long as the longest period of time the pipeline will run.
 
-13. Select **Add** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before you are ready to launch pipelines.
+1.  Select **Add** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before you are ready to launch pipelines.
 
 **See [Launch pipelines](../launch/launchpad.mdx) to start executing workflows in your Azure Batch compute environment.**
 

--- a/platform_versioned_docs/version-23.4.0/compute-envs/eks.mdx
+++ b/platform_versioned_docs/version-23.4.0/compute-envs/eks.mdx
@@ -19,13 +19,13 @@ Assign a service account role to the AWS IAM user used by Seqera to access the E
 
 **Assign a service account role to your Seqera IAM user**
 
-1. Modify the EKS auth configuration:
+1.  Modify the EKS auth configuration:
 
 ```bash
 kubectl edit configmap -n kube-system aws-auth
 ```
 
-2. In the editor that opens, add this entry:
+1.  In the editor that opens, add this entry:
 
 ```yaml
 mapUsers: |
@@ -35,7 +35,7 @@ mapUsers: |
     - tower-launcher-role
 ```
 
-3. Retrieve your user ARN from the [AWS IAM console](https://console.aws.amazon.com/iam), or with the AWS CLI:
+1.  Retrieve your user ARN from the [AWS IAM console](https://console.aws.amazon.com/iam), or with the AWS CLI:
 
 ```bash
 aws sts get-caller-identity
@@ -45,7 +45,7 @@ aws sts get-caller-identity
 The same user must be used when specifying the AWS credentials in the Seqera compute environment configuration.
 :::
 
-4. The AWS user must have [this](../_templates/eks/eks-iam-policy.json) IAM policy applied.
+1.  The AWS user must have [this](../_templates/eks/eks-iam-policy.json) IAM policy applied.
 
 See the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html) for more details.
 
@@ -53,44 +53,44 @@ See the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/add
 
 After you have prepared your Kubernetes cluster and assigned a service account role to your Seqera IAM user, create a Seqera EKS compute environment:
 
-1. In a workspace, select **Compute environments > New environment**.
-2. Enter a descriptive name for this environment, e.g., _Amazon EKS (eu-west-1)_.
-3. From the **Provider** drop-down menu, select **Amazon EKS**.
-4. Under **Storage**, select either **Fusion storage** (recommended) or **Legacy storage**. The [Fusion v2](../supported_software/fusion/fusion.mdx) virtual distributed file system allows access to your AWS S3-hosted data (`s3://` URLs). This eliminates the need to configure a shared file system in your Kubernetes cluster. See [Fusion v2](#fusion-v2) below.
-5. From the **Credentials** drop-down menu, select existing AWS credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 9.
+1.  In a workspace, select **Compute environments > New environment**.
+1.  Enter a descriptive name for this environment, e.g., _Amazon EKS (eu-west-1)_.
+1.  From the **Provider** drop-down menu, select **Amazon EKS**.
+1.  Under **Storage**, select either **Fusion storage** (recommended) or **Legacy storage**. The [Fusion v2](../supported_software/fusion/fusion.mdx) virtual distributed file system allows access to your AWS S3-hosted data (`s3://` URLs). This eliminates the need to configure a shared file system in your Kubernetes cluster. See [Fusion v2](#fusion-v2) below.
+1.  From the **Credentials** drop-down menu, select existing AWS credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 9.
 
 :::note
 The user must have the IAM permissions required to describe and list EKS clusters, per service account role requirements in the previous section.
 :::
 
-6. Enter a name, e.g., _EKS Credentials_.
-7. Add the IAM user **Access key** and **Secret key**. This is the IAM user with the service account role detailed in the previous section.
-8. (Optional) Under **Assume role**, specify the IAM role to be assumed by the Seqera IAM user to access the compute environment AWS resources.
+1.  Enter a name, e.g., _EKS Credentials_.
+1.  Add the IAM user **Access key** and **Secret key**. This is the IAM user with the service account role detailed in the previous section.
+1.  (Optional) Under **Assume role**, specify the IAM role to be assumed by the Seqera IAM user to access the compute environment AWS resources.
 
 :::note
 When using AWS keys without an assumed role, the associated AWS user account must have Seqera [Launch](https://github.com/seqeralabs/nf-tower-aws/tree/master/launch) and [Forge](https://github.com/seqeralabs/nf-tower-aws/tree/master/forge) permissions. When an assumed role is provided, the keys are only used to retrieve temporary credentials impersonating the role specified. In this case, Seqera [Launch](https://github.com/seqeralabs/nf-tower-aws/tree/master/launch) and [Forge](https://github.com/seqeralabs/nf-tower-aws/tree/master/forge) permissions must be granted to the role instead of the user account.
 :::
 
-9. Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
-10. Select a **Cluster name** from the list of available EKS clusters in the selected region.
-11. Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is _tower-nf_ by default.
-12. Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is _tower-launcher-sa_ by default.
+1.  Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
+1.  Select a **Cluster name** from the list of available EKS clusters in the selected region.
+1.  Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is _tower-nf_ by default.
+1.  Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which is _tower-launcher-sa_ by default.
 
 :::note
 If you enable Fusion v2 (**Fusion storage** in step 4 above), the head service account must have access to the S3 storage bucket specified as your work directory.
 :::
 
-13. Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in the provided examples.
+1.  Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in the provided examples.
 
 :::note
 The **Storage claim** isn't needed when Fusion v2 is enabled.
 :::
 
-14. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-15. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-16. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
-17. Configure any advanced options described in the next section, as needed.
-18. Select **Create** to finalize the compute environment setup.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1.  Configure any advanced options described in the next section, as needed.
+1.  Select **Create** to finalize the compute environment setup.
 
 ### Advanced options
 
@@ -129,7 +129,7 @@ To use [Fusion v2](../supported_software/fusion/fusion.mdx) in your Seqera EKS c
 
 **Configure IAM to use Fusion v2**
 
-1. Allow the IAM role access to your S3 bucket:
+1.  Allow the IAM role access to your S3 bucket:
 
 ```json
 {
@@ -156,7 +156,7 @@ To use [Fusion v2](../supported_software/fusion/fusion.mdx) in your Seqera EKS c
 
 Replace `<YOUR-BUCKET>` with a bucket name of your choice.
 
-2. The IAM role must have a trust relationship with your Kubernetes service account:
+1.  The IAM role must have a trust relationship with your Kubernetes service account:
 
 ```json
 {
@@ -181,7 +181,7 @@ Replace `<YOUR-BUCKET>` with a bucket name of your choice.
 
 Replace `<YOUR-ACCOUNT-ID>`, `<YOUR-REGION>`, `<YOUR-CLUSTER-ID>`, `<YOUR-EKS-SERVICE-ACCOUNT>` with your corresponding values.
 
-3. Annotate the Kubernetes service account with the IAM role:
+1.  Annotate the Kubernetes service account with the IAM role:
 
 ```shell
 kubectl annotate serviceaccount <YOUR-EKS-SERVICE-ACCOUNT> --namespace <YOUR-EKS-NAMESPACE> eks.amazonaws.com/role-arn=arn:aws:iam::<YOUR-ACCOUNT-ID>:role/<YOUR-IAM-ROLE>

--- a/platform_versioned_docs/version-23.4.0/compute-envs/gke.mdx
+++ b/platform_versioned_docs/version-23.4.0/compute-envs/gke.mdx
@@ -46,25 +46,25 @@ See [Role-based access control](https://cloud.google.com/kubernetes-engine/docs/
 
 After you've prepared your Kubernetes cluster and granted cluster access to your service account, create a Seqera GKE compute environment:
 
-1. In a Seqera workspace, select **Compute environments > New environment**.
+1.  In a Seqera workspace, select **Compute environments > New environment**.
 
-2. Enter a descriptive name for this environment, e.g., _Google GKE (europe-west1)_.
+1.  Enter a descriptive name for this environment, e.g., _Google GKE (europe-west1)_.
 
-3. From the **Provider** drop-down, select **Google GKE**.
+1.  From the **Provider** drop-down, select **Google GKE**.
 
-4. Under **Storage**, select either **Fusion storage** (recommended) or **Legacy storage**. The [Fusion v2](../supported_software/fusion/fusion.mdx) virtual distributed file system allows access to your Google Cloud-hosted data (`gs://` URLs). This eliminates the need to configure a shared file system in your Kubernetes cluster. See [Fusion v2](#fusion-v2) below.
+1.  Under **Storage**, select either **Fusion storage** (recommended) or **Legacy storage**. The [Fusion v2](../supported_software/fusion/fusion.mdx) virtual distributed file system allows access to your Google Cloud-hosted data (`gs://` URLs). This eliminates the need to configure a shared file system in your Kubernetes cluster. See [Fusion v2](#fusion-v2) below.
 
-5. From the **Credentials** drop-down menu, select existing GKE credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 8.
+1.  From the **Credentials** drop-down menu, select existing GKE credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 8.
 
-6. Enter a name for the credentials, e.g., _GKE Credentials_.
+1.  Enter a name for the credentials, e.g., _GKE Credentials_.
 
-7. Enter the **Service account key** for your Google service account.
+1.  Enter the **Service account key** for your Google service account.
 
 :::tip
 You can create multiple credentials in your Seqera environment. See [Credentials](../credentials/overview.mdx).
 :::
 
-8. Select the **Location** of your GKE cluster.
+1.  Select the **Location** of your GKE cluster.
 
 :::caution
 GKE clusters can be either regional or zonal. For example, `us-west1` identifies the United States West-Coast _region_, which has three _zones_: `us-west1-a`, `us-west1-b`, and `us-west1-c`.
@@ -73,31 +73,31 @@ Seqera Platform's auto-completion only shows regions. You should manually edit t
 ![](./_images/gke_regions.png)
 :::
 
-9. Select or enter the **Cluster name** of your GKE cluster.
+1.  Select or enter the **Cluster name** of your GKE cluster.
 
-10. Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is _tower-nf_ by default.
+1.  Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is _tower-nf_ by default.
 
-11. Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is _tower-launcher-sa_ by default.
+1.  Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is _tower-launcher-sa_ by default.
 
 :::note
 If you enable Fusion v2 (**Fusion storage** in step 4 above), the head service account must have access to the Google Cloud storage bucket specified as your work directory.
 :::
 
-12. Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in the provided examples.
+1.  Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in the provided examples.
 
 :::note
 The **Storage claim** isn't needed when Fusion v2 is enabled.
 :::
 
-13. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 
-14. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
 
-15. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1.  Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
 
-16. Configure any advanced options described in the next section, as needed.
+1.  Configure any advanced options described in the next section, as needed.
 
-17. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 ### Advanced options
 
@@ -134,12 +134,12 @@ To use [Fusion v2](../supported_software/fusion/fusion.mdx) in your Seqera GKE c
 
 **Configure IAM to use Fusion v2**
 
-1. Ensure the **Workload Identity** feature is enabled for the cluster:
+1.  Ensure the **Workload Identity** feature is enabled for the cluster:
 
 - **Enable Workload Identity** in the cluster **Security** settings.
 - **Enable GKE Metadata Server** in the node group **Security** settings.
 
-2. Allow the IAM service account access to your Google storage bucket:
+1.  Allow the IAM service account access to your Google storage bucket:
 
 ```shell
 gcloud storage buckets add-iam-policy-binding gs://<YOUR-BUCKET> --role roles/storage.objectAdmin --member serviceAccount:<IAM-SERVICE-ACCOUNT>@<GOOGLE-CLOUD-PROJECT>.iam.gserviceaccount.com
@@ -147,13 +147,13 @@ gcloud storage buckets add-iam-policy-binding gs://<YOUR-BUCKET> --role roles/st
 
 The role must have at least `storage.objects.create`, `storage.objects.get`, and `storage.objects.list` permissions.
 
-3. Allow the Kubernetes service account to impersonate the IAM service account:
+1.  Allow the Kubernetes service account to impersonate the IAM service account:
 
 ```shell
 gcloud iam service-accounts add-iam-policy-binding <IAM-SERVICE-ACCOUNT>@<GOOGLE-CLOUD-PROJECT>.iam.gserviceaccount.com --role roles/iam.workloadIdentityUser --member "serviceAccount:<GOOGLE-CLOUD-PROJECT>.svc.id.goog[<GKE-NAMESPACE>/<GKE-SERVICE-ACCOUNT>]"
 ```
 
-4. Annotate the Kubernetes service account with the email address of the IAM service account:
+1.  Annotate the Kubernetes service account with the email address of the IAM service account:
 
 ```shell
 kubectl annotate serviceaccount <GKE-SERVICE-ACCOUNT> --namespace <GKE-NAMESPACE> iam.gke.io/gcp-service-account=<IAM-SERVICE-ACCOUNT>@<GOOGLE-CLOUD-PROJECT>.iam.gserviceaccount.com

--- a/platform_versioned_docs/version-23.4.0/compute-envs/google-cloud-batch.mdx
+++ b/platform_versioned_docs/version-23.4.0/compute-envs/google-cloud-batch.mdx
@@ -11,8 +11,8 @@ This guide assumes you have an existing Google Cloud account. Sign up for a free
 
 The guide is split into two parts:
 
-1. How to configure your Google Cloud account to use the Batch API.
-2. How to create a Google Cloud Batch compute environment in Seqera.
+1.  How to configure your Google Cloud account to use the Batch API.
+1.  How to create a Google Cloud Batch compute environment in Seqera.
 
 ## Configure Google Cloud
 
@@ -75,16 +75,16 @@ Ask your Google Cloud administrator to grant you the following IAM user permissi
 
 To configure a credential in Seqera, you must first create a [service account JSON key file][get-json]:
 
-1. In the Google Cloud navigation menu, select **IAM & Admin > Service Accounts**.
-2. Select the email address of the service account.
+1.  In the Google Cloud navigation menu, select **IAM & Admin > Service Accounts**.
+1.  Select the email address of the service account.
 
     :::note
     The Compute Engine default service account is not recommended for production environments due to its powerful permissions. To use a service account other than the Compute Engine default, specify the service account email address under **Advanced options** on the Seqera compute environment creation form.
     :::
 
-3. Select **Keys > Add key > Create new key**.
-4. Select **JSON** as the key type.
-5. Select **Create**.
+1.  Select **Keys > Add key > Create new key**.
+1.  Select **JSON** as the key type.
+1.  Select **Create**.
 
 A JSON file will be downloaded to your computer. This file contains the credential needed to configure the compute environment in Seqera.
 
@@ -96,27 +96,27 @@ Google Cloud Storage is a type of **object storage**. To access files and store 
 
 #### Create a Cloud Storage bucket
 
-1. In the hamburger menu (**≡**), select **Cloud Storage**.
-2. From the **Buckets** tab, select **Create**.
-3. Enter a name for your bucket. You will reference this name when you create the compute environment in Seqera.
-4. Select **Region** for the **Location type** and select the **Location** for your bucket. You'll reference this location when you create the compute environment in Seqera.
+1.  In the hamburger menu (**≡**), select **Cloud Storage**.
+1.  From the **Buckets** tab, select **Create**.
+1.  Enter a name for your bucket. You will reference this name when you create the compute environment in Seqera.
+1.  Select **Region** for the **Location type** and select the **Location** for your bucket. You'll reference this location when you create the compute environment in Seqera.
 
     :::note
     The Batch API is available in a limited number of [locations][batch-locations]. These locations are only used to store metadata about the pipeline operations. The storage bucket and compute resources can be in any region.
     :::
 
-5. Select **Standard** for the default storage class.
-6. To restrict public access to your bucket data, select the **Enforce public access prevention on this bucket** checkbox.
-7. Under **Access control**, select **Uniform**.
-8. Select any additional object data protection tools, per your organization's data protection requirements.
-9. Select **Create**.
+1.  Select **Standard** for the default storage class.
+1.  To restrict public access to your bucket data, select the **Enforce public access prevention on this bucket** checkbox.
+1.  Under **Access control**, select **Uniform**.
+1.  Select any additional object data protection tools, per your organization's data protection requirements.
+1.  Select **Create**.
 
 #### Assign bucket permissions
 
-1. After the bucket is created, you are redirected to the **Bucket details** page.
-2. Select **Permissions**, then **Grant access** under **View by principals**.
-3. Copy the email address of your service account into **New principals**.
-4. Select the **Storage Admin** role, then select **Save**.
+1.  After the bucket is created, you are redirected to the **Bucket details** page.
+1.  Select **Permissions**, then **Grant access** under **View by principals**.
+1.  Copy the email address of your service account into **New principals**.
+1.  Select the **Storage Admin** role, then select **Save**.
 
 :::tip
 You've created a project, enabled the necessary Google APIs, created a bucket, and created a service account JSON key file with the required credentials. You now have what you need to set up a new compute environment in Seqera.
@@ -126,15 +126,15 @@ You've created a project, enabled the necessary Google APIs, created a bucket, a
 
 After your Google Cloud resources have been created, create a new Seqera compute environment:
 
-1. In a workspace, select **Compute Environments > New Environment**.
-2. Enter a descriptive name for this environment, e.g., _Google Cloud Batch (europe-north1)_.
-3. Select **Google Cloud Batch** as the target platform.
+1.  In a workspace, select **Compute Environments > New Environment**.
+1.  Enter a descriptive name for this environment, e.g., _Google Cloud Batch (europe-north1)_.
+1.  Select **Google Cloud Batch** as the target platform.
 
 #### Credentials
 
-1. From the **Credentials** drop-down, select existing Google credentials or select **+** to add new credentials. If you choose to use existing credentials, skip to the next section.
-2. Enter a name for the credentials, e.g., _Google Cloud Credentials_.
-3. Paste the contents of the JSON file created previously in the **Service account key** field.
+1.  From the **Credentials** drop-down, select existing Google credentials or select **+** to add new credentials. If you choose to use existing credentials, skip to the next section.
+1.  Enter a name for the credentials, e.g., _Google Cloud Credentials_.
+1.  Paste the contents of the JSON file created previously in the **Service account key** field.
 
 #### Location and work directory
 
@@ -174,17 +174,17 @@ Specify custom **Environment variables** for the head and compute jobs.
 If you use VM instance templates for the head or compute jobs (see step 6 below), resource allocation and networking values specified in the templates override any conflicting values you specify while creating your Seqera compute environment.
 :::
 
-1. Enable **Use Private Address** to ensure that your Google Cloud VMs aren't accessible to the public internet.
-2. Use **Boot disk size** to control the boot disk size of VMs.
-3. Use **Head Job CPUs** and **Head Job Memory** to specify the CPUs and memory allocated for head jobs.
-4. Use **Service Account email** to specify a service account email address other than the Compute Engine default to execute workflows with this compute environment (recommended for productions environments).
-5. Use **VPC** and **Subnet** to specify the name of a VPC network and subnet to be used by this compute environment. If your organization's VPC architecture relies on network tags, you can apply network tags to VM instance templates used for the Nextflow head and compute jobs (see below).
+1.  Enable **Use Private Address** to ensure that your Google Cloud VMs aren't accessible to the public internet.
+1.  Use **Boot disk size** to control the boot disk size of VMs.
+1.  Use **Head Job CPUs** and **Head Job Memory** to specify the CPUs and memory allocated for head jobs.
+1.  Use **Service Account email** to specify a service account email address other than the Compute Engine default to execute workflows with this compute environment (recommended for productions environments).
+1.  Use **VPC** and **Subnet** to specify the name of a VPC network and subnet to be used by this compute environment. If your organization's VPC architecture relies on network tags, you can apply network tags to VM instance templates used for the Nextflow head and compute jobs (see below).
 
     :::note
     You must specify both a **VPC** and **Subnet** for your compute environment to use either.
     :::
 
-6. Use **Head job instance template** and **Compute jobs instance template** to specify the name or fully-qualified reference of a VM instance template, without the `template://` prefix, to use for the head and compute jobs. [VM instance templates][gcp-vm-instance-template] allow you to define the resources allocated to Batch jobs. Configuration values defined in a VM instance template override any conflicting values you specify while creating your Seqera compute environment.
+1.  Use **Head job instance template** and **Compute jobs instance template** to specify the name or fully-qualified reference of a VM instance template, without the `template://` prefix, to use for the head and compute jobs. [VM instance templates][gcp-vm-instance-template] allow you to define the resources allocated to Batch jobs. Configuration values defined in a VM instance template override any conflicting values you specify while creating your Seqera compute environment.
 
     You can use network tags in VM instance templates to enable cross-network and cross-project distribution of compute resources. This is useful if your head and compute instances must reside in different GCP projects or across isolated networking infrastructures. Note that the use of network tags does not affect the resource labels applied to your compute environment.
 

--- a/platform_versioned_docs/version-23.4.0/compute-envs/google-cloud-lifesciences.mdx
+++ b/platform_versioned_docs/version-23.4.0/compute-envs/google-cloud-lifesciences.mdx
@@ -9,8 +9,8 @@ This guide assumes you have an existing Google Cloud account. Sign up for a free
 
 This guide is split into two parts:
 
-1. How to configure your Google Cloud account to use the Cloud Life Sciences API.
-2. How to create a Google Life Sciences compute environment in Seqera.
+1.  How to configure your Google Cloud account to use the Cloud Life Sciences API.
+1.  How to create a Google Life Sciences compute environment in Seqera.
 
 ## Configure Google Cloud
 
@@ -50,11 +50,11 @@ Seqera requires a service account with appropriate permissions to interact with 
 
 **Create a service account**
 
-1. In the navigation menu, select **IAM & Admin > Service Accounts**.
-2. Select the email address of the **Compute Engine default service account**.
-3. Select **Keys > Add key > Create new key**.
-4. Select **JSON** as the key type.
-5. Select **Create**.
+1.  In the navigation menu, select **IAM & Admin > Service Accounts**.
+1.  Select the email address of the **Compute Engine default service account**.
+1.  Select **Keys > Add key > Create new key**.
+1.  Select **JSON** as the key type.
+1.  Select **Create**.
 
 A JSON file will be downloaded to your computer. This file contains the credentials needed to configure the compute environment in Seqera.
 
@@ -66,26 +66,26 @@ Google Cloud Storage is a type of **object storage**. To access files and store 
 
 **Create a Cloud Storage bucket**
 
-1. In the hamburger menu (**≡**), select **Cloud Storage > Create bucket**.
-2. Enter a name for your bucket. You will reference this name when creating the compute environment in Seqera.
+1.  In the hamburger menu (**≡**), select **Cloud Storage > Create bucket**.
+1.  Enter a name for your bucket. You will reference this name when creating the compute environment in Seqera.
 
 :::caution
 Do not use underscores (`_`) in your bucket name. Use hyphens (`-`) instead.
 :::
 
-3. Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Seqera.
-4. Select **Standard** for the default storage class.
-5. Select **Uniform** for the **Access control**.
+1.  Select **Region** for the **Location type** and select the **Location** for your bucket. You will reference this location when creating the compute environment in Seqera.
+1.  Select **Standard** for the default storage class.
+1.  Select **Uniform** for the **Access control**.
 
 :::note
 The Cloud Life Sciences API is available in a limited number of [locations](https://cloud.google.com/life-sciences/docs/concepts/locations). These locations are only used to store metadata about the pipeline operations. The storage bucket and compute resources can be in any region.
 :::
 
-6. Select **Create**.
-7. Once the bucket is created, you will be redirected to the **Bucket details** page.
-8. Select **Permissions**, then **+ Add**.
-9. Copy the email address of the Compute Engine default service account into **New principals**.
-10. Select the following roles:
+1.  Select **Create**.
+1.  Once the bucket is created, you will be redirected to the **Bucket details** page.
+1.  Select **Permissions**, then **+ Add**.
+1.  Copy the email address of the Compute Engine default service account into **New principals**.
+1.  Select the following roles:
 
     - Storage Admin
     - Storage Legacy Bucket Owner
@@ -98,30 +98,30 @@ After your Google Cloud resources have been created, create a new Seqera compute
 
 **Create a Seqera Google Cloud Life Sciences compute environment**
 
-1. In a workspace, select **Compute Environments > New Environment**.
-2. Enter a descriptive name for this environment, e.g., _Google Life Sciences (europe-west2)_.
-3. Select **Google Life Sciences** as the target platform.
-4. From the **Credentials** drop-down, select existing Google Cloud credentials, or add new credentials by selecting the **+** button. If you choose to use existing credentials, skip to step 7.
+1.  In a workspace, select **Compute Environments > New Environment**.
+1.  Enter a descriptive name for this environment, e.g., _Google Life Sciences (europe-west2)_.
+1.  Select **Google Life Sciences** as the target platform.
+1.  From the **Credentials** drop-down, select existing Google Cloud credentials, or add new credentials by selecting the **+** button. If you choose to use existing credentials, skip to step 7.
 
 :::tip
 You can create multiple credentials in your Seqera workspace. See [Credentials](../credentials/overview.mdx).
 :::
 
-5. Enter a name for the credentials, e.g., _Google Cloud Credentials_.
-6. Enter the **Service account key** created previously.
-7. Select the [**Region** and **Zones**](https://cloud.google.com/compute/docs/regions-zones#available) where you wish to execute pipelines. Leave the **Location** empty for the Cloud Life Sciences API to use the closest available location.
-8. In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket must be accessible in the region selected in the previous step.
+1.  Enter a name for the credentials, e.g., _Google Cloud Credentials_.
+1.  Enter the **Service account key** created previously.
+1.  Select the [**Region** and **Zones**](https://cloud.google.com/compute/docs/regions-zones#available) where you wish to execute pipelines. Leave the **Location** empty for the Cloud Life Sciences API to use the closest available location.
+1.  In the **Pipeline work directory** field, enter your storage bucket URL, e.g., `gs://my-bucket`. This bucket must be accessible in the region selected in the previous step.
 
     :::note
     When you specify a Cloud Storage bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
     :::
 
-9. You can enable **Preemptible** to use preemptible instances, which have significantly reduced cost compared to on-demand instances.
-10. You can use a **Filestore file system** to automatically mount a Google Filestore volume in your pipelines.
-11. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-12. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-13. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
-14. Configure any advanced options you need:
+1.  You can enable **Preemptible** to use preemptible instances, which have significantly reduced cost compared to on-demand instances.
+1.  You can use a **Filestore file system** to automatically mount a Google Filestore volume in your pipelines.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Configure any advanced options you need:
 
     - Enable **Use Private Address** to ensure that your Google Cloud VMs aren't accessible to the public internet.
 
@@ -129,6 +129,6 @@ You can create multiple credentials in your Seqera workspace. See [Credentials](
 
     - Use **Head Job CPUs** and **Head Job Memory** to specify the CPUs and memory allocated for head jobs.
 
-15. Select **Create** to finalize the compute environment setup.
+1.  Select **Create** to finalize the compute environment setup.
 
 See [Launch pipelines](../launch/launchpad.mdx) to start executing workflows in your Google Cloud Life Sciences compute environment.

--- a/platform_versioned_docs/version-23.4.0/compute-envs/hpc.mdx
+++ b/platform_versioned_docs/version-23.4.0/compute-envs/hpc.mdx
@@ -26,18 +26,18 @@ To launch pipelines into an **HPC** cluster from Seqera, the following requireme
 To create a new **HPC** compute environment:
 
 1.  In a Seqera workspace, select **Compute environments > New environment**.
-2.  Enter a descriptive name for this environment. Use only alphanumeric characters, dashes, and underscores.
-3.  Select your HPC environment from the **Platform** dropdown menu.
-4.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
-5.  Enter a name for the credentials.
-6.  Enter the absolute path of the **Work directory** to be used on the cluster.
-7.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
-8.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
-9.  Enter the **Head queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will be submitted.
-10. Enter the **Compute queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will submit tasks.
-11. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-12. Specify custom **Environment variables** for the head job and/or compute jobs.
-13. Configure any advanced options needed:
+1.  Enter a descriptive name for this environment. Use only alphanumeric characters, dashes, and underscores.
+1.  Select your HPC environment from the **Platform** dropdown menu.
+1.  Select your credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
+1.  Enter a name for the credentials.
+1.  Enter the absolute path of the **Work directory** to be used on the cluster.
+1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
+1.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
+1.  Enter the **Head queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will be submitted.
+1.  Enter the **Compute queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will submit tasks.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  Specify custom **Environment variables** for the head job and/or compute jobs.
+1.  Configure any advanced options needed:
 
     - Use the **Nextflow queue size** to limit the number of jobs that Nextflow can submit to the scheduler at the same time.
     - Use the **Head job submit options** to specify platform-specific submit options for the head job. You can optionally apply these options to compute jobs as well:
@@ -52,6 +52,6 @@ Once set during compute environment creation, these options can't be overridden 
 In IBM LSF compute environments, use **Unit for memory limits**, **Per job memory limits**, and **Per task reserve** to control how memory is requested for Nextflow jobs.
 :::
 
-14. Select **Create** to finalize the creation of the compute environment.
+1.  Select **Create** to finalize the creation of the compute environment.
 
 See [Launch pipelines](../launch/launchpad.mdx) to start executing workflows in your HPC compute environment.

--- a/platform_versioned_docs/version-23.4.0/compute-envs/k8s.mdx
+++ b/platform_versioned_docs/version-23.4.0/compute-envs/k8s.mdx
@@ -17,15 +17,15 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
 **Prepare your Kubernetes cluster for Seqera Platform**
 
-1. Verify the connection to your Kubernetes cluster:
+1.  Verify the connection to your Kubernetes cluster:
 
    ```bash
    kubectl cluster-info
    ```
 
-2. Download the [tower-launcher.yml](../_templates/k8s/tower-launcher.yml) file.
+1.  Download the [tower-launcher.yml](../_templates/k8s/tower-launcher.yml) file.
 
-3. Create the Seqera launcher:
+1.  Create the Seqera launcher:
 
    ```bash
    kubectl apply -f path/to/tower-launcher.yml
@@ -33,7 +33,7 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
    This command creates a service account called `tower-launcher-sa` and the associated role bindings, all contained in a namespace called `tower-nf`. Seqera uses the service account to launch Nextflow pipelines. Use this service account name when setting up the compute environment for this Kubernetes cluster in Seqera.
 
-4. Create persistent storage. Seqera requires a `ReadWriteMany` persistent volume claim (PVC) mounted to all nodes where workflow pods will be dispatched.
+1.  Create persistent storage. Seqera requires a `ReadWriteMany` persistent volume claim (PVC) mounted to all nodes where workflow pods will be dispatched.
 
    You can use any storage solution that supports the `ReadWriteMany` [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes). The setup of this storage is beyond the scope of these instructions — the right solution for you will depend on what is available for your infrastructure or cloud vendor (NFS, GlusterFS, CephFS, Amazon FSx). Ask your cluster administrator for more information.
 
@@ -41,7 +41,7 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
    - Example PVC backed by NFS server: [tower-scratch-nfs.yml](../_templates/k8s/tower-scratch-nfs.yml)
 
-5. Apply the appropriate PVC configuration to your cluster:
+1.  Apply the appropriate PVC configuration to your cluster:
 
    ```bash
    kubectl apply -f <PVC_YAML_FILE>.
@@ -53,17 +53,17 @@ After you've prepared your Kubernetes cluster for Seqera integration, create a c
 
 **Create a Seqera Kubernetes compute environment**
 
-1. In a workspace, select **Compute environments > New environment**.
-2. Enter a descriptive name for this environment, e.g., _K8s cluster_.
-3. Select **Kubernetes** as the target platform.
-4. From the **Credentials** drop-down, select existing Kubernetes credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
+1.  In a workspace, select **Compute environments > New environment**.
+1.  Enter a descriptive name for this environment, e.g., _K8s cluster_.
+1.  Select **Kubernetes** as the target platform.
+1.  From the **Credentials** drop-down, select existing Kubernetes credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
 
 :::tip
 You can create multiple credentials in your Seqera workspace. See [Credentials](../credentials/overview.mdx).
 :::
 
-5. Enter a name, e.g., _K8s Credentials_.
-6. Select either the **Service Account Token** or **X509 Client Certs** tab:
+1.  Enter a name, e.g., _K8s Credentials_.
+1.  Select either the **Service Account Token** or **X509 Client Certs** tab:
 
    - To authenticate using a Kubernetes service account, enter your **Service account token**. Obtain the token with the following command:
 
@@ -76,7 +76,7 @@ You can create multiple credentials in your Seqera workspace. See [Credentials](
 
    - To authenticate using an X509 client certificate, paste the contents of your certificate and key file (including the `-----BEGIN...-----` and `-----END...-----` lines) in the **Client certificate** and **Client Key** fields respectively. See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/certificates/) for instructions to generate your client certificate and key.
 
-7. Enter the **Control plane URL**, obtained with this command:
+1.  Enter the **Control plane URL**, obtained with this command:
 
    ```bash
    kubectl cluster-info
@@ -84,18 +84,18 @@ You can create multiple credentials in your Seqera workspace. See [Credentials](
 
    It can also be found in your `~/.kube/config` file under the `server` field corresponding to your cluster.
 
-8. Specify the **SSL certificate** to authenticate your connection.
+1.  Specify the **SSL certificate** to authenticate your connection.
 
    Find the certificate data in your `~/.kube/config` file. It is the `certificate-authority-data` field corresponding to your cluster.
 
-9. Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is _tower-nf_ by default.
-10. Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is _tower-launcher-sa_ by default.
-11. Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in each of the provided examples.
-12. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-13. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre-and-post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-14. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
-15. Configure any advanced options described below, as needed.
-16. Select **Create** to finalize the compute environment setup.
+1.  Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is _tower-nf_ by default.
+1.  Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is _tower-launcher-sa_ by default.
+1.  Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in each of the provided examples.
+1.  Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1.  Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre-and-post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1.  You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1.  Configure any advanced options described below, as needed.
+1.  Select **Create** to finalize the compute environment setup.
 
 See [Launch pipelines](../launch/launchpad.mdx) to start executing workflows in your Kubernetes compute environment.
 

--- a/platform_versioned_docs/version-23.4.0/credentials/agent_credentials.mdx
+++ b/platform_versioned_docs/version-23.4.0/credentials/agent_credentials.mdx
@@ -17,11 +17,11 @@ You can share a single Tower Agent instance with all members of a workspace. Cre
     - From an organization workspace: Go to the **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-agent-creds`.
     - **Provider**: Select **Tower Agent**.
     - **Agent connection ID**: The connection ID used to run your Tower Agent instance. Must match the connection ID used when running the Agent (see **Usage** below).
     - **Shared agent**: Enables Tower Agent sharing for all workspace members.
     - **Usage**: Populates a code snippet for Tower Agent download with your connection ID. Replace `<YOUR TOKEN>` with your [Seqera access token](../api/overview.mdx#authentication).
 
-3. After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/platform_versioned_docs/version-23.4.0/credentials/aws_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.4.0/credentials/aws_registry_credentials.mdx
@@ -17,13 +17,13 @@ Wave requires programmatic access to your private Elastic Container Registry (EC
 
 **Create an IAM user with AWS ECR access**
 
-1. Open the [IAM console](https://console.aws.amazon.com/iam/).
-2. Select **Users** from the navigation pane.
-3. Select the name of the user whose keys you want to manage, then select the **Security credentials** tab. We recommend creating an IAM user specifically for Wave authentication instead of using existing credentials with broader permissions.
-4. In the **Access keys** section, select **Create access key**. Each IAM user can have only two access keys at a time, so if the Create option is deactivated, delete an existing access key first.
-5. On the **Access key best practices & alternatives** page, select **Other** and then **Next**.
-6. On the **Retrieve access key** page, you can either **Show** the user's secret access key details, or store them by selecting **Download .csv file**.
-7. The newly created access key pair is active by default and can be stored as a container registry credential in Seqera.
+1.  Open the [IAM console](https://console.aws.amazon.com/iam/).
+1.  Select **Users** from the navigation pane.
+1.  Select the name of the user whose keys you want to manage, then select the **Security credentials** tab. We recommend creating an IAM user specifically for Wave authentication instead of using existing credentials with broader permissions.
+1.  In the **Access keys** section, select **Create access key**. Each IAM user can have only two access keys at a time, so if the Create option is deactivated, delete an existing access key first.
+1.  On the **Access key best practices & alternatives** page, select **Other** and then **Next**.
+1.  On the **Retrieve access key** page, you can either **Show** the user's secret access key details, or store them by selecting **Download .csv file**.
+1.  The newly created access key pair is active by default and can be stored as a container registry credential in Seqera.
 
 :::note
 Your credential must be stored in Seqera Platform as a **container registry** credential, even if the same access keys already exist as a workspace credential.
@@ -35,7 +35,7 @@ Your credential must be stored in Seqera Platform as a **container registry** cr
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -43,4 +43,4 @@ Your credential must be stored in Seqera Platform as a **container registry** cr
     - **Password**: Specify your IAM user secret access.
     - **Registry server**: Specify container registry server name. For example, `<aws_account_id>.dkr.ecr.<region>.amazonaws.com`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/platform_versioned_docs/version-23.4.0/credentials/azure_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.4.0/credentials/azure_registry_credentials.mdx
@@ -19,18 +19,18 @@ You must use Azure credentials with long-term registry read (**content/read**) a
 
 **Create an access token with Azure container registry access**
 
-1. In the Azure portal, navigate to your container registry.
-2. Under **Repository permissions**, select **Tokens > +Add**.
-3. Enter a token name.
-4. Under **Scope map**, select **Create new**.
-5. In the **Create scope map** section, enter a name and description for the new scope map.
-6. Select your **Repository** from the drop-down menu.
-7. Select **content/read** from the **Permissions** drop-down menu, then select **Add** to create the scope map.
-8. In the **Create token** section, ensure the **Status** is **Enabled** (default), then select **Create**.
-9. Return to **Repository permissions > Tokens** for your registry, then select the token you just created.
-10. On the token details page, select **password1** or **password2**.
-11. In the password details section, uncheck the **Set expiration date?** checkbox, then select **Generate**.
-12. Copy and save the generated password (this is only displayed once).
+1.  In the Azure portal, navigate to your container registry.
+1.  Under **Repository permissions**, select **Tokens > +Add**.
+1.  Enter a token name.
+1.  Under **Scope map**, select **Create new**.
+1.  In the **Create scope map** section, enter a name and description for the new scope map.
+1.  Select your **Repository** from the drop-down menu.
+1.  Select **content/read** from the **Permissions** drop-down menu, then select **Add** to create the scope map.
+1.  In the **Create token** section, ensure the **Status** is **Enabled** (default), then select **Create**.
+1.  Return to **Repository permissions > Tokens** for your registry, then select the token you just created.
+1.  On the token details page, select **password1** or **password2**.
+1.  In the password details section, uncheck the **Set expiration date?** checkbox, then select **Generate**.
+1.  Copy and save the generated password (this is only displayed once).
 
 ## Add credentials to Seqera
 
@@ -38,7 +38,7 @@ You must use Azure credentials with long-term registry read (**content/read**) a
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -46,4 +46,4 @@ You must use Azure credentials with long-term registry read (**content/read**) a
     - **Password**: Your registry token password. For example, `my-registry-token`.
     - **Registry server**: Specify the container registry server name. You can obtain this from the Azure portal: **Settings > Access keys > Login server**. For example, `myregistry.azurecr.io`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/platform_versioned_docs/version-23.4.0/credentials/docker_hub_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.4.0/credentials/docker_hub_registry_credentials.mdx
@@ -17,11 +17,11 @@ You must use Docker Hub credentials with **Read-only** access to authenticate Se
 
 **Create a Docker Hub PAT**
 
-1. Log in to [Docker Hub](https://hub.docker.com/).
-2. Select your username in the top right corner and select **Account Settings**.
-3. Select **Security > New Access Token**.
-4. Enter a token description and select **Read-only** from the Access permissions drop-down menu, then select **Generate**.
-5. Copy and save the generated access token (this is only displayed once).
+1.  Log in to [Docker Hub](https://hub.docker.com/).
+1.  Select your username in the top right corner and select **Account Settings**.
+1.  Select **Security > New Access Token**.
+1.  Enter a token description and select **Read-only** from the Access permissions drop-down menu, then select **Generate**.
+1.  Copy and save the generated access token (this is only displayed once).
 
 ## Add credentials to Seqera
 
@@ -29,7 +29,7 @@ You must use Docker Hub credentials with **Read-only** access to authenticate Se
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -37,4 +37,4 @@ You must use Docker Hub credentials with **Read-only** access to authenticate Se
     - **Password**: Specify your personal access token (PAT). For example, `1fcd02dc-...215bc3f3`.
     - **Registry server**: Specify the container registry hostname, excluding the protocol. For example, `docker.io`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/platform_versioned_docs/version-23.4.0/credentials/gitea_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.4.0/credentials/gitea_registry_credentials.mdx
@@ -23,7 +23,7 @@ You must create a PAT to access your Gitea container registry from Wave. For mor
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -31,7 +31,7 @@ You must create a PAT to access your Gitea container registry from Wave. For mor
     - **Password**: Specify your Gitea personal access token (PAT). For example, `1fcd02dc-...215bc3f3`.
     - **Registry server**: Specify your Gitea container registry URL. For example, `gitea.example.com`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
 
 [gitea-auth]: https://docs.gitea.com/usage/packages/container#login-to-the-container-registry
 [gitea-create]: https://docs.gitea.com/development/api-usage#authentication

--- a/platform_versioned_docs/version-23.4.0/credentials/github_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.4.0/credentials/github_registry_credentials.mdx
@@ -23,7 +23,7 @@ You must create a PAT to access your GitHub container registry from Wave. For mo
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -31,7 +31,7 @@ You must create a PAT to access your GitHub container registry from Wave. For mo
     - **Password**: Specify your personal access token (PAT) classic. For example, `1fcd02dc-...215bc3f3`.
     - **Registry server**: Specify your GitHub container registry URL. For example, `ghcr.io`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
 
 [github-pat]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic
 [github-create]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic

--- a/platform_versioned_docs/version-23.4.0/credentials/gitlab_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.4.0/credentials/gitlab_registry_credentials.mdx
@@ -23,7 +23,7 @@ If your organization enabled 2FA for your organization or project, you must crea
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -31,7 +31,7 @@ If your organization enabled 2FA for your organization or project, you must crea
     - **Password**: Specify your personal access token (PAT), group access token, or project access token if 2FA is enabled by your GitLab organization. Otherwise specify your GitLab password.
     - **Registry server**: Specify your GitLab container registry URL. For example, `gitlab.example.com`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
 
 [gitlab-cr]: https://docs.gitlab.com/ee/user/packages/container_registry/authenticate_with_container_registry.html
 [gitlab-pat]: https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html

--- a/platform_versioned_docs/version-23.4.0/credentials/google_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.4.0/credentials/google_registry_credentials.mdx
@@ -27,17 +27,17 @@ Create dedicated service account keys that are only used to interact with your r
 
 Administrators can create a service account from the Google Cloud console:
 
-1. Go to the [Create service account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts/create?walkthrough_id=iam--create-service-account) page.
-2. Select a Cloud project.
-3. Enter a service account name and (optional) description.
-4. Select **Create and continue**.
-5. From the **Role** drop-down menu under step 2, select **Artifact Registry > Artifact Registry Reader**, then select **Continue**.
-6. (Optional) Grant other users and admins access to this service account.
-7. Select **Done**.
-8. From the project service accounts page, select the three dots menu icon under **Actions** for the service account you just created, then select **Manage keys**.
-9. On the **Keys** page, select **Add key**.
-10. On the **Create private key** popup, select **JSON** and then **Create**. This triggers a download of a JSON file containing the service account private key and service account details.
-11. Base-64 encode the contents of the JSON key file:
+1.  Go to the [Create service account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts/create?walkthrough_id=iam--create-service-account) page.
+1.  Select a Cloud project.
+1.  Enter a service account name and (optional) description.
+1.  Select **Create and continue**.
+1.  From the **Role** drop-down menu under step 2, select **Artifact Registry > Artifact Registry Reader**, then select **Continue**.
+1.  (Optional) Grant other users and admins access to this service account.
+1.  Select **Done**.
+1.  From the project service accounts page, select the three dots menu icon under **Actions** for the service account you just created, then select **Manage keys**.
+1.  On the **Keys** page, select **Add key**.
+1.  On the **Create private key** popup, select **JSON** and then **Create**. This triggers a download of a JSON file containing the service account private key and service account details.
+1.  Base-64 encode the contents of the JSON key file:
 
 ```bash
         #Linux
@@ -54,16 +54,16 @@ Administrators can create a service account from the Google Cloud console:
 
 Administrators can create a service account from the Google Cloud console:
 
-1. Navigate to the [Create service account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts/create?walkthrough_id=iam--create-service-account) page.
-2. Select a Cloud project.
-3. Enter a service account name and an optional description.
-4. Select **Create and continue**.
-5. From the **Role** drop-down menu under step 2, search for and select **Storage Object Viewer**, then select **Continue**.
-6. (Optional) Grant other users and admins access to this service account under step 3.
-7. Select **Done**.
-8. From the project service accounts page, select the three dots menu icon under **Actions** for the service account you just created, then select **Manage keys**.
-9. On the **Keys** page, select **Add key**.
-10. On the **Create private key** popup, select **JSON** and then **Create**. This triggers a download of a JSON file containing the service account private key and service account details.
+1.  Navigate to the [Create service account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts/create?walkthrough_id=iam--create-service-account) page.
+1.  Select a Cloud project.
+1.  Enter a service account name and an optional description.
+1.  Select **Create and continue**.
+1.  From the **Role** drop-down menu under step 2, search for and select **Storage Object Viewer**, then select **Continue**.
+1.  (Optional) Grant other users and admins access to this service account under step 3.
+1.  Select **Done**.
+1.  From the project service accounts page, select the three dots menu icon under **Actions** for the service account you just created, then select **Manage keys**.
+1.  On the **Keys** page, select **Add key**.
+1.  On the **Create private key** popup, select **JSON** and then **Create**. This triggers a download of a JSON file containing the service account private key and service account details.
 
 ## Add credentials to Seqera
 
@@ -71,7 +71,7 @@ Administrators can create a service account from the Google Cloud console:
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -81,4 +81,4 @@ Administrators can create a service account from the Google Cloud console:
     - **Password**: Specify the JSON key file content. This content is base64-encoded for Artifact Registry. You must remove any line breaks or trailing spaces. For example, `wewogICJ02...9tIgp9Cg==`.
     - **Registry server**: Specify the container registry hostname, excluding the protocol. For example, `<location>-docker.pkg.dev`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/platform_versioned_docs/version-23.4.0/credentials/quay_registry_credentials.mdx
+++ b/platform_versioned_docs/version-23.4.0/credentials/quay_registry_credentials.mdx
@@ -15,12 +15,12 @@ For Quay repositories, we recommend using [robot accounts](https://docs.quay.io/
 
 **Create a Quay robot account**
 
-1. Sign in to [quay.io](https://quay.io/).
-2. From the user or organization view, select the **Robot Accounts** tab.
-3. Select **Create Robot Account**.
-4. Enter a robot account name. The username for robot accounts have the format `namespace+accountname`, where `namespace` is the user or organization name and `accountname` is your chosen robot account name.
-5. Grant the robot account repository **Read** permissions from **Settings > User and Robot Permissions** in the repository view.
-6. Select the robot account in your admin panel to retrieve the token value.
+1.  Sign in to [quay.io](https://quay.io/).
+1.  From the user or organization view, select the **Robot Accounts** tab.
+1.  Select **Create Robot Account**.
+1.  Enter a robot account name. The username for robot accounts have the format `namespace+accountname`, where `namespace` is the user or organization name and `accountname` is your chosen robot account name.
+1.  Grant the robot account repository **Read** permissions from **Settings > User and Robot Permissions** in the repository view.
+1.  Select the robot account in your admin panel to retrieve the token value.
 
 ## Add credentials to Seqera
 
@@ -28,7 +28,7 @@ For Quay repositories, we recommend using [robot accounts](https://docs.quay.io/
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
 
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
@@ -36,4 +36,4 @@ For Quay repositories, we recommend using [robot accounts](https://docs.quay.io/
     - **Password**: Specify your robot account access token. For example, `PasswordFromQuayAdminPanel`.
     - **Registry server**: Specify your container registry hostname. For example, `quay.io`.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/platform_versioned_docs/version-23.4.0/credentials/ssh_credentials.mdx
+++ b/platform_versioned_docs/version-23.4.0/credentials/ssh_credentials.mdx
@@ -21,11 +21,11 @@ To use SSH public key authentication:
 To generate an SSH key pair:
 
 1.  From the target machine, open a terminal window and run `ssh-keygen`.
-2.  Follow the prompts to:
+1.  Follow the prompts to:
     - Specify a file path and name (or keep the default).
     - Specify a passphrase (recommended).
-3. Navigate to the target folder (default `/home/user/.ssh/id_rsa`) and open the private key file with a plain text editor.
-4. Copy the private key file contents before navigating to Seqera.
+1.  Navigate to the target folder (default `/home/user/.ssh/id_rsa`) and open the private key file with a plain text editor.
+1.  Copy the private key file contents before navigating to Seqera.
 
 ## Create an SSH credential in Seqera
 
@@ -33,10 +33,10 @@ To generate an SSH key pair:
     - From an organization workspace: Go to **Credentials > Add Credentials**.
     - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
 
-2.  Complete the following fields:
+1.  Complete the following fields:
     - **Name**: A unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-ssh-creds`.
     - **Provider**: Select **SSH**.
     - **SSH private key**: Paste the SSH private key file contents. Include the `-----BEGIN OPENSSH PRIVATE KEY-----` and `-----END OPENSSH PRIVATE KEY-----` lines.
     - **Passphrase**: The SSH private key passphrase (recommended). If your key pair was created without a passphrase, leave this blank.
 
-3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
+1.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/platform_versioned_docs/version-23.4.0/data/data-explorer.mdx
+++ b/platform_versioned_docs/version-23.4.0/data/data-explorer.mdx
@@ -126,29 +126,29 @@ Apply a [CORS configuration](https://learn.microsoft.com/en-us/rest/api/storages
 
 **Seqera Cloud Azure CORS configuration**
 
-1. From the [Azure portal](https://portal.azure.com), go to the **Storage account** you wish to configure.
-2. Under **Settings** in the left navigation menu, select **Resource sharing (CORS)**.
-3. Add a new entry under **Blob service**:
+1.  From the [Azure portal](https://portal.azure.com), go to the **Storage account** you wish to configure.
+1.  Under **Settings** in the left navigation menu, select **Resource sharing (CORS)**.
+1.  Add a new entry under **Blob service**:
 
 - **Allowed origins**: `https://tower.nf`
 - **Allowed methods**: `GET,POST,PUT,DELETE,HEAD`
 - **Allowed headers**: `x-ms-blob-type,content-type`
 - **Exposed headers**: `x-ms-blob-type`
 
-4. Select **Save** to apply the CORS configuration.
+1.  Select **Save** to apply the CORS configuration.
 
 **Seqera Enterprise Azure CORS configuration**
 
-1. From the [Azure portal](https://portal.azure.com), go to the Storage account you wish to configure.
-2. Under **Settings** in the left navigation menu, select **Resource sharing (CORS)**.
-3. Add a new entry under **Blob service**:
+1.  From the [Azure portal](https://portal.azure.com), go to the Storage account you wish to configure.
+1.  Under **Settings** in the left navigation menu, select **Resource sharing (CORS)**.
+1.  Add a new entry under **Blob service**:
 
 - **Allowed origins**: `https://<your_seqera_instance_url>`
 - **Allowed methods**: `GET,POST,PUT,DELETE,HEAD`
 - **Allowed headers**: `x-ms-blob-type,content-type`
 - **Exposed headers**: `x-ms-blob-type`
 
-4. Select **Save** to apply the CORS configuration.
+1.  Select **Save** to apply the CORS configuration.
 
 ### Google Cloud Storage CORS configuration
 

--- a/platform_versioned_docs/version-23.4.0/data/data-studios.mdx
+++ b/platform_versioned_docs/version-23.4.0/data/data-studios.mdx
@@ -29,12 +29,12 @@ Select the **Data Studios** tab to view all data studios. The list includes the 
 
 ### Add a data studio
 
-1. Select **Add data studio**.
-2. Select a template from the three options provided (JupyterLab, RStudio Server, or Visual Studio Code).
-3. Select a compute environment. Currently, only AWS Batch is supported.
-4. Mount data using Data Explorer: Select one or more datasets to mount. Datasets are mounted using the [Fusion file system](https://seqera.io/fusion) and are available at `/workspace/data/<dataset>`. Mounted data doesn't need to match the compute environment or region of the cloud provider of the data studio. However, this might cause increased costs or errors.
-5. Optional: Enter CPU and memory allocations. The default values are 2 CPUs and 8192 MB memory (RAM).
-6. Select **Add**.
+1.  Select **Add data studio**.
+1.  Select a template from the three options provided (JupyterLab, RStudio Server, or Visual Studio Code).
+1.  Select a compute environment. Currently, only AWS Batch is supported.
+1.  Mount data using Data Explorer: Select one or more datasets to mount. Datasets are mounted using the [Fusion file system](https://seqera.io/fusion) and are available at `/workspace/data/<dataset>`. Mounted data doesn't need to match the compute environment or region of the cloud provider of the data studio. However, this might cause increased costs or errors.
+1.  Optional: Enter CPU and memory allocations. The default values are 2 CPUs and 8192 MB memory (RAM).
+1.  Select **Add**.
 
 You'll be returned to the Data Studios landing page that displays the list of data studios in your workspace. The data studio you created will be listed with the status **stopped**.
 

--- a/platform_versioned_docs/version-23.4.0/data/datasets.mdx
+++ b/platform_versioned_docs/version-23.4.0/data/datasets.mdx
@@ -47,11 +47,11 @@ Datasets can point to files stored in various locations, such as Amazon S3 or Gi
 
 All Seqera users have access to the datasets feature in organization workspaces. To create a new dataset:
 
-1. Open the **Datasets** tab in your organization workspace.
-2. Select **New dataset**.
-3. Complete the **Name** and **Description** fields using information relevant to your dataset.
-4. Add the dataset file to your workspace with drag-and-drop or the system file explorer dialog.
-5. For dataset files that use the first row for column names, customize the dataset view with the **First row as header** option.
+1.  Open the **Datasets** tab in your organization workspace.
+1.  Select **New dataset**.
+1.  Complete the **Name** and **Description** fields using information relevant to your dataset.
+1.  Add the dataset file to your workspace with drag-and-drop or the system file explorer dialog.
+1.  For dataset files that use the first row for column names, customize the dataset view with the **First row as header** option.
 
 :::note
 The size of the dataset file must not exceed 10 MB.
@@ -61,9 +61,9 @@ The size of the dataset file must not exceed 10 MB.
 
 Seqera can accommodate multiple versions of a dataset. To add a new version for an existing dataset, follow these steps:
 
-1. Select **Edit** next to the dataset you wish to update.
-2. In the Edit dialog, select **Add a new version**.
-3. Upload the newer version of the dataset and select **Update**.
+1.  Select **Edit** next to the dataset you wish to update.
+1.  In the Edit dialog, select **Add a new version**.
+1.  Upload the newer version of the dataset and select **Update**.
 
 :::caution
 All subsequent versions of a dataset must be the same format (CSV or TSV) as the initial version.
@@ -73,9 +73,9 @@ All subsequent versions of a dataset must be the same format (CSV or TSV) as the
 
 To use a dataset with the saved pipelines in your workspace:
 
-1. Open any pipeline that contains a pipeline schema from the [Launchpad](../launch/launchpad.mdx).
-2. Select the input field for the pipeline, removing any default value.
-3. Pick the dataset to use as input to your pipeline.
+1.  Open any pipeline that contains a pipeline schema from the [Launchpad](../launch/launchpad.mdx).
+1.  Select the input field for the pipeline, removing any default value.
+1.  Pick the dataset to use as input to your pipeline.
 
 :::note
 The input field drop-down menu will only display datasets that match the file type specified in the `nextflow_schema.json` of the chosen pipeline. If the schema specifies `"mimetype": "text/csv"`, no TSV datasets will be available for use with that pipeline, and vice-versa.

--- a/platform_versioned_docs/version-23.4.0/enterprise/_templates/nginx/cert_on_frontend.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/_templates/nginx/cert_on_frontend.mdx
@@ -1,7 +1,7 @@
 title: "cert_on_frontend"
 This example assumes deployment on an Amazon Linux 2 AMI.
 
-1. Install NGINX and other required packages:
+1.  Install NGINX and other required packages:
 
    ```yml
    sudo amazon-linux-extras install nginx1.12
@@ -12,9 +12,9 @@ This example assumes deployment on an Amazon Linux 2 AMI.
    sudo amazon-linux-extras install epel -y
    ```
 
-2. Generate a [private certificate and key](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs).
+1.  Generate a [private certificate and key](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs).
 
-3. Create a `ssl.conf` file.
+1.  Create a `ssl.conf` file.
 
    ```ini
 
@@ -52,15 +52,15 @@ This example assumes deployment on an Amazon Linux 2 AMI.
 
    ```
 
-4. Make a local copy of the `frontend` container's `/etc/nginx/nginx.conf` file.
+1.  Make a local copy of the `frontend` container's `/etc/nginx/nginx.conf` file.
 
-5. Add the following to the `server` block of your local `nginx.conf` file:
+1.  Add the following to the `server` block of your local `nginx.conf` file:
 
    ```ini
    include /etc/nginx/ssl.conf;
    ```
 
-6. Modify the `frontend` container definition in your `docker-compose.yml` file:
+1.  Modify the `frontend` container definition in your `docker-compose.yml` file:
 
    ```yml
    frontend:

--- a/platform_versioned_docs/version-23.4.0/enterprise/advanced-topics/cloudformation.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/advanced-topics/cloudformation.mdx
@@ -14,11 +14,11 @@ This guide assumes that all [prerequisites](../prerequisites/aws.mdx) have been 
 
 ## Set up an ECS cluster
 
-1. Navigate to the ECS console in AWS.
+1.  Navigate to the ECS console in AWS.
 
-2. Select **Create cluster**.
+1.  Select **Create cluster**.
 
-3. Select **Amazon ECS > Clusters > EC2 Linux + Networking**.
+1.  Select **Amazon ECS > Clusters > EC2 Linux + Networking**.
 
 ### ECS Cluster Configuration
 
@@ -47,13 +47,13 @@ This guide assumes that all [prerequisites](../prerequisites/aws.mdx) have been 
 
 ## Deploy Tower
 
-1. Download [aws-ecs-cloudformation.json](../_templates/cloudformation/aws-ecs-cloudformation.json) and [params.json.template](../_templates/cloudformation/params.json.template).
+1.  Download [aws-ecs-cloudformation.json](../_templates/cloudformation/aws-ecs-cloudformation.json) and [params.json.template](../_templates/cloudformation/params.json.template).
 
-2. Rename `params.template.json` to `params.json` and configure for your environment.
+1.  Rename `params.template.json` to `params.json` and configure for your environment.
 
    For more information on configuration, visit the [Configuration](../configuration/overview.mdx) section.
 
-3. Deploy the Tower stack to your ECS cluster:
+1.  Deploy the Tower stack to your ECS cluster:
 
    ```bash
    aws cloudformation create-stack \

--- a/platform_versioned_docs/version-23.4.0/enterprise/advanced-topics/db-docker-to-RDS.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/advanced-topics/db-docker-to-RDS.mdx
@@ -23,9 +23,9 @@ While [Docker Compose](../docker-compose.mdx) is a fast and convenient way to de
 
 Before starting your migration:
 
-1. Create an RDS MySQL-compliant instance and populate it with a [Seqera user and database](../configuration/overview.mdx#seqera-and-redis-databases).
+1.  Create an RDS MySQL-compliant instance and populate it with a [Seqera user and database](../configuration/overview.mdx#seqera-and-redis-databases).
 
-2. Ensure both your database and EC2 instances' Security Group(s) have been configured to allow MySQL traffic (default: Port 3306).
+1.  Ensure both your database and EC2 instances' Security Group(s) have been configured to allow MySQL traffic (default: Port 3306).
 
 ## Migration steps
 
@@ -37,67 +37,67 @@ These migration instructions assume:
 
 :::
 
-1. Connect to the EC2 instance with SSH and navigate to your Seqera instance's `docker compose` folder.
+1.  Connect to the EC2 instance with SSH and navigate to your Seqera instance's `docker compose` folder.
 
-2. Shut down the application:
+1.  Shut down the application:
 
    ```bash
    docker compose down
    ```
 
-3. Mount a new folder into the MySQL container for migration activities:
+1.  Mount a new folder into the MySQL container for migration activities:
 
-   1. Create a new folder to hold migration artefacts:
+   1.  Create a new folder to hold migration artefacts:
 
       ```bash
       mkdir ~/tower_migration
       ```
 
-   2. Back up the database:
+   2.  Back up the database:
 
       ```bash
       sudo tar -zcvf ~/tower_migration/tower_backup.tar.gz ~/.tower/db/mysql
       ```
 
-4. Add a new volume entry for the db container to the Seqera `docker-compose.yml`:
+1.  Add a new volume entry for the db container to the Seqera `docker-compose.yml`:
 
    ```
    $HOME/tower_migration:/tower_migration
    ```
 
-5. Restart the application to confirm your changes were successful:
+1.  Restart the application to confirm your changes were successful:
 
    ```bash
    docker compose up
    ```
 
-6. Stop all the non-MySQL containers:
+1.  Stop all the non-MySQL containers:
 
    ```bash
    docker container stop <CONTAINER ID>
    ```
 
-7. Exec onto the MySQL container:
+1.  Exec onto the MySQL container:
 
    ```bash
    docker exec -it <CONTAINER ID> /bin/bash
    ```
 
-   1. Dump your data to disk:
+   1.  Dump your data to disk:
 
       ```bash
       mysqldump -u tower -p --databases tower --no-tablespaces --set-gtid-purged=OFF > /tower_migration/tower_dumpfile.sql
       ```
 
-   2. Exit the container.
+   2.  Exit the container.
 
-8. Stop the MySQL container:
+1.  Stop the MySQL container:
 
    ```bash
    docker container stop <CONTAINER ID>
    ```
 
-9. Import the dump file into your new RDS instance:
+1.  Import the dump file into your new RDS instance:
 
    ```bash
    mysql --host <DB-HOST> --port 3306 -u tower -p tower < ~/tower_migration/tower_dumpfile.sql
@@ -106,8 +106,8 @@ These migration instructions assume:
    :::note
    If you encounter an `Access denied; you need (at least one of) the SUPER or SET_USER_ID privilege(s) for this operation` error, do the following:
 
-   1. Create a backup of your MySQL dump file (`tower_dumpfile.sql`).
-   2. Run the following command on the dump file:
+   1.  Create a backup of your MySQL dump file (`tower_dumpfile.sql`).
+   2.  Run the following command on the dump file:
 
    ```bash
    sed 's/\sDEFINER=`[^`]*`@`[^`]*`//g' -i tower_dumpfile.sql
@@ -115,20 +115,20 @@ These migration instructions assume:
 
    :::
 
-10. Log in to the RDS instance and ensure that the Seqera database is populated with tables prefixed by `tw_`.
+1.  Log in to the RDS instance and ensure that the Seqera database is populated with tables prefixed by `tw_`.
 
-11. Modify the `tower.env` config file in the Seqera Docker folder:
+1.  Modify the `tower.env` config file in the Seqera Docker folder:
 
-    1. Comment out the existing `TOWER_DB-*` variables.
-    2. Add new entries [relevant to your database](../configuration/overview.mdx#seqera-and-redis-databases).
-    3. Save and exit.
+    1.  Comment out the existing `TOWER_DB-*` variables.
+    2.  Add new entries [relevant to your database](../configuration/overview.mdx#seqera-and-redis-databases).
+    3.  Save and exit.
 
-12. Restart the application:
+1.  Restart the application:
 
     ```bash
     docker compose up
     ```
 
-13. Confirm that Seqera Enterprise starts and that your data is available when you log in.
+1.  Confirm that Seqera Enterprise starts and that your data is available when you log in.
 
 The migration is complete and testing can begin.

--- a/platform_versioned_docs/version-23.4.0/enterprise/advanced-topics/manual-aws-batch-setup.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/advanced-topics/manual-aws-batch-setup.mdx
@@ -18,21 +18,21 @@ Batch Forge _automatically creates_ the AWS Batch queues required for your workf
 
 Complete the following procedures to configure AWS Batch manually:
 
-1. Create a user policy.
-2. Create the instance role policy.
-3. Create the AWS Batch service role.
-4. Create an EC2 Instance role.
-5. Create an EC2 SpotFleet role.
-6. Create a launch template.
-7. Create the AWS Batch compute environments.
-8. Create the AWS Batch queue.
+1.  Create a user policy.
+1.  Create the instance role policy.
+1.  Create the AWS Batch service role.
+1.  Create an EC2 Instance role.
+1.  Create an EC2 SpotFleet role.
+1.  Create a launch template.
+1.  Create the AWS Batch compute environments.
+1.  Create the AWS Batch queue.
 
 ### Create a user policy
 
 Create the policy for the user launching Nextflow jobs:
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create policy** from the Policies page.
-1. Create a new policy with the following content:
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create policy** from the Policies page.
+1.  Create a new policy with the following content:
 
    ```json
    {
@@ -58,14 +58,14 @@ Create the policy for the user launching Nextflow jobs:
    }
    ```
 
-1. Save with it the name `seqera-user`.
+1.  Save with it the name `seqera-user`.
 
 ### Create the instance role policy
 
 Create the policy with a role that allows Seqera to submit Batch jobs on your EC2 instances:
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create policy** from the Policies page.
-1. Create a new policy with the following content:
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create policy** from the Policies page.
+1.  Create a new policy with the following content:
 
    ```json
    {
@@ -105,39 +105,39 @@ Create the policy with a role that allows Seqera to submit Batch jobs on your EC
    }
    ```
 
-1. Save it with the name `seqera-batchjob`.
+1.  Save it with the name `seqera-batchjob`.
 
 ### Create the Batch Service role
 
 Create a service role used by AWS Batch to launch EC2 instances on your behalf:
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
-1. Select **AWS service** as the trusted entity type, and **Batch** as the service.
-1. On the next page, the `AWSBatchServiceRole` is already attached. No further permissions are needed for this role.
-1. Enter `seqera-servicerole` as the role name and add an optional description and tags if needed, then select **Create**.
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
+1.  Select **AWS service** as the trusted entity type, and **Batch** as the service.
+1.  On the next page, the `AWSBatchServiceRole` is already attached. No further permissions are needed for this role.
+1.  Enter `seqera-servicerole` as the role name and add an optional description and tags if needed, then select **Create**.
 
 ### Create an EC2 instance role
 
 Create a role that controls which AWS resources the EC2 instances launched by AWS Batch can access:
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
-1. Select AWS service as the trusted entity type, EC2 as the service, and _EC2 - Allows EC2 instances to call AWS services on your behalf_ as the use case.
-1. Select **Next: Permissions**. Search for the following policies to attach to the role:
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
+1.  Select AWS service as the trusted entity type, EC2 as the service, and _EC2 - Allows EC2 instances to call AWS services on your behalf_ as the use case.
+1.  Select **Next: Permissions**. Search for the following policies to attach to the role:
 
-	- `AmazonEC2ContainerServiceforEC2Role`
-	- `AmazonS3FullAccess` (you may want to use a custom policy to allow access only on specific S3 buckets)
-	- `seqera-batchjob` (the instance role policy created above)
+  - `AmazonEC2ContainerServiceforEC2Role`
+  - `AmazonS3FullAccess` (you may want to use a custom policy to allow access only on specific S3 buckets)
+  - `seqera-batchjob` (the instance role policy created above)
 
-1. Enter `seqera-instancerole` as the role name and add an optional description and tags if needed, then select **Create**.
+1.  Enter `seqera-instancerole` as the role name and add an optional description and tags if needed, then select **Create**.
 
 ### Create an EC2 SpotFleet role
 
 The EC2 SpotFleet role allows you to use Spot instances when you run jobs in AWS Batch. Create a role for the creation and launch of Spot fleets — Spot instances with similar compute capabilities (i.e., vCPUs and RAM):
 
-1. In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
-1. Select AWS service as the trusted entity type, EC2 as the service, and _EC2 - Spot Fleet Tagging_ as the use case.
-1. On the next page, the `AmazonEC2SpotFleetTaggingRole` is already attached. No further permissions are needed for this role.
-1. Enter `seqera-fleetrole` as the role name and add an optional description and tags if needed, then select **Create**.
+1.  In the [IAM Console](https://console.aws.amazon.com/iam/home), select **Create role** from the Roles page.
+1.  Select AWS service as the trusted entity type, EC2 as the service, and _EC2 - Spot Fleet Tagging_ as the use case.
+1.  On the next page, the `AmazonEC2SpotFleetTaggingRole` is already attached. No further permissions are needed for this role.
+1.  Enter `seqera-fleetrole` as the role name and add an optional description and tags if needed, then select **Create**.
 
 ### Create a launch template
 
@@ -146,8 +146,8 @@ Create a launch template to configure the EC2 instances deployed by Batch jobs:
 <Tabs>
 <TabItem value="AWS Batch with Fusion v2" label="AWS Batch with Fusion v2" default>
 
-  1. In the [EC2 Console](https://console.aws.amazon.com/ec2/v2/home), select **Create launch template** from the Launch templates page.
-  1. Scroll down to **Advanced details** and paste the following in the **User data** field:
+  1.  In the [EC2 Console](https://console.aws.amazon.com/ec2/v2/home), select **Create launch template** from the Launch templates page.
+  1.  Scroll down to **Advanced details** and paste the following in the **User data** field:
 
     ```bash
     MIME-Version: 1.0
@@ -212,14 +212,14 @@ Create a launch template to configure the EC2 instances deployed by Batch jobs:
     --//--
     ```
 
-  1. In the line `| sed 's/$FORGE_ID/<your prefix>/g' \`, replace `<your prefix>` with your desired prefix to be added to the AWS resources created by your compute environment.
-  1. Save the template with the name `seqera-launchtemplate`.
+  1.  In the line `| sed 's/$FORGE_ID/<your prefix>/g' \`, replace `<your prefix>` with your desired prefix to be added to the AWS resources created by your compute environment.
+  1.  Save the template with the name `seqera-launchtemplate`.
 
 </TabItem>
 <TabItem value="AWS Batch without Fusion v2" label="AWS Batch without Fusion v2" default>
 
-  1. In the [EC2 Console](https://console.aws.amazon.com/ec2/v2/home), select **Create launch template** from the Launch templates page.
-  1. Scroll down to **Advanced details** and paste the following in the **User data** field:
+  1.  In the [EC2 Console](https://console.aws.amazon.com/ec2/v2/home), select **Create launch template** from the Launch templates page.
+  1.  Scroll down to **Advanced details** and paste the following in the **User data** field:
 
     ```bash
     MIME-Version: 1.0
@@ -268,8 +268,8 @@ Create a launch template to configure the EC2 instances deployed by Batch jobs:
     --//--
     ```
 
-  1. In the line `| sed 's/$FORGE_ID/<your prefix>/g' \`, replace `<your prefix>` with your desired prefix to be added to the AWS resources created by your compute environment.
-  1. Save the template with the name `seqera-launchtemplate`.
+  1.  In the line `| sed 's/$FORGE_ID/<your prefix>/g' \`, replace `<your prefix>` with your desired prefix to be added to the AWS resources created by your compute environment.
+  1.  Save the template with the name `seqera-launchtemplate`.
 
 </TabItem>
 </Tabs>
@@ -294,37 +294,37 @@ Create a compute environment for each queue in the AWS Batch console:
 
 The head queue requires an on-demand compute environment. Do not select **Use Spot instances** during compute environment creation.
 
-1. In the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home), select **Create** on the Compute environments page.
-1. Select **Amazon EC2** as the compute environment configuration.
+1.  In the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home), select **Create** on the Compute environments page.
+1.  Select **Amazon EC2** as the compute environment configuration.
 
     :::note
     Seqera AWS Batch compute environments created with [Batch Forge](../../compute-envs/aws-batch.md#tower-forge-compute-environment) support using Fargate for the head job, but manual compute environments must use EC2.
     :::
 
-1. Enter a name of your choice, and apply the `seqera-servicerole` and `seqera-instancerole`.
-1. Enter vCPU limits and instance types, if needed.
+1.  Enter a name of your choice, and apply the `seqera-servicerole` and `seqera-instancerole`.
+1.  Enter vCPU limits and instance types, if needed.
 
     :::note
     To use the same queue for both head and compute tasks, you must assign sufficient resources to your compute environment.
     :::
 
-1. Expand **Additional configuration** and select the `seqera-launchtemplate` from the Launch template dropdown.
-1. Configure VPCs, subnets, and security groups on the next page as needed.
-1. Review your configuration and select **Create compute environment**.  
+1.  Expand **Additional configuration** and select the `seqera-launchtemplate` from the Launch template dropdown.
+1.  Configure VPCs, subnets, and security groups on the next page as needed.
+1.  Review your configuration and select **Create compute environment**.  
 
 </TabItem>
 <TabItem value="Compute queue with Spot instances" label="Compute queue with Spot instances" default>
 
 Create this compute environment to use Spot instances for your workflow compute tasks. This compute environment cannot be assigned to the Nextflow head job queue.
 
-1. In the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home), select **Create** on the Compute environments page.
-1. Select **Amazon EC2** as the compute environment configuration.
-1. Enter a name of your choice, and apply the `seqera-servicerole` and `seqera-instancerole`.
-1. Select **Enable using Spot instances** to use Spot instances and save computing costs.  
-1. Select the `seqera-fleetrole` and enter vCPU limits and instance types, if needed.
-1. Expand **Additional configuration** and select the `seqera-launchtemplate` from the Launch template dropdown.
-1. Configure VPCs, subnets, and security groups on the next page as needed.
-1. Review your configuration and select **Create compute environment**.  
+1.  In the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home), select **Create** on the Compute environments page.
+1.  Select **Amazon EC2** as the compute environment configuration.
+1.  Enter a name of your choice, and apply the `seqera-servicerole` and `seqera-instancerole`.
+1.  Select **Enable using Spot instances** to use Spot instances and save computing costs.  
+1.  Select the `seqera-fleetrole` and enter vCPU limits and instance types, if needed.
+1.  Expand **Additional configuration** and select the `seqera-launchtemplate` from the Launch template dropdown.
+1.  Configure VPCs, subnets, and security groups on the next page as needed.
+1.  Review your configuration and select **Create compute environment**.  
 
 </TabItem>
 </Tabs>
@@ -340,18 +340,18 @@ You only need to create one queue if you intend to use on-demand instances for y
 <Tabs>
 <TabItem value="Head queue" label="Head queue" default>
 
-1. Go to the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home).
-2. Create a new queue.
-3. Associate the queue with the head queue compute environment created in the previous section.
-4. Save it with a name of your choice.
+1.  Go to the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home).
+1.  Create a new queue.
+1.  Associate the queue with the head queue compute environment created in the previous section.
+1.  Save it with a name of your choice.
 
 </TabItem>
 <TabItem value="Compute queue" label="Compute queue" default>
 
-1. Go to the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home).
-2. Create a new queue.
-3. Associate the queue with the compute queue environment created in the previous section.
-4. Save it with a name of your choice.
+1.  Go to the [Batch Console](https://eu-west-1.console.aws.amazon.com/batch/home).
+1.  Create a new queue.
+1.  Associate the queue with the compute queue environment created in the previous section.
+1.  Save it with a name of your choice.
 
 </TabItem>
 </Tabs>

--- a/platform_versioned_docs/version-23.4.0/enterprise/configuration/authentication.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/configuration/authentication.mdx
@@ -42,12 +42,12 @@ The following identity providers are currently supported:
 
 To use GitHub as SSO provider for Seqera:
 
-1. Register your Seqera instance as a [GitHub OAuth App](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app)
+1.  Register your Seqera instance as a [GitHub OAuth App](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app)
    in your organization settings page.
 
-2. When creating the OAuth App, specify the following path as callback URL: `https://<your-deployment-domain-name>/oauth/callback/github` (replace `<your-deployment-domain-name>` with the domain name of your deployment).
+1.  When creating the OAuth App, specify the following path as callback URL: `https://<your-deployment-domain-name>/oauth/callback/github` (replace `<your-deployment-domain-name>` with the domain name of your deployment).
 
-3. Include the following variables in the backend environment configuration:
+1.  Include the following variables in the backend environment configuration:
 
    - `TOWER_GITHUB_CLIENT`: The client ID provided by GitHub when registering the new OAuth App.
    - `TOWER_GITHUB_SECRET`: The client secret provided by GitHub when registering the new OAuth App.
@@ -56,13 +56,13 @@ To use GitHub as SSO provider for Seqera:
 
 To use Google as the identity provider for Seqera:
 
-1. Visit the [Google Cloud console](https://console.developers.google.com) and create a new project.
-2. From the sidebar, select the **Credentials** tab.
-3. Select **Create credentials > OAuth client ID**.
-4. On the next page, select **Web Application** type.
-5. Enter the redirect URL: `https://<your-deployment-domain-name>/oauth/callback/google` (replace `<{your-deployment-domain-name>` with the domain name of your deployment).
-6. Confirm the operation. You'll then receive a `client ID` and `secret ID`.
-7. Include the `client ID` and `secret ID` in the following variables in the Seqera backend environment configuration:
+1.  Visit the [Google Cloud console](https://console.developers.google.com) and create a new project.
+1.  From the sidebar, select the **Credentials** tab.
+1.  Select **Create credentials > OAuth client ID**.
+1.  On the next page, select **Web Application** type.
+1.  Enter the redirect URL: `https://<your-deployment-domain-name>/oauth/callback/google` (replace `<{your-deployment-domain-name>` with the domain name of your deployment).
+1.  Confirm the operation. You'll then receive a `client ID` and `secret ID`.
+1.  Include the `client ID` and `secret ID` in the following variables in the Seqera backend environment configuration:
 
 - `TOWER_GOOGLE_CLIENT`: The client ID provided by Google above.
 - `TOWER_GOOGLE_SECRET`: The client secret provided by Google above.
@@ -71,9 +71,9 @@ To use Google as the identity provider for Seqera:
 
 To use [Keycloak](https://www.keycloak.org/) as the identity provider for Seqera, configure a new client in your Keycloak service with these steps:
 
-1. In the **Realm settings**, ensure the **Endpoints** field includes _OpenID Endpoint Configuration_.
-2. Open the **Client** page and select **Create** to set up a new client for Seqera.
-3. In the **Settings** tag, include the following fields:
+1.  In the **Realm settings**, ensure the **Endpoints** field includes _OpenID Endpoint Configuration_.
+1.  Open the **Client** page and select **Create** to set up a new client for Seqera.
+1.  In the **Settings** tag, include the following fields:
    - **Client Id**: An ID of your choice, e.g., `seqera`
    - **Enabled**: `ON`
    - **Client Protocol**: `openid-connect`
@@ -82,10 +82,10 @@ To use [Keycloak](https://www.keycloak.org/) as the identity provider for Seqera
    - **Implicit Flow Enabled**: `OFF`
    - **Direct Access Grants Enabled**: `ON`
    - **Valid Redirect URIs**: https:///\<YOUR HOST\>//oauth/callback/oidc, e.g., `http://localhost:8000/oauth/callback/oidc`
-4. Select **Save**.
-5. In the **Credentials** tab, note the **Secret** field.
-6. In the **Keys** tab, set the field **Use JWKS URL** to `OFF`.
-7. Complete the setup in Seqera by adding the following environment variables to your configuration:
+1.  Select **Save**.
+1.  In the **Credentials** tab, note the **Secret** field.
+1.  In the **Keys** tab, set the field **Use JWKS URL** to `OFF`.
+1.  Complete the setup in Seqera by adding the following environment variables to your configuration:
 
    - `TOWER_OIDC_CLIENT`: The client ID assigned in step 3 above.
    - `TOWER_OIDC_SECRET`: The contents of the **Secret** field noted in step 5 above.
@@ -95,35 +95,35 @@ To use [Keycloak](https://www.keycloak.org/) as the identity provider for Seqera
 
 To use [Entra ID OIDC](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc) as the identity provider for Seqera, configure a new client in your Entra ID service:
 
-1. Log in to the [Azure portal](https://portal.azure.com/).
-2. Go to the **Entra ID** service.
-3. Select **Manage Tenants**.
-4. Create a new **Tenant**, e.g., `SeqeraOrg`.
-5. Select the new tenant.
-6. Go to **App Registrations**.
-7. Select **New Registration** and specify the following:
+1.  Log in to the [Azure portal](https://portal.azure.com/).
+1.  Go to the **Entra ID** service.
+1.  Select **Manage Tenants**.
+1.  Create a new **Tenant**, e.g., `SeqeraOrg`.
+1.  Select the new tenant.
+1.  Go to **App Registrations**.
+1.  Select **New Registration** and specify the following:
 
-   1. A name for the application.
-   2. The scope of user verification (e.g., single tenant, multi-tenant, personal MSFT accounts, etc).
+   1.  A name for the application.
+   2.  The scope of user verification (e.g., single tenant, multi-tenant, personal MSFT accounts, etc).
 
 :::note
 The Entra ID app must have user consent settings configured to **Allow user consent for apps** to ensure that admin approval is not required for each application login. See [User consent settings](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/configure-user-consent?pivots=portal#configure-user-consent-settings).
 :::
 
-8. Specify the **Redirect** (callback) URI.
+1.  Specify the **Redirect** (callback) URI.
 
 :::note
 This must be an `https://` URI, per Microsoft's requirements.
 :::
 
-9. Open the newly-created app:
+1.  Open the newly-created app:
 
-   1. Note the `Application (client) ID` on the **Essentials** table.
-   2. Generate **Client credentials** on the **Essentials** table.
-   3. Select **Endpoints** and note the OpenID Connect metadata document URI.
+   1.  Note the `Application (client) ID` on the **Essentials** table.
+   2.  Generate **Client credentials** on the **Essentials** table.
+   3.  Select **Endpoints** and note the OpenID Connect metadata document URI.
 
-10. Add users to your tenant as required.
-11. Complete the setup in Seqera by adding the following environment variables to your configuration:
+1.  Add users to your tenant as required.
+1.  Complete the setup in Seqera by adding the following environment variables to your configuration:
 
     ```bash
     TOWER_OIDC_CLIENT=<YOUR_APPLICATION_ID>
@@ -131,26 +131,26 @@ This must be an `https://` URI, per Microsoft's requirements.
     TOWER_OIDC_ISSUER=<YOUR_OIDC_METADATA_URL_UP_TO_"v2.0">   (e.g. https://login.microsoftonline.com/000000-0000-0000-00-0000000000000/v2.0)
     ```
 
-12. Add `auth-oidc` to the `MICRONAUT_ENVIRONMENTS` environment variable for both the `cron` and `backend` services.
+1.  Add `auth-oidc` to the `MICRONAUT_ENVIRONMENTS` environment variable for both the `cron` and `backend` services.
 
 ### Okta identity provider
 
 To use [Okta](https://www.okta.com/) as the identity provider for Seqera:
 
-1. Sign in to your Okta organization with your administrator account.
-2. From the **Admin Console** side navigation, select **Applications > Applications**.
-3. Select **Add Application**.
-4. Select **Create New App**.
-5. Select the **OpenID Connect** sign-on method.
-6. Select **Create**.
-7. Enter a name for your new app integration, e.g., `Seqera`.
-8. In **Configure OpenID Connect**, add the following redirect URIs:
+1.  Sign in to your Okta organization with your administrator account.
+1.  From the **Admin Console** side navigation, select **Applications > Applications**.
+1.  Select **Add Application**.
+1.  Select **Create New App**.
+1.  Select the **OpenID Connect** sign-on method.
+1.  Select **Create**.
+1.  Enter a name for your new app integration, e.g., `Seqera`.
+1.  In **Configure OpenID Connect**, add the following redirect URIs:
 
    - **Sign-in redirect URIs** : `https://<YOUR HOST OR IP>/oauth/callback/oidc`
    - **Sign-out redirect URIs** : `https://<YOUR HOST OR IP>/logout`
 
-9. Select **Save**.
-10. Okta automatically redirects to your new application settings. Complete the setup in Seqera by adding the following environment variables to your configuration:
+1.  Select **Save**.
+1.  Okta automatically redirects to your new application settings. Complete the setup in Seqera by adding the following environment variables to your configuration:
 
     - `TOWER_OIDC_CLIENT`: Copy the **Client ID** value from **General > Client Credentials** for the corresponding app client configuration.
     - `TOWER_OIDC_SECRET`: Copy the **Client secret** value from **General > Client Credentials** for the corresponding app client configuration.

--- a/platform_versioned_docs/version-23.4.0/enterprise/configuration/aws_parameter_store.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/configuration/aws_parameter_store.mdx
@@ -31,10 +31,10 @@ Due to the order of operations when deploying Seqera Enterprise, some configurat
 
 To enable Seqera use AWS Parameter Store values:
 
-1. Grant [AWS Parameter Store permissions](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html) to your Seqera host instance.
-2. Add `TOWER_ENABLE_AWS_SSM=true` in the `tower.env` configuration file.
-3. Create individual parameters in the AWS Parameter Store (see below).
-4. Start your Seqera instance and confirm the following entries appear in the **backend** container log:
+1.  Grant [AWS Parameter Store permissions](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html) to your Seqera host instance.
+1.  Add `TOWER_ENABLE_AWS_SSM=true` in the `tower.env` configuration file.
+1.  Create individual parameters in the AWS Parameter Store (see below).
+1.  Start your Seqera instance and confirm the following entries appear in the **backend** container log:
 
 ```bash
 [main] - INFO  i.m.context.DefaultBeanContext - Reading bootstrap environment configuration
@@ -51,8 +51,8 @@ Seqera does not support StringList parameters. Configuration parameters with mul
 
 To create Seqera configuration parameters in AWS Parameter Store, do the following:
 
-1. Navigate to the **Parameter Store** from the **AWS Systems Manager Service** console.
-2. From the **My parameters** tab, select **Create parameter** and populate as follows:
+1.  Navigate to the **Parameter Store** from the **AWS Systems Manager Service** console.
+1.  From the **My parameters** tab, select **Create parameter** and populate as follows:
 
 | Field | Description |
 | ----- | ----------- |

--- a/platform_versioned_docs/version-23.4.0/enterprise/configuration/overview.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/configuration/overview.mdx
@@ -465,13 +465,13 @@ Simple Email Service (SES) is only supported in Seqera deployments on AWS.
 
 To configure AWS SES as your Seqera email service:
 
-1. Set `TOWER_ENABLE_AWS_SES=true` in your environment variables.
-2. Specify the email address used to send Seqera emails with one of the following:
+1.  Set `TOWER_ENABLE_AWS_SES=true` in your environment variables.
+1.  Specify the email address used to send Seqera emails with one of the following:
     - the `TOWER_CONTACT_EMAIL` environment variable
     - a `mail.from` entry in `tower.yml`
     - a `/config/<application_name>/mail/from` AWS Parameter Store entry
-3. The [AWS SES service](https://docs.aws.amazon.com/ses/index.html) must run in the same region as your Seqera instance.
-4. The [Seqera IAM role](../../compute-envs/aws-batch.mdx#iam) must include the `ses:SendRawEmail` permission.
+1.  The [AWS SES service](https://docs.aws.amazon.com/ses/index.html) must run in the same region as your Seqera instance.
+1.  The [Seqera IAM role](../../compute-envs/aws-batch.mdx#iam) must include the `ses:SendRawEmail` permission.
 
 ## Nextflow launch container
 

--- a/platform_versioned_docs/version-23.4.0/enterprise/configuration/pipeline_optimization.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/configuration/pipeline_optimization.mdx
@@ -17,29 +17,29 @@ Docker Compose makes use of a separate container to set up the pipeline resource
 
 To use the pipeline resource optimization service in a new Docker Compose installation of Seqera Enterprise, use the following steps:
 
-1. To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable in `tower.env`. A non-zero value for this environment variable activates the optimization service automatically, so `TOWER_ENABLE_GROUNDSWELL` does not need to be set when you declare a custom URL.
+1.  To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable in `tower.env`. A non-zero value for this environment variable activates the optimization service automatically, so `TOWER_ENABLE_GROUNDSWELL` does not need to be set when you declare a custom URL.
 
-2. Set the `TOWER_ENABLE_GROUNDSWELL` environment variable in `tower.env` to `true`. This enables the service at the default service URL `http://groundswell:8090`.
+1.  Set the `TOWER_ENABLE_GROUNDSWELL` environment variable in `tower.env` to `true`. This enables the service at the default service URL `http://groundswell:8090`.
 
-3. In your [docker-compose.yml](../_templates/docker/docker-compose.yml) file, uncomment the `groundswell` section at the bottom.
+1.  In your [docker-compose.yml](../_templates/docker/docker-compose.yml) file, uncomment the `groundswell` section at the bottom.
 
     - To create a schema for the optimization service on the same local MySQL container, uncomment the `init.sql` script in the `volumes` section.
 
-4. Download the [init.sql](../_templates/docker/init.sql) file. Store this file in the mount path of your `docker-compose.yml` file, else update the `source: ./init.sql` line in your `docker-compose.yml` with the file path.
+1.  Download the [init.sql](../_templates/docker/init.sql) file. Store this file in the mount path of your `docker-compose.yml` file, else update the `source: ./init.sql` line in your `docker-compose.yml` with the file path.
 
-5. When the pipeline resource optimization service is active, pipelines that can be optimized display a lightbulb icon in your Launchpad. Any pipeline with at least one successful run can be optimized.
+1.  When the pipeline resource optimization service is active, pipelines that can be optimized display a lightbulb icon in your Launchpad. Any pipeline with at least one successful run can be optimized.
 
 ### Existing installation
 
 To use the pipeline resource optimization service in an existing Docker Compose installation of Seqera Enterprise, use the following steps:
 
-1. To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable. A non-zero value for this environment variable activates the optimization service automatically, so `TOWER_ENABLE_GROUNDSWELL` does not need to be set when you declare a custom URL.
+1.  To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable. A non-zero value for this environment variable activates the optimization service automatically, so `TOWER_ENABLE_GROUNDSWELL` does not need to be set when you declare a custom URL.
 
-2. Set the `TOWER_ENABLE_GROUNDSWELL` environment variable to `true`. This enables the service at the default service URL `http://groundswell:8090`.
+1.  Set the `TOWER_ENABLE_GROUNDSWELL` environment variable to `true`. This enables the service at the default service URL `http://groundswell:8090`.
 
-3. In your [docker-compose.yml](../_templates/docker/docker-compose.yml) file, uncomment the `groundswell` section at the bottom. If you use a `docker-compose.yml` file older than version 23.3, download a newer version of the file to extract the `groundswell` section.
+1.  In your [docker-compose.yml](../_templates/docker/docker-compose.yml) file, uncomment the `groundswell` section at the bottom. If you use a `docker-compose.yml` file older than version 23.3, download a newer version of the file to extract the `groundswell` section.
 
-4. Log in to your database server and run the following commands:
+1.  Log in to your database server and run the following commands:
 
     ```sql
     CREATE DATABASE IF NOT EXISTS `swell`;
@@ -48,7 +48,7 @@ To use the pipeline resource optimization service in an existing Docker Compose 
     FLUSH PRIVILEGES;
     ```
 
-5. If you use Amazon RDS or other managed database services, run the following commands in your database instance:
+1.  If you use Amazon RDS or other managed database services, run the following commands in your database instance:
 
     ```sql
     CREATE DATABASE IF NOT EXISTS `swell`;
@@ -57,7 +57,7 @@ To use the pipeline resource optimization service in an existing Docker Compose 
     FLUSH PRIVILEGES;
     ```
 
-6. Download the [groundswell.env](../_templates/docker/groundswell.env) file. Store this file in the mount path of your `docker-compose.yml` file. Update the `TOWER_DB_URL` and `SWELL_DB_URL` values:
+1.  Download the [groundswell.env](../_templates/docker/groundswell.env) file. Store this file in the mount path of your `docker-compose.yml` file. Update the `TOWER_DB_URL` and `SWELL_DB_URL` values:
 
     ```env
     # Uncomment for container DB instances
@@ -69,17 +69,17 @@ To use the pipeline resource optimization service in an existing Docker Compose 
     # SWELL_DB_URL=mysql://db1.abcdefghijkl.us-east-1.rds.amazonaws.com:3306/swell
     ```
 
-7. When the pipeline resource optimization service is active, pipelines that can be optimized display a lightbulb icon in your Launchpad. Any pipeline with at least one successful run can be optimized.
+1.  When the pipeline resource optimization service is active, pipelines that can be optimized display a lightbulb icon in your Launchpad. Any pipeline with at least one successful run can be optimized.
 
 ## Kubernetes deployment
 
 Kubernetes deployments use an [initContainer](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that runs during pod initialization to set up the pipeline resource optimization service. To use the service in new or existing Kubernetes installations of Seqera Enterprise, do the following:
 
-1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml).
+1.  Download the [groundswell manifest](../_templates/k8s/groundswell.yml).
 
-2. Define a set of credentials for the optimization database. This can be the same database used for Seqera, but in a different schema.
+1.  Define a set of credentials for the optimization database. This can be the same database used for Seqera, but in a different schema.
 
-3. Log in to your database server and run the following commands:
+1.  Log in to your database server and run the following commands:
 
     ```sql
     CREATE DATABASE IF NOT EXISTS `swell`;
@@ -88,7 +88,7 @@ Kubernetes deployments use an [initContainer](https://kubernetes.io/docs/concept
     FLUSH PRIVILEGES;
     ```
 
-4. If you use Amazon RDS or other managed database services, run the following commands in your database instance:
+1.  If you use Amazon RDS or other managed database services, run the following commands in your database instance:
 
     ```sql
     CREATE DATABASE IF NOT EXISTS `swell`;
@@ -97,6 +97,6 @@ Kubernetes deployments use an [initContainer](https://kubernetes.io/docs/concept
     FLUSH PRIVILEGES;
     ```
 
-5. The initContainers process will wait until both the Seqera and pipeline resource optimization service databases are ready before starting the migration in the Seqera database and finally starting the optimization container.
+1.  The initContainers process will wait until both the Seqera and pipeline resource optimization service databases are ready before starting the migration in the Seqera database and finally starting the optimization container.
 
-6. When the pipeline resource optimization service is active, pipelines that can be optimized display a lightbulb icon in your Launchpad. Any pipeline with at least one successful run can be optimized.
+1.  When the pipeline resource optimization service is active, pipelines that can be optimized display a lightbulb icon in your Launchpad. Any pipeline with at least one successful run can be optimized.

--- a/platform_versioned_docs/version-23.4.0/enterprise/configuration/reverse_proxy.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/configuration/reverse_proxy.mdx
@@ -11,13 +11,13 @@ As of February 2024, this configuration guide is not currently recommended for p
 
 To expose your Seqera instance behind a reverse proxy, complete the following steps:
 
-1. Use the [Seqera frontend unprivileged](../kubernetes.mdx#seqera-frontend-unprivileged) image.
-2. Add `TOWER_BASE_PATH` to the environment variables of the frontend container:
+1.  Use the [Seqera frontend unprivileged](../kubernetes.mdx#seqera-frontend-unprivileged) image.
+1.  Add `TOWER_BASE_PATH` to the environment variables of the frontend container:
    - `TOWER_BASE_PATH: "/myseqera/"` exposes your instance at `https://example.com/myseqera/` (this must match your proxy configuration)
-3. In the backend/cron environment variables or in the Seqera config file, edit the following environment variables:
+1.  In the backend/cron environment variables or in the Seqera config file, edit the following environment variables:
    - Set `TOWER_SERVER_URL` to the complete URL where you want to expose your instance, e.g., `TOWER_SERVER_URL: "https://example.com/myseqera"` (without the trailing slash)
    - Disable/unset `TOWER_LANDING_URL`
-4. Configure your reverse proxy to redirect all Seqera-related links to your Seqera frontend container:
+1.  Configure your reverse proxy to redirect all Seqera-related links to your Seqera frontend container:
 
 - If your frontend container listens on `http://tower-frontend:8080` and you're using Apache HTTP as your reverse proxy, add the following lines at the end of your configuration file (replace `/myseqera/` with the URL you defined in `TOWER_BASE_PATH`):
 

--- a/platform_versioned_docs/version-23.4.0/enterprise/configuration/ssl_tls.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/configuration/ssl_tls.mdx
@@ -18,19 +18,19 @@ If you secure related infrastructure (such as private Git repositories) with cer
 
 **Configure private certificate trust**
 
-1. This guide assumes you're using the original containers supplied by Seqera.
-2. Replace `TARGET_HOSTNAME`, `TARGET_ALIAS`, and `PRIVATE_CERT.pem` with your unique values.
-3. Previous instructions advised using `openssl`. The native `keytool` utility is preferred as it simplifies steps and better accommodates private CA certificates.
+1.  This guide assumes you're using the original containers supplied by Seqera.
+1.  Replace `TARGET_HOSTNAME`, `TARGET_ALIAS`, and `PRIVATE_CERT.pem` with your unique values.
+1.  Previous instructions advised using `openssl`. The native `keytool` utility is preferred as it simplifies steps and better accommodates private CA certificates.
 
 **Use Docker volume**
 
-1. Retrieve the private certificate on your Seqera container host:
+1.  Retrieve the private certificate on your Seqera container host:
 
 ```
 keytool -printcert -rfc -sslserver TARGET_HOSTNAME:443  >  /PRIVATE_CERT.pem
 ```
 
-2. Modify the `backend` and `cron` container configuration blocks in `docker-compose.yml`:
+1.  Modify the `backend` and `cron` container configuration blocks in `docker-compose.yml`:
 
 ```yaml
 CONTAINER_NAME:
@@ -52,19 +52,19 @@ CONTAINER_NAME:
 
 **Use K8s ConfigMap**
 
-1. Retrieve the private certificate on a machine with CLI access to your Kubernetes cluster:
+1.  Retrieve the private certificate on a machine with CLI access to your Kubernetes cluster:
 
 ```bash
 keytool -printcert -rfc -sslserver TARGET_HOSTNAME:443 > /PRIVATE_CERT.pem
 ```
 
-2. Load the certificate as a `ConfigMap` in the same namespace where your Seqera instance will run:
+1.  Load the certificate as a `ConfigMap` in the same namespace where your Seqera instance will run:
 
 ```bash
 kubectl create configmap private-cert-pemstore --from-file=/PRIVATE_CERT.pem
 ```
 
-3. Modify both the `backend` and `cron` Deployment objects:
+1.  Modify both the `backend` and `cron` Deployment objects:
 
 - Define a new volume based on the certificate `ConfigMap`:
 
@@ -110,7 +110,7 @@ kubectl create configmap private-cert-pemstore --from-file=/PRIVATE_CERT.pem
 
 **Download on Pod start**
 
-1. Modify both the `backend` and `cron` Deployment objects to retrieve and load the certificate prior to running your Seqera instance:
+1.  Modify both the `backend` and `cron` Deployment objects to retrieve and load the certificate prior to running your Seqera instance:
 
 ```yaml
 spec:
@@ -133,9 +133,9 @@ If you secure infrastructure such as private Git repositories or your Seqera Ent
 
 **Import private certificates via pre-run script**
 
-1. This configuration assumes you're using the default `nf-launcher` image supplied by Seqera.
-2. Replace `TARGET_HOSTNAME`, `TARGET_ALIAS`, and `PRIVATE_CERT.pem` with your unique values.
-3. Previous instructions advised using `openssl`. The native `keytool` utility is preferred as it simplifies steps and better accommodates private CA certificates.
+1.  This configuration assumes you're using the default `nf-launcher` image supplied by Seqera.
+1.  Replace `TARGET_HOSTNAME`, `TARGET_ALIAS`, and `PRIVATE_CERT.pem` with your unique values.
+1.  Previous instructions advised using `openssl`. The native `keytool` utility is preferred as it simplifies steps and better accommodates private CA certificates.
 
 Add the following to your compute environment [pre-run script](../../launch/advanced.mdx#pre-and-post-run-scripts):
 

--- a/platform_versioned_docs/version-23.4.0/enterprise/docker-compose.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/docker-compose.mdx
@@ -15,25 +15,25 @@ The DB or Redis volume is persistent after a Docker restart by default. Use the 
 
 ## Deploy Seqera Enterprise
 
-1. Download and configure [tower.env](_templates/docker/tower.env). See [Configuration](../enterprise/configuration/overview.mdx#basic-configuration) for detailed instructions.
+1.  Download and configure [tower.env](_templates/docker/tower.env). See [Configuration](../enterprise/configuration/overview.mdx#basic-configuration) for detailed instructions.
 
-2. Download and configure [tower.yml](_templates/docker/tower.yml). See [Configuration](../enterprise/configuration/overview.mdx#basic-configuration) for detailed instructions.
+1.  Download and configure [tower.yml](_templates/docker/tower.yml). See [Configuration](../enterprise/configuration/overview.mdx#basic-configuration) for detailed instructions.
 
-3. Download and configure the [docker-compose.yml](_templates/docker/docker-compose.yml) file:
+1.  Download and configure the [docker-compose.yml](_templates/docker/docker-compose.yml) file:
 
       - The `db` and `mail` containers should only be used for local testing. If you have configured these services elsewhere, you can remove these containers.
 
       - To configure the Seqera pipeline resource optimization service (`groundswell`), see [Pipeline resource optimization](./configuration/pipeline_optimization.mdx).
 
-4. Deploy the application and wait for it to initialize (this process takes a few minutes):
+1.  Deploy the application and wait for it to initialize (this process takes a few minutes):
 
       ```bash
       docker compose up
       ```
 
-5. [Test](./testing.mdx) the application by running an nf-core pipeline with a test profile.
+1.  [Test](./testing.mdx) the application by running an nf-core pipeline with a test profile.
 
-6. After you've confirmed that Seqera Enterprise is correctly configured and you can launch workflows, run `docker compose up -d` to deploy the application as a background process. You can then disconnect from the VM instance.
+1.  After you've confirmed that Seqera Enterprise is correctly configured and you can launch workflows, run `docker compose up -d` to deploy the application as a background process. You can then disconnect from the VM instance.
 
 :::note
 For more information on configuration, see [Configuration options](./configuration/overview.mdx).

--- a/platform_versioned_docs/version-23.4.0/enterprise/index.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/index.mdx
@@ -73,15 +73,15 @@ _Reference architecture diagram of Seqera Platform Enterprise on AWS using Elast
 Seqera Enterprise is distributed as a collection of Docker containers available through the Seqera
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. When you've received your credentials, retrieve the application container images with these steps:
 
-1. Retrieve the `name` and `secret` values from the JSON file you received from Seqera support.
+1.  Retrieve the `name` and `secret` values from the JSON file you received from Seqera support.
 
-2. Authenticate to the registry by using the `name` and `secret` values copied in the previous step:
+1.  Authenticate to the registry by using the `name` and `secret` values copied in the previous step:
 
    ```bash
    docker login -u '<NAME>' -p '<SECRET>' cr.seqera.io
    ```
 
-3. Pull the application container images:
+1.  Pull the application container images:
 
    ```bash
    docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v23.4.3

--- a/platform_versioned_docs/version-23.4.0/enterprise/kubernetes.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/kubernetes.mdx
@@ -19,13 +19,13 @@ Complete the following procedures to install Seqera Enterprise on a Kubernetes c
 
 Create a namespace for the Seqera resources.
 
-1. Create the namespace (e.g., `seqera-nf`):
+1.  Create the namespace (e.g., `seqera-nf`):
 
     ```bash
     kubectl create namespace seqera-nf
     ```
 
-2. Switch to the namespace:
+1.  Switch to the namespace:
 
     ```bash
     kubectl config set-context --current --namespace=seqera-nf
@@ -35,9 +35,9 @@ Create a namespace for the Seqera resources.
 
 Seqera Platform Enterprise is distributed as a collection of Docker containers available through the Seqera container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. After you've received your credentials, grant your cluster access to the registry:
 
-1. Retrieve the `name` and `secret` values from the JSON file that you received from Seqera support.
+1.  Retrieve the `name` and `secret` values from the JSON file that you received from Seqera support.
 
-2. Create a [secret](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/) with the `name` and `secret` values retrieved in the previous step:
+1.  Create a [secret](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/) with the `name` and `secret` values retrieved in the previous step:
 
     ```bash
     kubectl create secret docker-registry cr.seqera.io \
@@ -48,7 +48,7 @@ Seqera Platform Enterprise is distributed as a collection of Docker containers a
 
     The credential `name` contains a dollar `$` character. To prevent the Linux shell from interpreting this value as an environment variable, you must wrap it in single quotes.
 
-3. Configure the Seqera cron service and the application frontend and backend to use the secret created in the previous step (see [tower-cron.yml](./_templates/k8s/tower-cron.yml) and [tower-svc.yml](./_templates/k8s/tower-svc.yml)):
+1.  Configure the Seqera cron service and the application frontend and backend to use the secret created in the previous step (see [tower-cron.yml](./_templates/k8s/tower-cron.yml) and [tower-svc.yml](./_templates/k8s/tower-svc.yml)):
 
     ```yaml
     imagePullSecrets:
@@ -59,9 +59,9 @@ Seqera Platform Enterprise is distributed as a collection of Docker containers a
 
 ### Seqera ConfigMap
 
-1. Download and configure a [ConfigMap](_templates/k8s/configmap.yml) as detailed on the [configuration](configuration/overview.mdx) page.
+1.  Download and configure a [ConfigMap](_templates/k8s/configmap.yml) as detailed on the [configuration](configuration/overview.mdx) page.
 
-2. Deploy the ConfigMap to your cluster:
+1.  Deploy the ConfigMap to your cluster:
 
     ```bash
     kubectl apply -f configmap.yml
@@ -77,7 +77,7 @@ Seqera Enterprise requires a Redis database for caching purposes. Configure Redi
 
 **Deploy a Redis manifest to your cluster**
 
-1. Download the appropriate manifest for your infrastructure:
+1.  Download the appropriate manifest for your infrastructure:
 
     - [Azure AKS](_templates/k8s/redis.aks.yml)
 
@@ -85,7 +85,7 @@ Seqera Enterprise requires a Redis database for caching purposes. Configure Redi
 
     - [Google Kubernetes Engine](_templates/k8s/redis.gke.yml)
 
-2. Deploy to your cluster:
+1.  Deploy to your cluster:
 
     ```bash
     kubectl apply -f redis.*.yml
@@ -137,9 +137,9 @@ If you run the Redis service as a container as part of your Docker or Kubernetes
 
 ### Seqera cron service
 
-1. Download the [cron service manifest](_templates/k8s/tower-cron.yml) file.
+1.  Download the [cron service manifest](_templates/k8s/tower-cron.yml) file.
 
-2. Deploy the manifest to your cluster:
+1.  Deploy the manifest to your cluster:
 
   ```bash
   kubectl apply -f tower-cron.yml
@@ -151,9 +151,9 @@ This container creates the required database schema the first time it instantiat
 
 ### Seqera frontend and backend
 
-1. Download the [manifest](_templates/k8s/tower-svc.yml).
+1.  Download the [manifest](_templates/k8s/tower-svc.yml).
 
-2. Deploy the manifest to your cluster:
+1.  Deploy the manifest to your cluster:
 
   ```bash
   kubectl apply -f tower-svc.yml
@@ -241,21 +241,21 @@ kubectl get pods
 
 To confirm that Seqera Enterprise is properly configured, follow these steps:
 
-1. Log in to your Seqera instance.
+1.  Log in to your Seqera instance.
 
-2. Create an **organization**.
+1.  Create an **organization**.
 
-3. Create a **workspace** within that organization.
+1.  Create a **workspace** within that organization.
 
-4. Create a new **Compute environment**. See [Compute environments](../compute-envs/overview.mdx) for detailed instructions.
+1.  Create a new **Compute environment**. See [Compute environments](../compute-envs/overview.mdx) for detailed instructions.
 
-5. Select **Quick Launch** from the **Launchpad** tab in your workspace.
+1.  Select **Quick Launch** from the **Launchpad** tab in your workspace.
 
-6. Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
+1.  Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
 
-7. In the **Config profiles** dropdown, select the `test` profile.
+1.  In the **Config profiles** dropdown, select the `test` profile.
 
-8. In **Pipeline parameters**, change the output directory to a location based on your compute environment:
+1.  In **Pipeline parameters**, change the output directory to a location based on your compute environment:
 
     ```yaml
     # save to S3 bucket
@@ -265,7 +265,7 @@ To confirm that Seqera Enterprise is properly configured, follow these steps:
     outdir: /scratch/results
     ```
 
-9. Select **Launch**; you'll be redirected to the **Runs** tab for the workflow. After a few minutes, progress logs will be listed in that workflow's **Execution log** tab.
+1.  Select **Launch**; you'll be redirected to the **Runs** tab for the workflow. After a few minutes, progress logs will be listed in that workflow's **Execution log** tab.
 
 ## Optional features
 
@@ -281,19 +281,19 @@ The initContainers will wait until both the Seqera and pipeline optimization ser
 
 The included [dbconsole.yml](_templates/k8s/dbconsole.yml) manifest can be used to deploy a simple web frontend to the Seqera database. Though not required, this can be useful for administrative purposes.
 
-1. Deploy the database console:
+1.  Deploy the database console:
 
   ```bash
   kubectl apply -f dbconsole.yml
   ```
 
-2. Enable a port-forward for the database console to your local machine:
+1.  Enable a port-forward for the database console to your local machine:
 
   ```bash
   kubectl port-forward deployment/dbconsole 8080:8080
   ```
 
-3. Access the database console in a web browser at `http://localhost:8080`.
+1.  Access the database console in a web browser at `http://localhost:8080`.
 
 ### High availability
 

--- a/platform_versioned_docs/version-23.4.0/enterprise/prerequisites/aws.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/prerequisites/aws.mdx
@@ -60,8 +60,8 @@ If you're installing Seqera Enterprise with Kubernetes, an [Elastic Kubernetes S
 
 **The ingress that we provide for EKS assumes that your cluster supports:**
 
-1. ALB provisioning via the [AWS Load Balancer Controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
-2. ALB integration with the [Amazon Certificate Manager](https://aws.amazon.com/certificate-manager/)
+1.  ALB provisioning via the [AWS Load Balancer Controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
+1.  ALB integration with the [Amazon Certificate Manager](https://aws.amazon.com/certificate-manager/)
 
 Additionally, the ingress assumes the presence of SSL certificates, DNS resolution, and ALB logging. If you've chosen not to use some or all of these features, you'll need to modify the manifest accordingly before applying it to the cluster.
 
@@ -70,15 +70,15 @@ Additionally, the ingress assumes the presence of SSL certificates, DNS resoluti
 Seqera Platform Enterprise is distributed as a collection of Docker containers available through the Seqera
 container registry ([cr.seqera.io](https://cr.seqera.io)). Contact [support](https://support.seqera.io) to get your container access credentials. Once you've received your credentials, retrieve the Seqera container images:
 
-1. Retrieve the **username** and **password** you received from Seqera support.
+1.  Retrieve the **username** and **password** you received from Seqera support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    ```bash
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
    ```
 
-3. Pull the Seqera container images with the following commands:
+1.  Pull the Seqera container images with the following commands:
 
    ```bash
    docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v23.4.3
@@ -96,17 +96,17 @@ This section provides step-by-step instructions for some commonly used AWS servi
 
 From version 23.1, you can retrieve Seqera Enterprise configuration values remotely from the AWS Parameter Store:
 
-1. Configure [AWS authentication](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html) to grant AWS Parameter Store access on your local host.
-2. Retrieve the Seqera container images and install the application using the instructions at the top of this page.
-3. The default value for `tower.application.name` is `tower-app`. This can be changed in your `tower.yml` configuration file. Note that your application name must be specified in the path to your configuration values in AWS Parameter Store (see step 5 below).
-4. Set the `TOWER_ENABLE_AWS_SSM` environment variable to `true`.
-5. Add configuration parameters to the AWS Parameter Store individually, using the format `/config/<application_name>/<cfg_path> : <cfg_value>`. For example:
+1.  Configure [AWS authentication](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html) to grant AWS Parameter Store access on your local host.
+1.  Retrieve the Seqera container images and install the application using the instructions at the top of this page.
+1.  The default value for `tower.application.name` is `tower-app`. This can be changed in your `tower.yml` configuration file. Note that your application name must be specified in the path to your configuration values in AWS Parameter Store (see step 5 below).
+1.  Set the `TOWER_ENABLE_AWS_SSM` environment variable to `true`.
+1.  Add configuration parameters to the AWS Parameter Store individually, using the format `/config/<application_name>/<cfg_path> : <cfg_value>`. For example:
 
    ```bash
    /config/tower-app/tower.logger.levels.com.amazonaws : "WARN"
    ```
 
-6. Start or restart your Seqera instance to confirm that the configuration value is fetched. The following entries should appear in your backend log:
+1.  Start or restart your Seqera instance to confirm that the configuration value is fetched. The following entries should appear in your backend log:
 
    ```bash
    [main] - INFO  i.m.context.DefaultBeanContext - Reading bootstrap environment configuration
@@ -119,25 +119,25 @@ From version 23.1, you can retrieve Seqera Enterprise configuration values remot
 If you use Simple Email Service in sandbox mode, both the _sender_ and the _receiver_ email addresses must be verified via AWS SES. Sandbox is not recommended for production use. See the [AWS docs](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) for instructions to move out of the sandbox.
 :::
 
-1. Go to the [**Amazon Simple Email Service**](https://us-east-2.console.aws.amazon.com/ses) console.
+1.  Go to the [**Amazon Simple Email Service**](https://us-east-2.console.aws.amazon.com/ses) console.
 
-2. In the navigation menu, select **SMTP Settings**.
+1.  In the navigation menu, select **SMTP Settings**.
 
-3. Select **Create my SMTP Credentials**
+1.  Select **Create my SMTP Credentials**
 
-4. Select **Create**.
+1.  Select **Create**.
 
-5. Select **Show User SMTP Credentials** to copy your credentials, or select **Download Credentials**.
+1.  Select **Show User SMTP Credentials** to copy your credentials, or select **Download Credentials**.
 
 **The credentials (username and password) will not be shown to you again after this instance.**
 
-6. You will be automatically redirected to the IAM dashboard. Log back in to the [Amazon SES Console](https://us-east-2.console.aws.amazon.com/ses).
+1.  You will be automatically redirected to the IAM dashboard. Log back in to the [Amazon SES Console](https://us-east-2.console.aws.amazon.com/ses).
 
-7. Select **Email Addresses** in the navigation menu. Then, select **Verify a new Email Address**.
+1.  Select **Email Addresses** in the navigation menu. Then, select **Verify a new Email Address**.
 
-8. A pop-up asking for your email should automatically appear. Once you type in your email address and select **Verify This Email Address**, you should receive a confirmation email from Amazon SES to confirm email address ownership.
+1.  A pop-up asking for your email should automatically appear. Once you type in your email address and select **Verify This Email Address**, you should receive a confirmation email from Amazon SES to confirm email address ownership.
 
-9. Open the verification link in the message.
+1.  Open the verification link in the message.
 
 **The verification link is **only valid for 24 hours** after your original request for verification.**
 
@@ -149,76 +149,76 @@ See the AWS documentation for more options, such as setting up an [Easy DKIM for
 
 ### Amazon RDS
 
-1. Open the [Amazon RDS console](https://console.aws.amazon.com/rds/).
+1.  Open the [Amazon RDS console](https://console.aws.amazon.com/rds/).
 
-2. Select **Create database > Standard create > MySQL**.
+1.  Select **Create database > Standard create > MySQL**.
 
-3. Under **Edition**, select **MySQL Community** and any version under **5.7.x**, or **8.0.x**.
+1.  Under **Edition**, select **MySQL Community** and any version under **5.7.x**, or **8.0.x**.
 
-4. Enter the **DB cluster identifier** (e.g., `tower-db`).
+1.  Enter the **DB cluster identifier** (e.g., `tower-db`).
 
-5. Enter the **Master username**, or keep the default.
+1.  Enter the **Master username**, or keep the default.
 
-6. Enter the **Master password**.
+1.  Enter the **Master password**.
 
    - To use an automatically generated master password, select **Auto generate a password**.
    - To use a custom master password, deselect **Auto generate a password** and enter your password in **Master password** and **Confirm password**.
 
-7. Under **Instance configuration**, select the **DB instance class** and instance type.
+1.  Under **Instance configuration**, select the **DB instance class** and instance type.
 
-8. Under **Connectivity**, select the correct **VPC security group**. Confirm this with your AWS administrator.
+1.  Under **Connectivity**, select the correct **VPC security group**. Confirm this with your AWS administrator.
 
-9. Under **Additional configuration**, enter the **Initial database name** (e.g., `tower`).
+1.  Under **Additional configuration**, enter the **Initial database name** (e.g., `tower`).
 
-10. Select **Create database**.
+1.  Select **Create database**.
 
 After your database is created:
 
-1. Update the inbound rules for the underlying EC2 instance to allow MySQL connections.
+1.  Update the inbound rules for the underlying EC2 instance to allow MySQL connections.
 
-2. Update `TOWER_DB_URL` in your configuration value with the database hostname.
+1.  Update `TOWER_DB_URL` in your configuration value with the database hostname.
 
 ### Amazon EC2
 
 If you've never set up an Amazon EC2 instance for Linux, see [this guide](https://aws.amazon.com/ec2/getting-started/) to get started.
 
-1. Open the [AWS Management console](https://us-east-2.console.aws.amazon.com/console/home).
+1.  Open the [AWS Management console](https://us-east-2.console.aws.amazon.com/console/home).
 
-2. Log in as an IAM user with your credentials.
+1.  Log in as an IAM user with your credentials.
 
-3. Under **AWS services**, select **All Services**.
+1.  Under **AWS services**, select **All Services**.
 
-4. Under **Compute**, select **EC2**.
+1.  Under **Compute**, select **EC2**.
 
-5. Select **Instances**, then **Launch instances**.
+1.  Select **Instances**, then **Launch instances**.
 
-6. You will be asked to choose an Amazon Machine Image (AMI). Scroll to the middle of the page and select **Amazon Linux 2**.
+1.  You will be asked to choose an Amazon Machine Image (AMI). Scroll to the middle of the page and select **Amazon Linux 2**.
 
-7. Once you choose **Select**, you'll be redirected to **Step 2: Choose an Instance Type**.
+1.  Once you choose **Select**, you'll be redirected to **Step 2: Choose an Instance Type**.
 
-8. Scroll down and select either **c5a.xlarge** or **c5.large** — these provide 4 CPUs and 8 GB of RAM.
+1.  Scroll down and select either **c5a.xlarge** or **c5.large** — these provide 4 CPUs and 8 GB of RAM.
 
-9. Select **Next: Configure Instance Details**.
+1.  Select **Next: Configure Instance Details**.
 
-10. If required, configure the instance details settings. Then, select **Next: Add Storage**.
+1.  If required, configure the instance details settings. Then, select **Next: Add Storage**.
 
-11. The root storage should be 20GB. Configure this under **Size (GiB)**.
+1.  The root storage should be 20GB. Configure this under **Size (GiB)**.
 
-12. Select **Add Tags** (if required) to add case-sensitive key-value pairs (e.g., `key = Name` and `value = Webserver`).
+1.  Select **Add Tags** (if required) to add case-sensitive key-value pairs (e.g., `key = Name` and `value = Webserver`).
 
-13. Select **Next: Configure Security Group**.
+1.  Select **Next: Configure Security Group**.
 
-14. Enter `tower-sg` as the Security Group name.
+1.  Enter `tower-sg` as the Security Group name.
 
-15. Optionally, you can enter a description for your Security Group's name.
+1.  Optionally, you can enter a description for your Security Group's name.
 
-16. Configure the type of protocol settings. Note that the security group port must be configured to 8000.
+1.  Configure the type of protocol settings. Note that the security group port must be configured to 8000.
 
-17. Select **Review and Launch**.
+1.  Select **Review and Launch**.
 
-18. Once you have reviewed your instance, select **Launch**.
+1.  Once you have reviewed your instance, select **Launch**.
 
-19. Select an existing key pair or create a new one in the pop-up that appears.
+1.  Select an existing key pair or create a new one in the pop-up that appears.
 
     If you already have an existing key pair, select **Choose an existing key pair** and choose from the available options in the drop-down menu.
 
@@ -226,19 +226,19 @@ If you've never set up an Amazon EC2 instance for Linux, see [this guide](https:
 
     **Note:** Once you download the key pair, store it in a secure and accessible location. You won't be able to download the file again after it is created.
 
-20. Select **Launch Instances**.
+1.  Select **Launch Instances**.
 
-21. Use the key pair to connect to the server using SSH and its public IP address. Terminal-based SSH is easier to use than browser-based SSH for copying and pasting text.
+1.  Use the key pair to connect to the server using SSH and its public IP address. Terminal-based SSH is easier to use than browser-based SSH for copying and pasting text.
 
-22. Install Docker by following the [Installing Docker](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-docker.html#install-docker-instructions) instructions for Linux.
+1.  Install Docker by following the [Installing Docker](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-docker.html#install-docker-instructions) instructions for Linux.
 
-23. Install Docker Compose by following the [manual installation instructions](https://docs.docker.com/compose/install/linux/#install-the-plugin-manually).
+1.  Install Docker Compose by following the [manual installation instructions](https://docs.docker.com/compose/install/linux/#install-the-plugin-manually).
 
-24. Confirm that Docker Compose is installed:
+1.  Confirm that Docker Compose is installed:
 
     ```bash
     docker compose version
     Docker Compose version v2.24.1
     ```
 
-25. Configure AWS CLI and retrieve the [Seqera container images](#seqera-container-images). AWS CLI v2 is pre-installed in Amazon Linux.
+1.  Configure AWS CLI and retrieve the [Seqera container images](#seqera-container-images). AWS CLI v2 is pre-installed in Amazon Linux.

--- a/platform_versioned_docs/version-23.4.0/enterprise/prerequisites/azure.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/prerequisites/azure.mdx
@@ -29,10 +29,10 @@ From version 22.1.1, HTTP-only implementations **must** set the `TOWER_ENABLE_UN
 
 While there are many ways to implement DNS and TLS-termination, Seqera recommends using the specialized native services offered by your cloud provider. In the case of Azure:
 
--   Use **Application Gateway** for TLS-termination and load-balancing.
--   Use [**App Service Domains**](https://docs.microsoft.com/en-us/azure/dns/dns-overview) for domain acquisition.
--   Use **Azure DNS** for domain record management.
--   Use **Azure Vault** for PKI certificate storage.
+- Use **Application Gateway** for TLS-termination and load-balancing.
+- Use [**App Service Domains**](https://docs.microsoft.com/en-us/azure/dns/dns-overview) for domain acquisition.
+- Use **Azure DNS** for domain record management.
+- Use **Azure Vault** for PKI certificate storage.
 
 These decisions should be made before you continue as they impact how Seqera configuration files are updated.
 
@@ -60,14 +60,14 @@ To customize your cluster's Ingress Controller to support HTTPS redirects and TL
 Seqera Platform Enterprise is distributed as a collection of Docker containers available through the Seqera
 container registry ([cr.seqera.io](https://cr.seqera.io)). Contact [support](https://support.seqera.io) to get your container access credentials. Once you've received your credentials, retrieve the Seqera container images:
 
-1. Retrieve the **username** and **password** you received from Seqera support.
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Retrieve the **username** and **password** you received from Seqera support.
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    ```bash
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
    ```
 
-3. Pull the Seqera container images with the following commands:
+1.  Pull the Seqera container images with the following commands:
 
    ```bash
    docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v23.4.3
@@ -83,13 +83,13 @@ This section provides step-by-step instructions for some commonly used Azure ser
 
 ### Azure Resource Group
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
+1.  Sign in to the [Azure portal](https://portal.azure.com).
 
-2. Select **Resource groups**.
+1.  Select **Resource groups**.
 
-3. Select **Add**.
+1.  Select **Add**.
 
-4. Enter the following values:
+1.  Enter the following values:
 
    - **Subscription**: Select your Azure subscription.
 
@@ -97,19 +97,19 @@ This section provides step-by-step instructions for some commonly used Azure ser
 
    - **Region**: Select the region where your assets will exist (e.g., `East US`).
 
-5. Select **Review and Create**.
+1.  Select **Review and Create**.
 
-6. Select **Create**.
+1.  Select **Create**.
 
 ### Azure Storage Account
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
+1.  Sign in to the [Azure portal](https://portal.azure.com).
 
-2. Select **Storage accounts**.
+1.  Select **Storage accounts**.
 
-3. Select **Create**.
+1.  Select **Create**.
 
-4. Enter the following values:
+1.  Enter the following values:
 
    - **Subscription**: Select your Azure subscription.
 
@@ -123,71 +123,71 @@ This section provides step-by-step instructions for some commonly used Azure ser
 
    - **Redundancy**: Select `Geo-redundant storage (GRS)`.
 
-5. Select **Review + create**. Note that the default values are used in the other tabs. See the [Azure documentation](https://docs.microsoft.com/en-ca/azure/storage/common/storage-account-create?tabs=azure-portal#create-a-storage-account-1) for further details on each setting.
+1.  Select **Review + create**. Note that the default values are used in the other tabs. See the [Azure documentation](https://docs.microsoft.com/en-ca/azure/storage/common/storage-account-create?tabs=azure-portal#create-a-storage-account-1) for further details on each setting.
 
-6. Select **Create**.
+1.  Select **Create**.
 
 ### Azure Linux VM
 
 We recommend the following VM settings:
 
-1. Use **default values** unless otherwise specified.
-2. Provision at least **2 CPUS** and **8GB RAM**.
-3. Use the **Ubuntu Server 20.04 LTS - Gen2** image.
-4. Ensure your VM is **accessible by SSH**.
-5. Do not implement DNS or Load Balancing directly against the VM (do so via Azure Application Gateway instead).
+1.  Use **default values** unless otherwise specified.
+1.  Provision at least **2 CPUS** and **8GB RAM**.
+1.  Use the **Ubuntu Server 20.04 LTS - Gen2** image.
+1.  Ensure your VM is **accessible by SSH**.
+1.  Do not implement DNS or Load Balancing directly against the VM (do so via Azure Application Gateway instead).
 
 To create a VM:
 
-1. Configure the **Basics** tab:
+1.  Configure the **Basics** tab:
 
    - Ensure your **Region** is the same as your **Resource group**.
    - Do not set the VM as an **Azure Spot instance**.
    - Ensure your Security Group allows ingress on **Port 8000**.
 
-2. Configure the **Disks** tab:
+1.  Configure the **Disks** tab:
 
    - Ensure your OS disk type is **Standard SSD**.
 
-3. Configure the **Network** tab:
+1.  Configure the **Network** tab:
 
    - Ensure that a **Public IP** is assigned to the VM.
    - Do not place the VM in the backend pool of an existing load balancing solution.
 
-4. Select **Review + create**.
+1.  Select **Review + create**.
 
-5. Select **Create**.
+1.  Select **Create**.
 
 To make the VM's IP address static:
 
-1. Enter **Public IP addresses** in the search.
+1.  Enter **Public IP addresses** in the search.
 
-2. Under **Services**, select **Public IP addresses**.
+1.  Under **Services**, select **Public IP addresses**.
 
-3. On the **Public IP addresses** page, select the entry containing your VM name. A page opens with that IP's details.
+1.  On the **Public IP addresses** page, select the entry containing your VM name. A page opens with that IP's details.
 
-4. Select **Configuration** from the left-hand navigation panel.
+1.  Select **Configuration** from the left-hand navigation panel.
 
-5. Ensure that your IP address assignment is **Static**.
+1.  Ensure that your IP address assignment is **Static**.
 
-6. Do not add a custom DNS name label to the VM.
+1.  Do not add a custom DNS name label to the VM.
 
 To allow ingress on port 8000:
 
-1. Enter **Virtual Machines** in the search bar.
+1.  Enter **Virtual Machines** in the search bar.
 
-2. Under **Services**, select **Virtual machines**.
+1.  Under **Services**, select **Virtual machines**.
 
-3. On the **Virtual machines** page, select your VM name to navigate to the VM details.
+1.  On the **Virtual machines** page, select your VM name to navigate to the VM details.
 
-4. Select **Networking** from the left-hand navigation panel.
+1.  Select **Networking** from the left-hand navigation panel.
 
-5. **Add inbound port rule** for port 8000.
+1.  **Add inbound port rule** for port 8000.
 
 To install Docker:
 
 1.  Complete the steps for the [Install using the apt repository][docker] instructions.
-2.  Confirm that Docker Compose is installed:
+1.  Confirm that Docker Compose is installed:
 
     ```bash
     docker compose version

--- a/platform_versioned_docs/version-23.4.0/enterprise/prerequisites/gcp.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/prerequisites/gcp.mdx
@@ -37,13 +37,13 @@ From version 22.1.1, HTTP-only implementations **must** set the `TOWER_ENABLE_UN
 
 - **(Optional) Public IP address**: A public IP address can be reserved for the Seqera ingress to keep the IP address constant across restarts. If you don't reserve an IP address, the ingress will create one for you automatically, but it will be different every time you deploy the ingress. Reserve a public IP address with the following steps:
 
-  1. Got to **VPC network > External IP addresses** and select **Reserve Static Address**.
+  1.  Got to **VPC network > External IP addresses** and select **Reserve Static Address**.
 
-  2. Assign a name (e.g., `tower-ip`). This name will be used later to configure the ingress.
+  2.  Assign a name (e.g., `tower-ip`). This name will be used later to configure the ingress.
 
-  3. Select the region where your GKE cluster is deployed.
+  3.  Select the region where your GKE cluster is deployed.
 
-  4. Select **Reserve**.
+  4.  Select **Reserve**.
 
 ### Prerequisites for Docker
 
@@ -62,15 +62,15 @@ Seqera doesn't currently support GKE Autopilot due to a privilege issue with the
 Seqera Platform Enterprise is distributed as a collection of Docker containers available through the Seqera
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. Once you've received your credentials, retrieve the Seqera container images:
 
-1. Retrieve the **username** and **password** you received from Seqera support.
+1.  Retrieve the **username** and **password** you received from Seqera support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    ```bash
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
    ```
 
-3. Pull the Seqera container images with the following commands:
+1.  Pull the Seqera container images with the following commands:
 
    ```bash
    docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v23.4.3
@@ -88,41 +88,41 @@ This section provides step-by-step instructions for some commonly used GCP servi
 
 ### Google CloudSQL
 
-1. Browse to **Cloud SQL** and select **Create Instance**.
+1.  Browse to **Cloud SQL** and select **Create Instance**.
 
-2. Select **MySQL** (you may need to enable the API).
+1.  Select **MySQL** (you may need to enable the API).
 
-3. Change to **Single zone** availability, unless you require high availability.
+1.  Change to **Single zone** availability, unless you require high availability.
 
-4. Update the **Region** and **Zone** to match the location of your Seqera deployment.
+1.  Update the **Region** and **Zone** to match the location of your Seqera deployment.
 
-5. Expand **Show configuration options** and update the **Machine type** and **Storage** settings. The recommended machine type and disk size depends on the number of parallel pipelines you expect to run. In this guide, we use the **Standard** machine type with **1 vCPU**, and **20 GB SSD** storage.
+1.  Expand **Show configuration options** and update the **Machine type** and **Storage** settings. The recommended machine type and disk size depends on the number of parallel pipelines you expect to run. In this guide, we use the **Standard** machine type with **1 vCPU**, and **20 GB SSD** storage.
 
-6. Expand **Connections**, disable **Public IP**, and enable **Private IP**.
+1.  Expand **Connections**, disable **Public IP**, and enable **Private IP**.
 
-7. Select the **Network** (usually **default**). You may need to set up a **Private services access connection** for this VPC if you have not done so already. Enable the API and select **Use an automatically allocated IP range**. Select **Continue**, then **Create Connection**.
+1.  Select the **Network** (usually **default**). You may need to set up a **Private services access connection** for this VPC if you have not done so already. Enable the API and select **Use an automatically allocated IP range**. Select **Continue**, then **Create Connection**.
 
-8. Select **Create Instance**.
+1.  Select **Create Instance**.
 
-9. Once the database has been created, select the instance, then **Databases**. Create a new database named _tower_.
+1.  Once the database has been created, select the instance, then **Databases**. Create a new database named _tower_.
 
-10. Note the Private IP address of the instance as it must be supplied to the `TOWER_DB_URL` environment variable.
+1.  Note the Private IP address of the instance as it must be supplied to the `TOWER_DB_URL` environment variable.
 
 ### Google Compute Engine
 
-1. From the Navigation menu of the Google Cloud console, select **Compute Engine** to create a new VM instance. Select the machine name, region/zone, and machine type. In this example we have used an `e2-standard-2` instance (2 vCPUs, 8 GB memory).
+1.  From the Navigation menu of the Google Cloud console, select **Compute Engine** to create a new VM instance. Select the machine name, region/zone, and machine type. In this example we have used an `e2-standard-2` instance (2 vCPUs, 8 GB memory).
 
-2. Enable HTTP traffic. By default, the frontend is exposed to port 8000, so you will need to add a firewall rule to the underlying VPC network to allow port 8000 (after VM creation).
+1.  Enable HTTP traffic. By default, the frontend is exposed to port 8000, so you will need to add a firewall rule to the underlying VPC network to allow port 8000 (after VM creation).
 
-3. Connect to the machine using SSH. If you run into issues with SSH, or would like to set up IAP SSH, refer to the documentation for [TCP forward to IAP](https://cloud.google.com/iap/docs/using-tcp-forwarding).
+1.  Connect to the machine using SSH. If you run into issues with SSH, or would like to set up IAP SSH, refer to the documentation for [TCP forward to IAP](https://cloud.google.com/iap/docs/using-tcp-forwarding).
 
-4. Install [Docker](https://docs.docker.com/engine/install/debian/) by following the instructions for Debian GNU/Linux.
+1.  Install [Docker](https://docs.docker.com/engine/install/debian/) by following the instructions for Debian GNU/Linux.
 
-5. Confirm that Docker Compose is installed:
+1.  Confirm that Docker Compose is installed:
 
     ```bash
     docker compose version
     Docker Compose version v2.24.1
     ```
 
-6.  Configure `gcloud` and retrieve the [Seqera container images](#seqera-container-images).
+1.  Configure `gcloud` and retrieve the [Seqera container images](#seqera-container-images).

--- a/platform_versioned_docs/version-23.4.0/enterprise/prerequisites/on-prem.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/prerequisites/on-prem.mdx
@@ -34,15 +34,15 @@ From version 22.1.1, HTTP-only implementations **must** set the `TOWER_ENABLE_UN
 Seqera Platform Enterprise is distributed as a collection of Docker containers available through the Seqera
 container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. Once you've received your credentials, retrieve the Seqera container images:
 
-1. Retrieve the **username** and **password** you received from Seqera support.
+1.  Retrieve the **username** and **password** you received from Seqera support.
 
-2. Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
+1.  Run the following Docker command to authenticate to the registry (using the `username` and `password` values copied in step 1):
 
    ```bash
    docker login -u '/\<USERNAME\>/' -p '/\PASSWORD\>/' cr.seqera.io
    ```
 
-3. Pull the Seqera container images with the following commands:
+1.  Pull the Seqera container images with the following commands:
 
    ```bash
    docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v23.4.3

--- a/platform_versioned_docs/version-23.4.0/enterprise/release_notes/22.1.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/release_notes/22.1.mdx
@@ -76,13 +76,13 @@ We've also implemented a first version of a much requested feature from HPC user
 
 This Tower version requires a database schema update. Follow these steps to update your DB instance and the Tower installation.
 
-1. Make a backup of the Tower database.
-2. Download and update your container versions to:
+1.  Make a backup of the Tower database.
+2.  Download and update your container versions to:
 
-    * `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v22.1.5`
-    * `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v22.1.5`
+    - `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v22.1.5`
+    - `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v22.1.5`
 
-3. Redeploy the Tower application:
+3.  Redeploy the Tower application:
 
     **docker compose**:
 

--- a/platform_versioned_docs/version-23.4.0/enterprise/release_notes/22.2.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/release_notes/22.2.mdx
@@ -51,8 +51,8 @@ Available reports are listed in a Reports tab on the Runs page. Users can select
 
 ## Notes
 
-1. As of version 22.1.x, Nextflow Tower Enterprise will follow a three month release cadence, using the following version number scheme: `YY.Q.PATCH`, where `YY` represents the year, `Q` represents the quarter and `PATCH` the incremental patch number.
-2. As of version 21.02.x, a license key must be provided to enable the Tower deployment feature. The license key should be specified using the configuration variable `TOWER_LICENSE`. If you don't have a license key, contact sales@seqera.io.
+1.  As of version 22.1.x, Nextflow Tower Enterprise will follow a three month release cadence, using the following version number scheme: `YY.Q.PATCH`, where `YY` represents the year, `Q` represents the quarter and `PATCH` the incremental patch number.
+2.  As of version 21.02.x, a license key must be provided to enable the Tower deployment feature. The license key should be specified using the configuration variable `TOWER_LICENSE`. If you don't have a license key, contact sales@seqera.io.
 
 ## Warnings
 
@@ -64,13 +64,13 @@ Available reports are listed in a Reports tab on the Runs page. Users can select
 
 This Tower version requires a database schema update. Follow these steps to update your DB instance and the Tower installation.
 
-1. Make a backup of the Tower database.
-2. Download and update your container versions to:
+1.  Make a backup of the Tower database.
+2.  Download and update your container versions to:
 
-    * `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v22.2.1`
-    * `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v22.2.1`
+    - `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v22.2.1`
+    - `195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v22.2.1`
 
-3. Redeploy the Tower application:
+3.  Redeploy the Tower application:
 
     **docker compose**:
 

--- a/platform_versioned_docs/version-23.4.0/enterprise/release_notes/22.3.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/release_notes/22.3.mdx
@@ -113,9 +113,9 @@ This feature is currently only available on Tower Cloud (tower.nf). For more inf
 
 This Tower version requires a database schema update. Follow these steps to update your DB instance and the Tower installation.
 
-1. Make a backup of the Tower database.
-2. Download and update your container versions.
-3. Redeploy the Tower application:
+1.  Make a backup of the Tower database.
+2.  Download and update your container versions.
+3.  Redeploy the Tower application:
 
     **docker compose**:
 

--- a/platform_versioned_docs/version-23.4.0/enterprise/release_notes/22.4.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/release_notes/22.4.mdx
@@ -15,12 +15,12 @@ In Nextflow Tower 22.3, Seqera Labs introduced [resource labels](../../resource-
 
 In Tower Enterprise 22.4, an administrator can now:
 
--   Override and save the resource labels automatically assigned to a pipeline.
-  -   The pipeline will have a different resource label set from its associated compute environment. Resource labels added to the pipeline propagate to the cloud provider, without being permanently associated with the compute environment in Tower.
-  -   If a maintainer edits a pipeline and changes the compute environment, the resource labels field is updated with the resource labels of the new compute environment.
--   Override and save the resource labels associated with an action, following the same logic as pipelines above.
--   Override the resource labels associated with a workflow run before launch, enabling job-level tagging.
-  -   The resource labels tied to a workflow run are associated with specific cloud resources that do not include all resources tagged when a compute environment is created.
+- Override and save the resource labels automatically assigned to a pipeline.
+- The pipeline will have a different resource label set from its associated compute environment. Resource labels added to the pipeline propagate to the cloud provider, without being permanently associated with the compute environment in Tower.
+- If a maintainer edits a pipeline and changes the compute environment, the resource labels field is updated with the resource labels of the new compute environment.
+- Override and save the resource labels associated with an action, following the same logic as pipelines above.
+- Override the resource labels associated with a workflow run before launch, enabling job-level tagging.
+- The resource labels tied to a workflow run are associated with specific cloud resources that do not include all resources tagged when a compute environment is created.
 
 ### All runs view
 
@@ -64,8 +64,8 @@ The only requirement is that the new compute environment has access to the origi
 
 ### Warnings
 
-1. The default `nf-launcher` image includes a `curl` command which will fail if your Tower is secured with a private TLS certificate. To mitigate this problem, please see [these instructions](../configuration/ssl_tls.mdx).
-2. This version requires all database connections to use the following configuration value: `TOWER_DB_DRIVER=org.mariadb.jdbc.Driver`. Please update your configuration if you are upgrading. All other database configuration values should remain unchanged.
+1.  The default `nf-launcher` image includes a `curl` command which will fail if your Tower is secured with a private TLS certificate. To mitigate this problem, please see [these instructions](../configuration/ssl_tls.mdx).
+2.  This version requires all database connections to use the following configuration value: `TOWER_DB_DRIVER=org.mariadb.jdbc.Driver`. Please update your configuration if you are upgrading. All other database configuration values should remain unchanged.
 3.  This version expects the use of HTTPS by default for all browser client connections. If your Tower installation requires the use of unsecured HTTP, set the following environment variable in the infrastructure hosting the Tower application: `TOWER_ENABLE_UNSAFE_MODE=true`.
 4.  If you're upgrading from a version of Tower prior to `21.04.x`, please update your implementation to `21.04.x` before installing this release.
 
@@ -76,9 +76,9 @@ This Tower version requires a database schema update. Follow these steps to upda
 !!! warning
     To ensure no data loss, the database volume must be persistent on the local machine. Use the `volumes` key in the `db` or `redis` section of your `docker-compose.yml` file to specify a local path to the DB or Redis instance.
 
-1. Make a backup of the Tower database.
-2. Download and update your container versions.
-3. Redeploy the Tower application:
+1.  Make a backup of the Tower database.
+2.  Download and update your container versions.
+3.  Redeploy the Tower application:
 
     **docker compose**:
 

--- a/platform_versioned_docs/version-23.4.0/enterprise/release_notes/23.1.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/release_notes/23.1.mdx
@@ -59,9 +59,9 @@ This Tower version requires a database schema update. Follow these steps to upda
 !!! warning ""
     To ensure no data loss, the database volume must be persistent on the local machine. Use the `volumes` key in the `db` or `redis` section of your `docker-compose.yml` file to specify a local path to the DB or Redis instance.
 
-1. Make a backup of the Tower database.
-2. Download and update your container versions.
-3. Redeploy the Tower application:
+1.  Make a backup of the Tower database.
+2.  Download and update your container versions.
+3.  Redeploy the Tower application:
 
     **docker compose**:
 

--- a/platform_versioned_docs/version-23.4.0/enterprise/release_notes/23.2.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/release_notes/23.2.mdx
@@ -62,9 +62,9 @@ This Tower version requires a database schema update. Follow these steps to upda
 !!! warning ""
     To ensure no data loss, the database volume must be persistent on the local machine. Use the `volumes` key in the `db` or `redis` section of your docker-compose.yml file to specify a local path to the DB or Redis instance.
 
-1. Make a backup of the Tower database.
-2. Download and update your container versions.
-3. Redeploy the Tower application:
+1.  Make a backup of the Tower database.
+2.  Download and update your container versions.
+3.  Redeploy the Tower application:
 
     **docker compose**:
 
@@ -84,8 +84,8 @@ This Tower version requires a database schema update. Follow these steps to upda
 
 If you must host your nf-launcher container image on a private image registry:
 
-1. Copy the [nf-launcher image](https://quay.io/seqeralabs/nf-launcher:j17-23.04.2-up3) to your private registry.
-2. Update your `tower.env` with the launch container environment variable:
+1.  Copy the [nf-launcher image](https://quay.io/seqeralabs/nf-launcher:j17-23.04.2-up3) to your private registry.
+2.  Update your `tower.env` with the launch container environment variable:
 
     `TOWER_LAUNCH_CONTAINER=<FULL_PATH_TO_YOUR_PRIVATE_IMAGE>`
 

--- a/platform_versioned_docs/version-23.4.0/enterprise/release_notes/23.3.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/release_notes/23.3.mdx
@@ -78,9 +78,9 @@ This version requires a database schema update. Follow these steps to update you
 To ensure no data loss, the database volume must be persistent on the local machine. Use the `volumes` key in the `db` or `redis` section of your `docker-compose.yml` file to specify a local path to the DB or Redis instance.
 :::
 
-1. Make a backup of the Seqera Platform database.
-2. Download and update your container versions.
-3. Redeploy the application:
+1.  Make a backup of the Seqera Platform database.
+2.  Download and update your container versions.
+3.  Redeploy the application:
 
 **Docker Compose**:
 

--- a/platform_versioned_docs/version-23.4.0/enterprise/release_notes/changelog.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/release_notes/changelog.mdx
@@ -434,7 +434,7 @@ tags: [changelog]
 - Chore: Upgrade to Micronaut 3.4.x
 - Chore: Typography sync between tower and design
 
-* Full Changelog: v22.1.5-enterprise...v22.2.0-rc0-enterprise
+- Full Changelog: v22.1.5-enterprise...v22.2.0-rc0-enterprise
 
 #### 22.1.6 - 15 Jul 2022
 

--- a/platform_versioned_docs/version-23.4.0/enterprise/release_notes/enterprise_latest.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/release_notes/enterprise_latest.mdx
@@ -69,20 +69,20 @@ The database volume is persistent on the local machine by default if you use the
 
 To upgrade your database schema:
 
-1. Make a backup of the Seqera Platform database. If you use the pipeline optimization service and your `groundswell` database resides in a database instance separate from your Seqera database, make a backup of your `groundswell` database as well.
-2. Download the 23.4 versions of your deployment templates and update your Seqera container versions:
+1.  Make a backup of the Seqera Platform database. If you use the pipeline optimization service and your `groundswell` database resides in a database instance separate from your Seqera database, make a backup of your `groundswell` database as well.
+2.  Download the 23.4 versions of your deployment templates and update your Seqera container versions:
     - [docker-compose.yml](../_templates/docker/docker-compose.yml) for Docker Compose deployments
     - [tower-cron.yml](../_templates/k8s/tower-cron.yml) and [tower-svc.yml](../_templates/k8s/tower-svc.yml) for Kubernetes deployments
-3. Restart the application.
-4. If you're using a containerized database as part of your implementation:
-    1. Stop the application.
-    2. Upgrade the MySQL image.
-    3. Restart the application.
-5. If you're using Amazon RDS or other managed database services:
-    1. Stop the application
-    2. Upgrade your database instance.
-    3. Restart the application.
-6. If you're using the pipeline optimization service (`groundswell` database) in a database separate from your Seqera database, update the MySQL image for your `groundswell` database instance while the application is down (during step 4 or 5 above). If you're using the same database instance for both, the `groundswell` update will happen automatically during the Seqera database update.
+3.  Restart the application.
+4.  If you're using a containerized database as part of your implementation:
+    1.  Stop the application.
+    2.  Upgrade the MySQL image.
+    3.  Restart the application.
+5.  If you're using Amazon RDS or other managed database services:
+    1.  Stop the application
+    2.  Upgrade your database instance.
+    3.  Restart the application.
+6.  If you're using the pipeline optimization service (`groundswell` database) in a database separate from your Seqera database, update the MySQL image for your `groundswell` database instance while the application is down (during step 4 or 5 above). If you're using the same database instance for both, the `groundswell` update will happen automatically during the Seqera database update.
 
 **Custom deployment**:
 

--- a/platform_versioned_docs/version-23.4.0/enterprise/testing.mdx
+++ b/platform_versioned_docs/version-23.4.0/enterprise/testing.mdx
@@ -7,23 +7,23 @@ tags: [testing, deployment]
 
 After your [Docker Compose](./docker-compose.mdx) or [Kubernetes](./kubernetes.mdx) installation is complete, follow these steps to test whether the application is running as expected:
 
-1. Log in to the application.
+1.  Log in to the application.
 
-2. Create an [organization](../orgs-and-teams/organizations.mdx).
+1.  Create an [organization](../orgs-and-teams/organizations.mdx).
 
-3. Create a [workspace](../orgs-and-teams/workspace-management.mdx) within the organization.
+1.  Create a [workspace](../orgs-and-teams/workspace-management.mdx) within the organization.
 
-4. Create a new [compute environment](../compute-envs/overview.mdx).
+1.  Create a new [compute environment](../compute-envs/overview.mdx).
 
-5. Add your [GitHub credentials](../git/overview.mdx).
+1.  Add your [GitHub credentials](../git/overview.mdx).
 
-6. Select **Quick Launch** from the **Launchpad** tab in your workspace.
+1.  Select **Quick Launch** from the **Launchpad** tab in your workspace.
 
-7. Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
+1.  Enter the repository URL for the `nf-core/rnaseq` pipeline (`https://github.com/nf-core/rnaseq`).
 
-8. In the **Config profiles** drop-down menu, select the `test` profile.
+1.  In the **Config profiles** drop-down menu, select the `test` profile.
 
-9. In **Pipeline parameters**, change the output directory to a location based on your compute environment:
+1.  In **Pipeline parameters**, change the output directory to a location based on your compute environment:
 
     ```yaml
     # Uncomment to save to an S3 bucket
@@ -33,4 +33,4 @@ After your [Docker Compose](./docker-compose.mdx) or [Kubernetes](./kubernetes.m
     # outdir: /scratch/results
     ```
 
-10. Select **Launch**. You'll be redirected to the **Runs** tab for the workflow. After a few minutes, progress logs will be listed in that workflow's **Execution log** tab.
+1.  Select **Launch**. You'll be redirected to the **Runs** tab for the workflow. After a few minutes, progress logs will be listed in that workflow's **Execution log** tab.

--- a/platform_versioned_docs/version-23.4.0/faqs.mdx
+++ b/platform_versioned_docs/version-23.4.0/faqs.mdx
@@ -41,9 +41,9 @@ Attempting to launch a pipeline without specifying a `launch.id` in the API payl
 
 Launch users must add a `launch.id` to pipeline launch requests:
 
-1. Query the list of pipelines via the `/pipelines` endpoint. Find the `pipelineId` of the pipeline you intend to launch.
-2. Call the `/pipelines/{pipelineId}/launch` API to retrieve the pipeline's `launch.id`.
-3. Include the `launch.id` in your request to the `/workflow/launch` API endpoint:
+1.  Query the list of pipelines via the `/pipelines` endpoint. Find the `pipelineId` of the pipeline you intend to launch.
+1.  Call the `/pipelines/{pipelineId}/launch` API to retrieve the pipeline's `launch.id`.
+1.  Include the `launch.id` in your request to the `/workflow/launch` API endpoint:
 
    ```
    {
@@ -68,9 +68,9 @@ GitHub imposes [rate limits](https://docs.github.com/en/rest/overview/resources-
 
 Try the following:
 
-1. Ensure there's at least one GitHub credential in your workspace's **Credentials** tab.
-2. Ensure that the **Access token** field of all GitHub credential objects is populated with a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) value and **not** a user password. GitHub PATs are typically longer than passwords and include a `ghp_` prefix. For example:`ghp*IqIMNOZH6zOwIEB4T9A2g4EHMy8Ji42q4HA`
-3. Confirm that your PAT is providing the elevated threshold and transactions are being charged against it:
+1.  Ensure there's at least one GitHub credential in your workspace's **Credentials** tab.
+1.  Ensure that the **Access token** field of all GitHub credential objects is populated with a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) value and **not** a user password. GitHub PATs are typically longer than passwords and include a `ghp_` prefix. For example:`ghp*IqIMNOZH6zOwIEB4T9A2g4EHMy8Ji42q4HA`
+1.  Confirm that your PAT is providing the elevated threshold and transactions are being charged against it:
 
    `curl -H "Authorization: token ghp_LONG_ALPHANUMERIC_PAT" -H "Accept: application/vnd.github.v3+json" https://api.github.com/rate_limit`
 
@@ -80,14 +80,14 @@ This error can occur if incorrect configuration values are assigned to the `back
 
 Please verify the following:
 
-1. The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `backend` container:
+1.  The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `backend` container:
    - Contains `prod,redis,ha`
    - Does not contain `cron`
-2. The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `cron` container:
+1.  The `MICRONAUT_ENVIRONMENTS` environment variable associated with the `cron` container:
    - Contains `prod,redis,cron`
    - Does not contain `ha`
-3. You don't have another copy of the `MICRONAUT_ENVIRONMENTS` environment variable defined elsewhere in your application (such as a `tower.env` file or Kubernetes `ConfigMap`).
-4. If you're using a separate container/pod to execute `migrate-db.sh`, ensure there's no `MICRONAUT_ENVIRONMENTS` environment variable assigned to it.
+1.  You don't have another copy of the `MICRONAUT_ENVIRONMENTS` environment variable defined elsewhere in your application (such as a `tower.env` file or Kubernetes `ConfigMap`).
+1.  If you're using a separate container/pod to execute `migrate-db.sh`, ensure there's no `MICRONAUT_ENVIRONMENTS` environment variable assigned to it.
 
 **_No such variable_ error**
 
@@ -133,8 +133,8 @@ Clients who use Amazon Aurora as their database solution may encounter a _java.s
 
 Please modify the Seqera Enterprise configuration as follows to try resolving the problem:
 
-1. Ensure your `TOWER_DB_DRIVER` uses the specified MariaDB URI.
-2. Modify your `TOWER_DB_URL` to: `TOWER_DB_URL=jdbc:mysql://YOUR_DOMAIN:YOUR_PORT/YOUR_TOWER_DB?usePipelineAuth=false&useBatchMultiSend=false`
+1.  Ensure your `TOWER_DB_DRIVER` uses the specified MariaDB URI.
+1.  Modify your `TOWER_DB_URL` to: `TOWER_DB_URL=jdbc:mysql://YOUR_DOMAIN:YOUR_PORT/YOUR_TOWER_DB?usePipelineAuth=false&useBatchMultiSend=false`
 
 ## Datasets
 
@@ -142,10 +142,10 @@ Please modify the Seqera Enterprise configuration as follows to try resolving th
 
 When uploading datasets via the Seqera UI or CLI, some steps are automatically done on your behalf. To upload datasets via the Seqera API, additional steps are required:
 
-1. Explicitly define the MIME type of the file being uploaded.
-2. Make two calls to the API:
-   1. Create a dataset object.
-   2. Upload the samplesheet to the dataset object.
+1.  Explicitly define the MIME type of the file being uploaded.
+1.  Make two calls to the API:
+   1.  Create a dataset object.
+   2.  Upload the samplesheet to the dataset object.
 
 Example:
 
@@ -193,13 +193,13 @@ TLS connection errors can occur due to variability in the [default TLS version s
 
 To fix the problem, try the following:
 
-1. Set a JDK environment variable to force Nextflow and Seqera containers to use TLSv1.2 by default:
+1.  Set a JDK environment variable to force Nextflow and Seqera containers to use TLSv1.2 by default:
 
     ```
     export JAVA_OPTIONS="-Dmail.smtp.ssl.protocols=TLSv1.2"
     ```
 
-2. Add this parameter to your [nextflow.config file](./launch/advanced.mdx#nextflow-config-file):
+1.  Add this parameter to your [nextflow.config file](./launch/advanced.mdx#nextflow-config-file):
 
     ```
     mail {
@@ -207,10 +207,10 @@ To fix the problem, try the following:
     }
     ```
 
-3. Ensure these values are also set for Nextflow and/or Seqera:
+1.  Ensure these values are also set for Nextflow and/or Seqera:
 
-    -   `mail.smtp.starttls.enable=true`
-    -   `mail.smtp.starttls.required=true`
+    - `mail.smtp.starttls.enable=true`
+    - `mail.smtp.starttls.required=true`
 
 ## Git integration
 
@@ -260,9 +260,9 @@ Users with email addresses other than the `trustedEmails` list will undergo an a
 
 :::note
 
-1. You must rebuild your containers (`docker compose down`) to force Seqera to implement this change. Ensure your database is persistent before issuing the teardown command. See [here](./enterprise/docker-compose.mdx) for more information.
-2. All login attempts are visible to the root user at **Profile > Admin panel > Users**.
-3. Any user logged in prior to the restriction will not be subject to the new restriction. An admin of the organization should remove users that have previously logged in via (untrusted) email from the Admin panel users list. This will restart the approval process before they can log in via email.
+1.  You must rebuild your containers (`docker compose down`) to force Seqera to implement this change. Ensure your database is persistent before issuing the teardown command. See [here](./enterprise/docker-compose.mdx) for more information.
+1.  All login attempts are visible to the root user at **Profile > Admin panel > Users**.
+1.  Any user logged in prior to the restriction will not be subject to the new restriction. An admin of the organization should remove users that have previously logged in via (untrusted) email from the Admin panel users list. This will restart the approval process before they can log in via email.
 
 :::
 
@@ -298,7 +298,7 @@ Mount the APM solution's JAR file in Seqera's `backend` container and set the ag
 
 Although it's not possible to directly download the trace logs via Seqera, you can configure your workflow to export the file to persistent storage:
 
-1. Set this block in your [`nextflow.config`](./launch/advanced.mdx#nextflow-config-file):
+1.  Set this block in your [`nextflow.config`](./launch/advanced.mdx#nextflow-config-file):
 
    ```nextflow
    trace {
@@ -306,7 +306,7 @@ Although it's not possible to directly download the trace logs via Seqera, you c
    }
    ```
 
-2. Add a copy command to your pipeline's **Advanced options > Post-run script** field:
+1.  Add a copy command to your pipeline's **Advanced options > Post-run script** field:
 
    ```
    # Example: Export the generated trace file to an S3 bucket
@@ -521,9 +521,9 @@ Runs will fail if your Nextflow script or Nextflow config contain illegal charac
 
 The Groovy shell used by Nextflow to execute your workflow has a hard limit on string size (64KiB). Check the size of your scripts with the `ls -llh` command. If the size is greater than 65,535 bytes, consider these mitigation techniques:
 
-1. Remove any unnecessary code or comments from the script.
-2. Move long script bodies into a separate script file in the pipeline `/bin` directory.
-3. Consider using DSL2 so you can move each function, process, and workflow definition into its own script and include these scripts as [modules](https://www.nextflow.io/docs/latest/dsl2.html#modules).
+1.  Remove any unnecessary code or comments from the script.
+1.  Move long script bodies into a separate script file in the pipeline `/bin` directory.
+1.  Consider using DSL2 so you can move each function, process, and workflow definition into its own script and include these scripts as [modules](https://www.nextflow.io/docs/latest/dsl2.html#modules).
 
 ## Nextflow Launcher
 
@@ -744,9 +744,9 @@ Docker Hub imposes a rate limit of 100 anonymous pulls per 6 hours. Add the foll
 
 If your run fails with an _Essential container in task exited - CannotInspectContainerError: Could not transition to inspecting; timed out after waiting 30s_ error, try the following:
 
-1. Upgrade your [ECS Agent](https://github.com/aws/amazon-ecs-agent/releases) to [1.54.1](https://github.com/aws/amazon-ecs-agent/pull/2940) or newer. See [here](https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/ECS/latest-agent-version.html) for instructions to check your ECS Agent version.
-2. Provision more storage for your EC2 instance (preferably via EBS-autoscaling to ensure scalability).
-3. If the error is accompanied by _command exit status: 123_ and a _permissions denied_ error tied to a system command, ensure that the ECS Agent binary is set to be executable (`chmod u+x`).
+1.  Upgrade your [ECS Agent](https://github.com/aws/amazon-ecs-agent/releases) to [1.54.1](https://github.com/aws/amazon-ecs-agent/pull/2940) or newer. See [here](https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/ECS/latest-agent-version.html) for instructions to check your ECS Agent version.
+1.  Provision more storage for your EC2 instance (preferably via EBS-autoscaling to ensure scalability).
+1.  If the error is accompanied by _command exit status: 123_ and a _permissions denied_ error tied to a system command, ensure that the ECS Agent binary is set to be executable (`chmod u+x`).
 
 ### Queues
 
@@ -778,7 +778,7 @@ process {
 
 If you need to save files to an S3 bucket with a policy that [enforces AES256 server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html), the [nf-launcher](https://quay.io/repository/seqeralabs/nf-launcher?tab=tags) script which invokes the Nextflow head job requires additional configuration:
 
-1. Add the following configuration to the **Advanced options > Nextflow config file** textbox of the **Launch Pipeline** screen:
+1.  Add the following configuration to the **Advanced options > Nextflow config file** textbox of the **Launch Pipeline** screen:
 
    ```
    aws {
@@ -788,7 +788,7 @@ If you need to save files to an S3 bucket with a policy that [enforces AES256 se
    }
    ```
 
-2. Add the following configuration to the **Advanced options > Pre-run script** textbox of the **Launch Pipeline** screen:
+1.  Add the following configuration to the **Advanced options > Pre-run script** textbox of the **Launch Pipeline** screen:
 
    ```bash
    export TOWER_AWS_SSE=AES256
@@ -804,12 +804,12 @@ If you need to save files to an S3 bucket with a policy that [enforces AES256 se
 
 The default Azure Batch implementation in Seqera Platform uses a single pool for head and compute nodes. This means that all jobs spawn dedicated/on-demand VMs by default. To save cloud costs by using low priority VMs for compute jobs, specify separate pools for head and compute jobs:
 
-1. Create two Batch pools in Azure:
+1.  Create two Batch pools in Azure:
     - One Dedicated
     - One [Low priority](https://learn.microsoft.com/en-us/azure/batch/batch-spot-vms#differences-between-spot-and-low-priority-vms).
-2. Create a manual [Azure Batch](./compute-envs/azure-batch.mdx#manual) compute environment in Seqera Platform.
-3. In **Compute pool name** (step 10 in the guide linked above), specify your dedicated Batch pool.
-4. Specify the Low priority pool using the `process.queue` [directive](https://www.nextflow.io/docs/latest/process.html#queue) in your `nextflow.config` file (either via the launch form, or your pipeline repository's `nextflow.config` file).
+1.  Create a manual [Azure Batch](./compute-envs/azure-batch.mdx#manual) compute environment in Seqera Platform.
+1.  In **Compute pool name** (step 10 in the guide linked above), specify your dedicated Batch pool.
+1.  Specify the Low priority pool using the `process.queue` [directive](https://www.nextflow.io/docs/latest/process.html#queue) in your `nextflow.config` file (either via the launch form, or your pipeline repository's `nextflow.config` file).
 
 ### AKS
 
@@ -858,10 +858,10 @@ process {
 
 The following roles must be granted to the `nextflow-service-account`:
 
-1. Cloud Life Sciences Workflows Runner
-2. Service Account User
-3. Service Usage Consumer
-4. Storage Object Admin
+1.  Cloud Life Sciences Workflows Runner
+1.  Service Account User
+1.  Service Usage Consumer
+1.  Storage Object Admin
 
 For detailed information, see [this guide](https://cloud.google.com/life-sciences/docs/tutorials/nextflow#create_a_service_account_and_add_roles).
 
@@ -907,24 +907,24 @@ Nextflow is trying to use the Java VM defined for the following environment vari
 
 Possible reasons for this error:
 
-1. The queue where the Nextflow head job runs is in a different environment/node than your login node userspace.
-2. If your HPC cluster uses modules, the Java module may not be loaded by default.
+1.  The queue where the Nextflow head job runs is in a different environment/node than your login node userspace.
+1.  If your HPC cluster uses modules, the Java module may not be loaded by default.
 
 To troubleshoot:
 
-1. Open an interactive session with the head job queue.
-2. Launch the Nextflow job from the interactive session.
-3. If your cluster uses modules:
+1.  Open an interactive session with the head job queue.
+1.  Launch the Nextflow job from the interactive session.
+1.  If your cluster uses modules:
    - Add `module load <your_java_module>` in the **Advanced Features > Pre-run script** field when creating your HPC compute environment in Seqera.
-4. If your cluster doesn't use modules:
-   1. Source an environment with Java and Nextflow using the **Advanced Features > Pre-run script** field when creating your HPC compute environment in Seqera.
+1.  If your cluster doesn't use modules:
+   1.  Source an environment with Java and Nextflow using the **Advanced Features > Pre-run script** field when creating your HPC compute environment in Seqera.
 
 **Pipeline submissions to HPC clusters fail for some users**
 
 Nextflow launcher scripts will fail if processed by a non-Bash shell (e.g., `zsh`, `tcsh`). This problem can be identified from certain error entries:
 
-1. Your _.nextflow.log_ contains an error like _Invalid workflow status - expected: SUBMITTED; current: FAILED_.
-2. Your Seqera **Error report** tab contains an error like:
+1.  Your _.nextflow.log_ contains an error like _Invalid workflow status - expected: SUBMITTED; current: FAILED_.
+1.  Your Seqera **Error report** tab contains an error like:
 
 ```yaml
 Slurm job submission failed
@@ -935,6 +935,6 @@ Slurm job submission failed
 
 Connect to the head node via SSH and run `ps -p $$` to verify your default shell. If you see an entry other than Bash, fix as follows:
 
-1. Check which shells are available to you: `cat /etc/shells`
-2. Change your shell: `chsh -s /usr/bin/bash` (the path to the binary may differ, depending on your HPC configuration)
-3. If submissions continue to fail after this shell change, ask your Seqera Platform admin to restart the **backend** and **cron** containers, then submit again.
+1.  Check which shells are available to you: `cat /etc/shells`
+1.  Change your shell: `chsh -s /usr/bin/bash` (the path to the binary may differ, depending on your HPC configuration)
+1.  If submissions continue to fail after this shell change, ask your Seqera Platform admin to restart the **backend** and **cron** containers, then submit again.

--- a/platform_versioned_docs/version-23.4.0/getting-started/deployment-options.mdx
+++ b/platform_versioned_docs/version-23.4.0/getting-started/deployment-options.mdx
@@ -34,14 +34,14 @@ You can access your Seqera instance through the UI, the [API](../api/overview.md
 
 ### Seqera Platform web-based UI
 
-1. Create an account and log in to Seqera at [cloud.seqera.io](https://cloud.seqera.io).
+1.  Create an account and log in to Seqera at [cloud.seqera.io](https://cloud.seqera.io).
 
    :::note
    Platform login sessions remain active as long as the application browser window remains open and active. When the browser window is terminated, automatic logout occurs within 6 hours by default.
    :::
 
-2. Create and configure a new [compute environment](../compute-envs/overview.mdx).
-3. Start [launching pipelines](../launch/launchpad.mdx).
+1.  Create and configure a new [compute environment](../compute-envs/overview.mdx).
+1.  Start [launching pipelines](../launch/launchpad.mdx).
 
 ### Seqera API
 
@@ -55,17 +55,17 @@ See [CLI](../cli/cli.mdx).
 
 If you have an existing environment where you run Nextflow directly, you can still leverage Seqera Platform capabilities by executing your Nextflow run with a `with-tower` flag:
 
-1. Create an account and log in to Seqera at [cloud.seqera.io](https://cloud.seqera.io).
-2. From your personal workspace: Go to the user menu and select **Settings > Your tokens**.
-3. Select **Add token**.
-4. Enter a unique name for your token, then select **Add**.
-5. Copy and store your token securely.
+1.  Create an account and log in to Seqera at [cloud.seqera.io](https://cloud.seqera.io).
+1.  From your personal workspace: Go to the user menu and select **Settings > Your tokens**.
+1.  Select **Add token**.
+1.  Enter a unique name for your token, then select **Add**.
+1.  Copy and store your token securely.
 
 :::caution
 The access token is displayed only once. Save the token value before closing the **Personal Access Token** window.
 :::
 
-6. Open a terminal window and create environment variables to store the Seqera access token and Nextflow version. Replace `<your access token>` with your newly-created token.
+1.  Open a terminal window and create environment variables to store the Seqera access token and Nextflow version. Replace `<your access token>` with your newly-created token.
 
    ```bash
    export TOWER_ACCESS_TOKEN=<your access token>
@@ -76,7 +76,7 @@ The access token is displayed only once. Save the token value before closing the
 Bearer token support requires Nextflow version 20.10.0 or later. Set with the `NXF_VER` environment variable.
 :::
 
-7. To submit a pipeline to a [workspace](../orgs-and-teams/workspace-management.mdx) using Nextflow, add the workspace ID to your environment:
+1.  To submit a pipeline to a [workspace](../orgs-and-teams/workspace-management.mdx) using Nextflow, add the workspace ID to your environment:
 
    ```bash
    export TOWER_WORKSPACE_ID=000000000000000
@@ -84,7 +84,7 @@ Bearer token support requires Nextflow version 20.10.0 or later. Set with the `N
 
    To find your workspace ID, select your organization in Seqera and navigate to the **Workspaces** tab.
 
-8. Run your Nextflow pipeline with the `-with-tower` flag:
+1.  Run your Nextflow pipeline with the `-with-tower` flag:
 
    ```bash
    nextflow run main.nf -with-tower

--- a/platform_versioned_docs/version-23.4.0/getting-started/overview.mdx
+++ b/platform_versioned_docs/version-23.4.0/getting-started/overview.mdx
@@ -22,15 +22,15 @@ The Community Showcase [Launchpad](../launch/launchpad.mdx) is an example worksp
 
 ## Run a pipeline with sample data
 
-1. From the [Launchpad](../launch/launchpad.mdx), select a pipeline to view the pipeline detail page. _nf-core-rnaseq_ is a good first pipeline example.
-2. Optional: Select the URL under **Workflow repository** to view the pipeline code repository in another tab.
-3. Select **Launch** from the pipeline detail page.
-4. On the **Launch pipeline** page, enter a unique **Workflow run name** or use the pre-filled random name.
-5. Optional: Enter labels to be assigned to the run in the **Labels** field.
-6. Under **Input/output options**, select the dataset named after your chosen pipeline from the drop-down menu under **input**.
-7. Under **outdir**, specify an output directory where run results will be saved. This must be an absolute path to storage on cloud infrastructure and defaults to `./results`.
-8. Under **email**, enter an email address where you wish to receive the run completion summary.
-9. Under **multiqc_title**, enter a title for the MultiQC report. This is used as both the report page header and filename.
+1.  From the [Launchpad](../launch/launchpad.mdx), select a pipeline to view the pipeline detail page. _nf-core-rnaseq_ is a good first pipeline example.
+1.  Optional: Select the URL under **Workflow repository** to view the pipeline code repository in another tab.
+1.  Select **Launch** from the pipeline detail page.
+1.  On the **Launch pipeline** page, enter a unique **Workflow run name** or use the pre-filled random name.
+1.  Optional: Enter labels to be assigned to the run in the **Labels** field.
+1.  Under **Input/output options**, select the dataset named after your chosen pipeline from the drop-down menu under **input**.
+1.  Under **outdir**, specify an output directory where run results will be saved. This must be an absolute path to storage on cloud infrastructure and defaults to `./results`.
+1.  Under **email**, enter an email address where you wish to receive the run completion summary.
+1.  Under **multiqc_title**, enter a title for the MultiQC report. This is used as both the report page header and filename.
 
 The remaining launch form fields will vary depending on the pipeline you have selected. Parameters required for the pipeline to run are pre-filled by default, and empty fields are optional.
 
@@ -40,9 +40,9 @@ Once you've filled the necessary launch form details, select **Launch**. Your ne
 
 To run pipelines on your own infrastructure, you first need to create your own organization.
 
-* [Organizations](../orgs-and-teams/organizations.mdx) are the top-level structure in Seqera. They contain the building blocks of your organizational infrastructure.
-* [Workspaces](../orgs-and-teams/workspace-management.mdx) are where resources are managed. All team members can access the organization workspace. In addition to this, each user has a unique personal workspace to manage resources such as pipelines, compute environments, and credentials.
-* [Teams](../orgs-and-teams/organizations.mdx) are collections of members.
-* [Members](../administration/overview.mdx#membership-administration) belong to an organization and can have different levels of access across workspaces.
+- [Organizations](../orgs-and-teams/organizations.mdx) are the top-level structure in Seqera. They contain the building blocks of your organizational infrastructure.
+- [Workspaces](../orgs-and-teams/workspace-management.mdx) are where resources are managed. All team members can access the organization workspace. In addition to this, each user has a unique personal workspace to manage resources such as pipelines, compute environments, and credentials.
+- [Teams](../orgs-and-teams/organizations.mdx) are collections of members.
+- [Members](../administration/overview.mdx#membership-administration) belong to an organization and can have different levels of access across workspaces.
 
 You can create multiple workspaces within an organization context and associate each of these workspaces with dedicated teams of users, while providing fine-grained access control for each of the teams. See [Administration](../orgs-and-teams/organizations.mdx).

--- a/platform_versioned_docs/version-23.4.0/git/overview.mdx
+++ b/platform_versioned_docs/version-23.4.0/git/overview.mdx
@@ -35,13 +35,13 @@ Credentials are encrypted with the AES-256 cypher before secure storage and are 
 
 When you have multiple stored credentials, Seqera selects the most relevant credential for your repository in the following order:
 
-1. Seqera evaluates all the stored credentials available to the current workspace.
+1.  Seqera evaluates all the stored credentials available to the current workspace.
 
-2. Credentials are filtered by Git provider (GitHub, GitLab, Bitbucket, etc.)
+1.  Credentials are filtered by Git provider (GitHub, GitLab, Bitbucket, etc.)
 
-3. Seqera selects the credential with a **Repository base URL** most similar to the target repository.
+1.  Seqera selects the credential with a **Repository base URL** most similar to the target repository.
 
-4. If no **Repository base URL** values are specified in the workspace credentials, the most long-lived credential is selected.
+1.  If no **Repository base URL** values are specified in the workspace credentials, the most long-lived credential is selected.
 
 **Credential filtering example**
 
@@ -89,15 +89,15 @@ Once you have created and copied your access token, create a new credential in S
 
 **Create AzureDevOps credentials**
 
-1. From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
+1.  From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
 
-3. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-4. Select _Azure DevOps_ as the **Provider**.
+1.  Select _Azure DevOps_ as the **Provider**.
 
-5. Enter your **Username** and **Access token**.
+1.  Enter your **Username** and **Access token**.
 
-6. (Recommended) Enter the **Repository base URL** for which the credentials should be applied. This option is used to apply the provided credentials to a specific repository, e.g., `https://dev.azure.com/<your organization>/<your project>`.
+1.  (Recommended) Enter the **Repository base URL** for which the credentials should be applied. This option is used to apply the provided credentials to a specific repository, e.g., `https://dev.azure.com/<your organization>/<your project>`.
 
 ### GitHub
 
@@ -115,15 +115,15 @@ After you've created and copied your access token, create a new credential in Se
 
 **Create GitHub credentials**
 
-1. From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
+1.  From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
 
-2. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-3. Select _GitHub_ as the **Provider**.
+1.  Select _GitHub_ as the **Provider**.
 
-4. Enter your **Username** and **Access token**.
+1.  Enter your **Username** and **Access token**.
 
-5. (Recommended) Enter the **Repository base URL** for which the credentials should be applied. This option is used to apply the provided credentials to a specific repository, e.g., `https://github.com/seqeralabs`.
+1.  (Recommended) Enter the **Repository base URL** for which the credentials should be applied. This option is used to apply the provided credentials to a specific repository, e.g., `https://github.com/seqeralabs`.
 
 ### GitLab
 
@@ -133,17 +133,17 @@ After you have created and copied your access token, create a new credential in 
 
 **Create GitLab credentials**
 
-1. From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
+1.  From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
 
-2. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-3. Select _GitLab_ as the **Provider**.
+1.  Select _GitLab_ as the **Provider**.
 
-4. Enter your **Username**. For Group and Project access tokens, the username can be any non-empty value.
+1.  Enter your **Username**. For Group and Project access tokens, the username can be any non-empty value.
 
-5. Enter your token value in both the **Password** and **Access token** fields.
+1.  Enter your token value in both the **Password** and **Access token** fields.
 
-6. Enter the **Repository base URL** (recommended). This option is used to apply the credentials to a specific repository, e.g. `https://gitlab.com/seqeralabs`.
+1.  Enter the **Repository base URL** (recommended). This option is used to apply the credentials to a specific repository, e.g. `https://gitlab.com/seqeralabs`.
 
 ### Gitea
 
@@ -151,17 +151,17 @@ To connect to a private [Gitea](https://gitea.io/) repository, use your Gitea us
 
 **Create Gitea credentials**
 
-1. From an organization workspace, go to the **Credentials** tab and select **Add Credentials**. From your personal workspace, select **Your credentials** from the user menu, then select **Add credentials**.
+1.  From an organization workspace, go to the **Credentials** tab and select **Add Credentials**. From your personal workspace, select **Your credentials** from the user menu, then select **Add credentials**.
 
-2. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-3. Select _Gitea_ as the **Provider**.
+1.  Select _Gitea_ as the **Provider**.
 
-4. Enter your **Username**.
+1.  Enter your **Username**.
 
-5. Enter your **Password**.
+1.  Enter your **Password**.
 
-6. Enter your **Repository base URL** (required).
+1.  Enter your **Repository base URL** (required).
 
 ### Bitbucket
 
@@ -169,15 +169,15 @@ To connect to a private BitBucket repository, see the [BitBucket documentation](
 
 **Create BitBucket credentials**
 
-1. From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
+1.  From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
 
-2. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-3. Select _BitBucket_ as the **Provider**.
+1.  Select _BitBucket_ as the **Provider**.
 
-4. Enter your **Username** and **Password**.
+1.  Enter your **Username** and **Password**.
 
-5. Enter the **Repository base URL** (recommended). This option can be used to apply the credentials to a specific repository, e.g., `https://bitbucket.org/seqeralabs`.
+1.  Enter the **Repository base URL** (recommended). This option can be used to apply the credentials to a specific repository, e.g., `https://bitbucket.org/seqeralabs`.
 
 ### AWS CodeCommit
 
@@ -185,15 +185,15 @@ To connect to a private AWS CodeCommit repository, see the [AWS documentation](h
 
 **Create AWS CodeCommit credentials**
 
-1. From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
+1.  From an organization workspace: Select **Credentials > Add Credentials**. From your personal workspace: Go to the user menu and select **Your credentials > Add credentials**.
 
-2. Enter a **Name** for the new credentials.
+1.  Enter a **Name** for the new credentials.
 
-3. Select _CodeCommit_ as the **Provider**.
+1.  Select _CodeCommit_ as the **Provider**.
 
-4. Enter the **Access key** and **Secret key** of the AWS IAM account that will be used to access the target CodeCommit repository.
+1.  Enter the **Access key** and **Secret key** of the AWS IAM account that will be used to access the target CodeCommit repository.
 
-5. Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the credentials to a specific region, e.g., `https://git-codecommit.eu-west-1.amazonaws.com`.
+1.  Enter the **Repository base URL** for which the credentials should be applied (recommended). This option can be used to apply the credentials to a specific region, e.g., `https://git-codecommit.eu-west-1.amazonaws.com`.
 
 ### Self-hosted Git
 

--- a/platform_versioned_docs/version-23.4.0/launch/cache-resume.mdx
+++ b/platform_versioned_docs/version-23.4.0/launch/cache-resume.mdx
@@ -8,11 +8,11 @@ tags: [cache, launch, resume, relaunch]
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Nextflow maintains a [cache](https://www.nextflow.io/docs/latest/cache-and-resume.html) directory where it stores the intermediate results and metadata from workflow runs. Workflows executed in Seqera Platform use this caching mechanism to enable users to relaunch or resume failed or otherwise interrupted runs as needed. This eliminates the need to re-execute successfully completed tasks when a workflow is executed again due to task failures or other interruptions. 
+Nextflow maintains a [cache](https://www.nextflow.io/docs/latest/cache-and-resume.html) directory where it stores the intermediate results and metadata from workflow runs. Workflows executed in Seqera Platform use this caching mechanism to enable users to relaunch or resume failed or otherwise interrupted runs as needed. This eliminates the need to re-execute successfully completed tasks when a workflow is executed again due to task failures or other interruptions.
 
 ## Cache directory
 
-Nextflow stores all task executions to the task cache automatically, whether or not the resume or relaunch option is used. This makes it possible to resume or relaunch runs later if needed. Platform HPC and local compute environments use the default Nextflow cache directory (`.nextflow/cache`) to store the task cache. Cloud compute environments use the [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) mechanism to store the task cache in a sub-folder of the pipeline work directory. 
+Nextflow stores all task executions to the task cache automatically, whether or not the resume or relaunch option is used. This makes it possible to resume or relaunch runs later if needed. Platform HPC and local compute environments use the default Nextflow cache directory (`.nextflow/cache`) to store the task cache. Cloud compute environments use the [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) mechanism to store the task cache in a sub-folder of the pipeline work directory.
 
 To override the default cloud cache location in cloud compute environments, specify an alternate directory with the [cache](https://www.nextflow.io/docs/latest/process.html#process-cache) directive in your Nextflow configuration file (either in the **Advanced options > Nextflow config file** field on the launch form, or in the `nextflow.config` file in your pipeline repository).
 
@@ -21,44 +21,42 @@ To override the default cloud cache location in cloud compute environments, spec
 
 To customize the cache location used in your AWS Batch and Amazon EKS compute environments, specify an alternate cache directory in your Nextflow configuration:
 
-```groovy 
+```groovy
 cloudcache {
    enabled = true
    path = 's3://your-bucket/.cache'
    }
 ```
 
-The new cache directory must be accessible with the credentials associated with your compute environment. An alternate cloud storage location can be specified if you include the necessary credentials for that location in your Nextflow configuration. **This is not recommended for production environments**. 
+The new cache directory must be accessible with the credentials associated with your compute environment. An alternate cloud storage location can be specified if you include the necessary credentials for that location in your Nextflow configuration. **This is not recommended for production environments**.
 
 </TabItem>
 <TabItem value="Azure Batch" label="Azure Batch" default>
 
 To customize the cache location used in your Azure Batch compute environments, specify an alternate cache directory in your Nextflow configuration:
 
-```groovy 
+```groovy
 cloudcache {
    enabled = true
    path = 'az://your-container/.cache'
    }
 ```
 
-The new cache directory must be accessible with the credentials associated with your compute environment. An alternate cloud storage location can be specified if you include the necessary credentials for that location in your Nextflow configuration. **This is not recommended for production environments**. 
-
+The new cache directory must be accessible with the credentials associated with your compute environment. An alternate cloud storage location can be specified if you include the necessary credentials for that location in your Nextflow configuration. **This is not recommended for production environments**.
 
 </TabItem>
 <TabItem value="Google Cloud Batch and Google GKE" label="Google Cloud Batch and Google GKE " default>
 
 To customize the cache location used in your Google Cloud Batch and Google GKE compute environments, specify an alternate cache directory in your Nextflow configuration:
 
-```groovy 
+```groovy
 cloudcache {
    enabled = true
    path = 'gs://your-bucket/.cache'
    }
 ```
 
-The new cache directory must be accessible with the credentials associated with your compute environment. An alternate cloud storage location can be specified if you include the necessary credentials for that location in your Nextflow configuration. **This is not recommended for production environments**. 
-
+The new cache directory must be accessible with the credentials associated with your compute environment. An alternate cloud storage location can be specified if you include the necessary credentials for that location in your Nextflow configuration. **This is not recommended for production environments**.
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes" default>
@@ -124,7 +122,7 @@ Kubernetes compute environments do not use cloud cache by default. To specify a 
          path = 'gs://your-bucket/.cache'
          }
       ```
-   
+
    </details>
 
 </TabItem>

--- a/platform_versioned_docs/version-23.4.0/launch/launchpad.mdx
+++ b/platform_versioned_docs/version-23.4.0/launch/launchpad.mdx
@@ -47,24 +47,24 @@ For more information on relaunch and resume, see [Cache and resume](./cache-resu
 
 **Quick launch an unconfigured pipeline**
 
-1. Select **launch a run without configuration** below the Launchpad heading.
-1. On the **Launch** form, enter an optional **Workflow run name** (or keep the randomly assigned default) and assign optional labels to the run.
-1. Select a **Compute environment** from the available options. See [Compute environments](../compute-envs/overview.mdx) to learn how to create an environment for your preferred execution platform.
-1. Enter a repository URL for the **Pipeline to launch** (e.g., `https://github.com/nf-core/rnaseq.git`).
+1.  Select **launch a run without configuration** below the Launchpad heading.
+1.  On the **Launch** form, enter an optional **Workflow run name** (or keep the randomly assigned default) and assign optional labels to the run.
+1.  Select a **Compute environment** from the available options. See [Compute environments](../compute-envs/overview.mdx) to learn how to create an environment for your preferred execution platform.
+1.  Enter a repository URL for the **Pipeline to launch** (e.g., `https://github.com/nf-core/rnaseq.git`).
 
     :::note
     Nextflow pipelines are Git repositories that can reside on any public or private Git-hosting platform. See [Git integration](../git/overview.mdx) in the Seqera docs and [Pipeline sharing](https://www.nextflow.io/docs/latest/sharing.html) in the Nextflow docs for more details.
     :::
 
-1. Select a **Revision number** to use a specific version of the pipeline (optional). The Git default branch (e.g. main or master) or `manifest.defaultBranch` in the Nextflow configuration will be used by default.
-1. Enter the **Work directory**, which corresponds to the Nextflow work directory. You can also **Browse** for a cloud storage directory with Data Explorer. The default work directory of the compute environment will be used by default.
+1.  Select a **Revision number** to use a specific version of the pipeline (optional). The Git default branch (e.g. main or master) or `manifest.defaultBranch` in the Nextflow configuration will be used by default.
+1.  Enter the **Work directory**, which corresponds to the Nextflow work directory. You can also **Browse** for a cloud storage directory with Data Explorer. The default work directory of the compute environment will be used by default.
 
     :::note
     The credentials associated with the compute environment must have access to the work directory (e.g., an S3 bucket).
     :::
 
-1. Select any **Config profiles** you wish to use. See [Nextflow Config profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) for more details.
-1. Enter any **Pipeline parameters** in YAML or JSON format:
+1.  Select any **Config profiles** you wish to use. See [Nextflow Config profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) for more details.
+1.  Enter any **Pipeline parameters** in YAML or JSON format:
 
     ```
     reads: 's3://nf-bucket/exome-data/ERR013140_{1,2}.fastq.bz2'
@@ -75,14 +75,13 @@ For more information on relaunch and resume, see [Cache and resume](./cache-resu
     In YAML, quotes should be used for paths but not for numbers or Boolean values.
     :::
 
+1.  Select or create [resource labels](../resource-labels/overview.mdx) to apply to the resources consumed by the run, if needed.
 
-1. Select or create [resource labels](../resource-labels/overview.mdx) to apply to the resources consumed by the run, if needed.
+1.  Expand the [Pipeline secrets](../secrets/overview.mdx) dropdown to select user or workspace secrets to be used during the run, if needed.
 
-1. Expand the [Pipeline secrets](../secrets/overview.mdx) dropdown to select user or workspace secrets to be used during the run, if needed.
+1.  Apply any [Advanced options](./advanced.mdx), if needed.
 
-1. Apply any [Advanced options](./advanced.mdx), if needed.
-
-1. When you have filled the necessary launch form details, select **Launch**. The **Runs** tab shows your new run in a **submitted** status on the top of the list. Select the run name to navigate to the run detail page and view the configuration, parameters, status of individual tasks, and run report.
+1.  When you have filled the necessary launch form details, select **Launch**. The **Runs** tab shows your new run in a **submitted** status on the top of the list. Select the run name to navigate to the run detail page and view the configuration, parameters, status of individual tasks, and run report.
 
 :::note
 For more information on relaunch and resume, see [Cache and resume](./cache-resume.mdx).

--- a/platform_versioned_docs/version-23.4.0/orgs-and-teams/organizations.mdx
+++ b/platform_versioned_docs/version-23.4.0/orgs-and-teams/organizations.mdx
@@ -14,10 +14,10 @@ You can also add external collaborators to an organization.
 
 ### Create an organization
 
-1. Go to [Your organizations](https://tower.nf/orgs) and select **Add Organization**.
-2. Enter a **Name** and **Full name** for your organization.
-3. Enter any other optional fields as needed: **Description**, **Location**, **Website URL** and **Logo**.
-4. Select **Add**.
+1.  Go to [Your organizations](https://tower.nf/orgs) and select **Add Organization**.
+1.  Enter a **Name** and **Full name** for your organization.
+1.  Enter any other optional fields as needed: **Description**, **Location**, **Website URL** and **Logo**.
+1.  Select **Add**.
 
 ### Edit an organization
 
@@ -43,9 +43,9 @@ Seqera provides access control for members of an organization by classifying the
 
 To add a new member to an organization:
 
-1. Go to the **Members** tab of the organization menu.
-2. Select **Add member**.
-3. Enter the name or email address of the user you'd like to add to the organization.
+1.  Go to the **Members** tab of the organization menu.
+1.  Select **Add member**.
+1.  Enter the name or email address of the user you'd like to add to the organization.
 
 An email invitiation will be sent to the user. Once they accept the invitation, they can switch to the organization (or organization workspace) using their workspace drop-down.
 
@@ -57,11 +57,11 @@ An email invitiation will be sent to the user. Once they accept the invitation, 
 
 To create a new team within an organization:
 
-1. Go to the **Teams** tab of the organization menu.
-2. Select **Add Team**.
-3. Enter the **Name** of team.
-4. Optionally, add the **Description** and the team's **Avatar**.
-5. Select **Add**.
+1.  Go to the **Teams** tab of the organization menu.
+1.  Select **Add Team**.
+1.  Enter the **Name** of team.
+1.  Optionally, add the **Description** and the team's **Avatar**.
+1.  Select **Add**.
 
 To start adding members to your team, select **Edit > Members of team > Add member** and type in the name or email address of the organization members or collaborators.
 

--- a/platform_versioned_docs/version-23.4.0/orgs-and-teams/workspace-management.mdx
+++ b/platform_versioned_docs/version-23.4.0/orgs-and-teams/workspace-management.mdx
@@ -19,12 +19,12 @@ A workspace participant may be a member of the workspace organization or a colla
 
 Organization owners and admins can create a new workspace within an organization:
 
-1. Go to the **Workspaces** tab of the organization page.
-2. Select **Add Workspace**.
-3. Enter the **Name** and **Full name** for the workspace.
-4. Optionally, add a **Description** for the workspace.
-5. Under **Visibility**, select either **Private** or **Shared**. Private visibility means that workspace pipelines are only accessible to workspace participants.
-6. Select **Add**.
+1.  Go to the **Workspaces** tab of the organization page.
+1.  Select **Add Workspace**.
+1.  Enter the **Name** and **Full name** for the workspace.
+1.  Optionally, add a **Description** for the workspace.
+1.  Under **Visibility**, select either **Private** or **Shared**. Private visibility means that workspace pipelines are only accessible to workspace participants.
+1.  Select **Add**.
 
 :::tip
 As a workspace owner, you can modify optional workspace fields after workspace creation. You can either select **Edit** on an organization's workspaces list or the **Settings** tab within the workspace page.
@@ -44,10 +44,10 @@ Open the **Settings** tab on the workspace page and select **Edit Workspace**. M
 
 A new workspace participant can be an existing organization member, team, or collaborator. To add a new participant to a workspace:
 
-1. Go to the **Participants** tab in the workspace menu.
-2. Select **Add participant**.
-3. Enter the **Name** of the new participant.
-4. Optionally, update the participant **role**.
+1.  Go to the **Participants** tab in the workspace menu.
+1.  Select **Add participant**.
+1.  Enter the **Name** of the new participant.
+1.  Optionally, update the participant **role**.
 
 ## Participant roles
 
@@ -59,12 +59,12 @@ You can group **members** and **collaborators** into **teams** and apply a role 
 
 You can apply one of the following roles to workspace participants:
 
-1. **Owner**: The participant has full permissions for all resources within the workspace, including the workspace settings.
-2. **Admin**: The participant has full permissions for resources associated with the workspace and access to all the actions associated with all roles, including all data-related roles. They can can create, modify, and delete pipelines, compute environments, actions, credentials, and secrets. They can also add/remove users in the workspace and edit the workspace settings. A participant with this role cannot delete a workspace.
-3. **Maintain**: The participant can launch pipelines and modify pipeline executions (e.g., change the pipeline launch compute environment, parameters, pre/post-run scripts, Nextflow config), create new pipeline configurations in the Launchpad, and add secrets. They can upload, download, and preview data in Data Explorer, hide/unhide buckets, manage buckets, and manage the metadata associated with buckets. They can also add, update, and delete a data studio session. This includes starting, stopping, and changing the configuration. A participant with this role cannot modify compute environment settings and credentials.
-4. **Launch**: The participant can launch pipelines and modify the pipeline input/output parameters in the Launchpad. This includes starting, stopping, and changing the configuration. They cannot modify the launch configuration or other resources. They can list, search and view the status, configuration, and details of data studio sessions and connect to a running data studio session.
-5. **Connect**: The participant can list, search, and view the status, configuration, and details of data studios sessions. They cannot add, update (start/stop/change config) or delete data studios sessions. They can also connect to a running data studio session and interact with the contents, and access team resources in read-only mode. They cannot launch or maintain pipelines. A participant with this role also cannot manage any data in Data Explorer — uploading, downloading, or previewing data, hiding/unhiding, managing buckets, or managing the metadata associated with buckets.
-6. **View**: The participant can only access team resources in read-only mode. This includes the ability to list, search, and view the status, configuration, and details of mounted data in Data Explorer and data studio sessions.
+1.  **Owner**: The participant has full permissions for all resources within the workspace, including the workspace settings.
+1.  **Admin**: The participant has full permissions for resources associated with the workspace and access to all the actions associated with all roles, including all data-related roles. They can can create, modify, and delete pipelines, compute environments, actions, credentials, and secrets. They can also add/remove users in the workspace and edit the workspace settings. A participant with this role cannot delete a workspace.
+1.  **Maintain**: The participant can launch pipelines and modify pipeline executions (e.g., change the pipeline launch compute environment, parameters, pre/post-run scripts, Nextflow config), create new pipeline configurations in the Launchpad, and add secrets. They can upload, download, and preview data in Data Explorer, hide/unhide buckets, manage buckets, and manage the metadata associated with buckets. They can also add, update, and delete a data studio session. This includes starting, stopping, and changing the configuration. A participant with this role cannot modify compute environment settings and credentials.
+1.  **Launch**: The participant can launch pipelines and modify the pipeline input/output parameters in the Launchpad. This includes starting, stopping, and changing the configuration. They cannot modify the launch configuration or other resources. They can list, search and view the status, configuration, and details of data studio sessions and connect to a running data studio session.
+1.  **Connect**: The participant can list, search, and view the status, configuration, and details of data studios sessions. They cannot add, update (start/stop/change config) or delete data studios sessions. They can also connect to a running data studio session and interact with the contents, and access team resources in read-only mode. They cannot launch or maintain pipelines. A participant with this role also cannot manage any data in Data Explorer — uploading, downloading, or previewing data, hiding/unhiding, managing buckets, or managing the metadata associated with buckets.
+1.  **View**: The participant can only access team resources in read-only mode. This includes the ability to list, search, and view the status, configuration, and details of mounted data in Data Explorer and data studio sessions.
 
 ## Workspace run monitoring
 

--- a/platform_versioned_docs/version-23.4.0/pipeline-actions/overview.mdx
+++ b/platform_versioned_docs/version-23.4.0/pipeline-actions/overview.mdx
@@ -17,12 +17,12 @@ You must sign in to Seqera using GitHub authentication to create a GitHub webhoo
 
 To create a new action, select the **Actions** tab and select **Add Action**.
 
-1. Enter a **Name** for your action.
-2. Select **GitHub webhook** as the **Event source**.
-3. Select the **Compute environment** where the pipeline will be executed.
-4. Select the **Pipeline to launch** and (optionally) the **Revision number**.
-5. Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
-6. Select **Add**.
+1.  Enter a **Name** for your action.
+1.  Select **GitHub webhook** as the **Event source**.
+1.  Select the **Compute environment** where the pipeline will be executed.
+1.  Select the **Pipeline to launch** and (optionally) the **Revision number**.
+1.  Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
+1.  Select **Add**.
 
 The pipeline action is now set up. When a new commit occurs for the selected repository and revision, an event is triggered and the pipeline is launched.
 
@@ -40,12 +40,12 @@ A **Tower launch hook** creates a custom endpoint URL which can be used to trigg
 
 To create a new action, select the **Actions** tab and select **Add Action**.
 
-1. Enter a **Name** for your action.
-2. Select **Tower launch hook** as the event source.
-3. Select the **Compute environment** to execute your pipeline.
-4. Enter the **Pipeline to launch** and (optionally) the **Revision number**.
-5. Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
-6. Select **Add**.
+1.  Enter a **Name** for your action.
+1.  Select **Tower launch hook** as the event source.
+1.  Select the **Compute environment** to execute your pipeline.
+1.  Enter the **Pipeline to launch** and (optionally) the **Revision number**.
+1.  Enter the **Work directory**, the **Config profiles**, and the **Pipeline parameters**.
+1.  Select **Add**.
 
 The pipeline action is now set up and the new endpoint can be used to launch the corresponding pipeline programmatically.
 

--- a/platform_versioned_docs/version-23.4.0/pipeline-optimization/overview.mdx
+++ b/platform_versioned_docs/version-23.4.0/pipeline-optimization/overview.mdx
@@ -19,17 +19,17 @@ Due to the variability of production pipeline data inputs, optimization results 
 
 On the **Launchpad**, each pipeline that can be optimized shows a lightbulb icon. Any pipeline with at least one successful run can be optimized.
 
-1. Select the lightbulb icon to open the **Customize optimization profile** menu.
+1.  Select the lightbulb icon to open the **Customize optimization profile** menu.
 
-2. Under the **Optimization profile** tab, select a previous run from the dropdown. The list contains all successful runs.
+1.  Under the **Optimization profile** tab, select a previous run from the dropdown. The list contains all successful runs.
 
-3. Select which **Targets** to optimize.
+1.  Select which **Targets** to optimize.
 
-4. Enable **Retry with dynamic resources** for failed tasks to be retried with increased resources. This option is useful if an optimized setting is too low and causes a task to fail.
+1.  Enable **Retry with dynamic resources** for failed tasks to be retried with increased resources. This option is useful if an optimized setting is too low and causes a task to fail.
 
-5. Select the **Optimized configuration** tab to preview your configuration.
+1.  Select the **Optimized configuration** tab to preview your configuration.
 
-6. Select **Save** to save the optimized configuration and enable it for the pipeline. All subsequent launches of the pipeline will use the optimized configuration.
+1.  Select **Save** to save the optimized configuration and enable it for the pipeline. All subsequent launches of the pipeline will use the optimized configuration.
 
 You can also toggle the optimized profile from the pipeline detail page.
 
@@ -53,10 +53,10 @@ However, it's common for a pipeline to process input files that vary widely in s
 
 The best way to handle this variation is to create multiple optimized profiles for specific ranges of input sizes. Here is an example strategy:
 
-1. Separate your input files into "bins" based on their size, e.g., _small_, _medium_, and _large_. Duplicate your pipeline in the **Launchpad** for each bin.
+1.  Separate your input files into "bins" based on their size, e.g., _small_, _medium_, and _large_. Duplicate your pipeline in the **Launchpad** for each bin.
 
-2. For each bin, run the pipeline with a few representative samples from that bin. When the run completes, Seqera automatically creates an optimized profile for it.
+1.  For each bin, run the pipeline with a few representative samples from that bin. When the run completes, Seqera automatically creates an optimized profile for it.
 
-3. Configure and enable the optimized profile for each pipeline.
+1.  Configure and enable the optimized profile for each pipeline.
 
 You now have multiple optimized profiles to handle a variety of input sizes. Although this example uses three bins, you can use as many or as few bins as you need to handle the variation of your input data.

--- a/platform_versioned_docs/version-23.4.0/reports/overview.mdx
+++ b/platform_versioned_docs/version-23.4.0/reports/overview.mdx
@@ -21,8 +21,8 @@ You can download a report directly or from the provided file path. Reports large
 
 Create a config file that defines the paths to a selection of output files published by the pipeline for Seqera to render reports. There are 2 ways to provide the config file, both of which have to be in YAML format:
 
-1. **Pipeline repository**: If a file called `tower.yml` exists in the root of the pipeline repository then this will be fetched automatically before the pipeline execution.
-2. **Seqera Platform interface**: Provide the YAML definition within the **Advanced options > Seqera Cloud config file** box when:
+1.  **Pipeline repository**: If a file called `tower.yml` exists in the root of the pipeline repository then this will be fetched automatically before the pipeline execution.
+1.  **Seqera Platform interface**: Provide the YAML definition within the **Advanced options > Seqera Cloud config file** box when:
    - Creating a pipeline in the Launchpad.
    - Amending the launch settings during pipeline launch. This is available to users with the **Maintain** role only.
 

--- a/platform_versioned_docs/version-23.4.0/resource-labels/overview.mdx
+++ b/platform_versioned_docs/version-23.4.0/resource-labels/overview.mdx
@@ -107,8 +107,8 @@ Under **Find resources to tag**, search for the resource label key and value in 
 
 To include the cost information associated with your resource labels in your AWS billing reports:
 
-1. [Activate](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activating-tags.html) the associated tags in the **AWS Billing and Cost Management console**. Newly-applied tags may take up to 24 hours to appear on your cost allocation tags page.
-2. When your tags are activated and displayed in **Billing and Cost Management > Cost allocation tags**, you can apply them when you create [cost allocation reports](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/configurecostallocreport.html#allocation-viewing).
+1.  [Activate](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activating-tags.html) the associated tags in the **AWS Billing and Cost Management console**. Newly-applied tags may take up to 24 hours to appear on your cost allocation tags page.
+1.  When your tags are activated and displayed in **Billing and Cost Management > Cost allocation tags**, you can apply them when you create [cost allocation reports](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/configurecostallocreport.html#allocation-viewing).
 
 #### AWS limits
 

--- a/platform_versioned_docs/version-23.4.0/secrets/overview.mdx
+++ b/platform_versioned_docs/version-23.4.0/secrets/overview.mdx
@@ -74,8 +74,8 @@ The ECS Agent uses the [Batch Execution role](https://docs.aws.amazon.com/batch/
 
 **IAM permissions**
 
-1. Add the [`AmazonECSTaskExecutionRolePolicy` managed policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonECSTaskExecutionRolePolicy.html).
-2. Add this inline policy:
+1.  Add the [`AmazonECSTaskExecutionRolePolicy` managed policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonECSTaskExecutionRolePolicy.html).
+1.  Add this inline policy:
 
 ```json
     {

--- a/platform_versioned_docs/version-23.4.0/supported_software/agent/agent.mdx
+++ b/platform_versioned_docs/version-23.4.0/supported_software/agent/agent.mdx
@@ -13,22 +13,22 @@ Tower Agent is a standalone process that runs on a node that can submit jobs to 
 
 Tower Agent is distributed as a single executable file to simply download and execute.
 
-1. Download the latest release from [GitHub](https://github.com/seqeralabs/tower-agent) and make the file executable:
+1.  Download the latest release from [GitHub](https://github.com/seqeralabs/tower-agent) and make the file executable:
 
    ```bash
    curl -fSL https://github.com/seqeralabs/tower-agent/releases/latest/download/tw-agent-linux-x86_64 > tw-agent
    chmod +x ./tw-agent
    ```
 
-2. (Optional) Move it to a folder that's in your $PATH.
+1.  (Optional) Move it to a folder that's in your $PATH.
 
 ### Quickstart
 
 Before running the Agent:
 
-1. Create a [**personal access token**](../../api/overview.mdx#authentication).
+1.  Create a [**personal access token**](../../api/overview.mdx#authentication).
 
-2. Create [Tower Agent credentials](../../credentials/agent_credentials.mdx) in a Seqera Platform workspace.
+1.  Create [Tower Agent credentials](../../credentials/agent_credentials.mdx) in a Seqera Platform workspace.
 
 :::note
 To share a single Tower Agent instance with all members of a workspace, create a Tower Agent credential with **Shared agent** enabled.

--- a/platform_versioned_docs/version-23.4.0/supported_software/dragen/overview.mdx
+++ b/platform_versioned_docs/version-23.4.0/supported_software/dragen/overview.mdx
@@ -27,9 +27,9 @@ To deploy the pipeline on your own AWS cloud infrastructure, follow the instruct
 
 DRAGEN is a commercial technology provided by Illumina, so you will need to purchase a license from them. To run on Seqera, you will need to obtain the following information from Illumina:
 
-1. DRAGEN AWS private AMI ID
-2. DRAGEN license username
-3. DRAGEN license password
+1.  DRAGEN AWS private AMI ID
+1.  DRAGEN license username
+1.  DRAGEN license password
 
 Batch Forge automates most of the tasks required to set up an AWS Batch compute environment. See [AWS Batch](../../compute-envs/aws-batch.mdx) for more details.
 
@@ -45,7 +45,7 @@ The Region you select must contain DRAGEN F1 instances.
 
 See the [dragen.nf](https://github.com/seqeralabs/nf-dragen/blob/master/modules/local/dragen.nf) module implemented in the [nf-dragen](https://github.com/seqeralabs/nf-dragen) pipeline for reference. Any Nextflow processes that run DRAGEN must:
 
-1. Define the `dragen` label in your Nextflow process:
+1.  Define the `dragen` label in your Nextflow process:
 
    The `label` directive allows you to annotate a process with mnemonic identifiers of your choice. Seqera will use the `dragen` label to determine which processes need to be executed on DRAGEN F1 instances.
 
@@ -59,7 +59,7 @@ See the [dragen.nf](https://github.com/seqeralabs/nf-dragen/blob/master/modules/
 
    See the [Nextflow label docs](https://www.nextflow.io/docs/latest/process.html?highlight=label#label) for more information.
 
-2. Define secrets in Seqera:
+1.  Define secrets in Seqera:
 
    At Seqera, we use secrets to safely encrypt sensitive information when running licensed software via Nextflow. This enables our team to use the DRAGEN software safely via the `nf-dragen` pipeline without the need to configure the license key. These secrets will be provided securely to the `--lic-server` option when running DRAGEN on the CLI to validate the license.
 

--- a/platform_versioned_docs/version-23.4.0/supported_software/fusion/fusion.mdx
+++ b/platform_versioned_docs/version-23.4.0/supported_software/fusion/fusion.mdx
@@ -29,11 +29,11 @@ Fusion v2 improves pipeline throughput for containerized tasks by simplifying di
 
 We recommend using Fusion with AWS NVMe instances (fast instance storage) as this delivers the fastest performance when compared to environments using only AWS EBS (Elastic Block Store).
 
-1. For this configuration, use Seqera Platform version 23.1 or later.
-2. Create an [AWS Batch compute environment](../../compute-envs/aws-batch.mdx#tower-forge).
-3. Enable Wave containers, Fusion v2, and fast instance storage.
-4. Select the **Batch Forge** config mode.
-5. Select your **Instance types** under Advanced options:
+1.  For this configuration, use Seqera Platform version 23.1 or later.
+1.  Create an [AWS Batch compute environment](../../compute-envs/aws-batch.mdx#tower-forge).
+1.  Enable Wave containers, Fusion v2, and fast instance storage.
+1.  Select the **Batch Forge** config mode.
+1.  Select your **Instance types** under Advanced options:
    - If unspecified, Seqera will select the following NVMe-based instance type families: `'c5ad', 'c5d', 'c6id', 'i3', 'i4i', 'm5ad', 'm5d', 'm6id', 'r5ad', 'r5d', 'r6id'`
    - To specify an NVMe instance family type, select from the following:
      - Intel: `'c5ad', 'c5d', 'c6id', 'dl1', 'f1', 'g4ad', 'g4dn', 'g5', 'i3', 'i3en', 'i4i', 'm5ad', 'm5d', 'm5dn', 'm6id', 'p3dn', 'p4d', 'p4de', 'r5ad', 'r5d', 'r5dn', 'r6id', 'x2idn', 'x2iedn', 'z1d'`
@@ -47,17 +47,17 @@ When enabling fast instance storage, do not select the `optimal` instance type f
 We recommend selecting 8xlarge or above for large and long-lived production pipelines. Dedicated networking ensures a guaranteed network speed service level compared with "burstable" instances. See [Instance network bandwidth](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-network-bandwidth.html) for more information.
 :::
 
-6. Use an S3 bucket as the pipeline work directory.
+1.  Use an S3 bucket as the pipeline work directory.
 
 #### Batch Forge AWS compute environments with Fusion only
 
 To use Fusion in AWS environments without NVMe instances, enable Wave containers and Fusion v2 when creating a new compute environment without enabling fast instance storage. This option configures an AWS EBS (Elastic Bucket Store) disk with settings optimized for the Fusion file system.
 
-1. For this configuration, use Seqera Platform version 23.1 or later.
-2. Create an [AWS Batch compute environment](../../compute-envs/aws-batch.mdx#tower-forge).
-3. Enable Wave containers and Fusion v2.
-4. Select the **Batch Forge** config mode.
-5. When you enable Fusion v2 without fast instance storage, the following settings are applied:
+1.  For this configuration, use Seqera Platform version 23.1 or later.
+1.  Create an [AWS Batch compute environment](../../compute-envs/aws-batch.mdx#tower-forge).
+1.  Enable Wave containers and Fusion v2.
+1.  Select the **Batch Forge** config mode.
+1.  When you enable Fusion v2 without fast instance storage, the following settings are applied:
 
    - `process.scratch = false` is added to the Nextflow configuration file
    - EBS autoscaling is disabled
@@ -65,7 +65,7 @@ To use Fusion in AWS environments without NVMe instances, enable Wave containers
    - EBS boot disk type is changed to GP3
    - EBS boot disk throughput is increased to 325MB/s
 
-6. Use an S3 bucket as the pipeline work directory.
+1.  Use an S3 bucket as the pipeline work directory.
 
 #### Fusion in manual compute environments
 

--- a/wave_docs/cli/install.mdx
+++ b/wave_docs/cli/install.mdx
@@ -5,12 +5,12 @@ title: Install the Wave CLI
 To install the `wave` CLI for your platform, complete the following steps:
 
 1.  Download the [latest version of the Wave CLI][download] for your platform.
-2.  In a new terminal, complete the following steps:
+1.  In a new terminal, complete the following steps:
 
     1. Move the executable from your downloads folder to a location in your `PATH`, such as `~/bin`. For example: `mv wave-cli-0.8.0-macos-x86_64 ~/bin/wave`
     2. Ensure that the executable bit is set. For example: `chmod u+x ~/bin/wave`
 
-3.  Verify that you can build containers with Wave:
+1.  Verify that you can build containers with Wave:
 
     1.  Create a basic `Dockerfile`:
 

--- a/wave_docs/faq.mdx
+++ b/wave_docs/faq.mdx
@@ -13,8 +13,8 @@ From a technical point of view, Wave behaves as a proxy server that intermediate
 Wave has been designed to streamline the use of software containers with Nextflow data analysis pipelines, in three ways:
 
 1. Safely handle the authentication of container repositories to allow access to private registries and the ability to pull from public registries without being affected by service rate limits.
-2. Dynamically include in the container execution context pipeline scripts and infrastructure-related dependencies, without the need to rebuild the corresponding containers.
-3. Building the pipeline containers on-demand, using Dockerfiles associated with the pipeline modules or Conda packages specified in the pipeline configuration.
+1. Dynamically include in the container execution context pipeline scripts and infrastructure-related dependencies, without the need to rebuild the corresponding containers.
+1. Building the pipeline containers on-demand, using Dockerfiles associated with the pipeline modules or Conda packages specified in the pipeline configuration.
 
 ## How I can specify the credentials of my private container registry when using Wave?
 

--- a/wave_docs/index.mdx
+++ b/wave_docs/index.mdx
@@ -29,15 +29,15 @@ Wave offers a flexible approach to container image management. It allows you to 
 Imagine you have a base Ubuntu image in a container registry. Wave acts as a proxy between your docker client and the registry. When you request an augmented image, Wave intercepts the process.
 
 1. Base image layers download: The Docker client downloads the standard Ubuntu layers from the registry.
-2. Custom layer injection: Wave injects your custom layer, denoted by "ω", which could represent application code, libraries, configurations etc.
-3. New image creation: Wave combines the downloaded Ubuntu layers with your custom layer, effectively creating a new image on the fly.
+1. Custom layer injection: Wave injects your custom layer, denoted by "ω", which could represent application code, libraries, configurations etc.
+1. New image creation: Wave combines the downloaded Ubuntu layers with your custom layer, effectively creating a new image on the fly.
 
 ![](_images/wave_container_augmentation.png)
 
 #### Benefits of Wave augmentation
 
 1. Streamlined workflows: Wave simplifies your workflow by eliminating the need to manually build and manage custom images.
-2. Flexibility: You can easily modify the custom layer for different use cases, allowing for greater adaptability.
+1. Flexibility: You can easily modify the custom layer for different use cases, allowing for greater adaptability.
 
 ### Conda based containers
 


### PR DESCRIPTION
Next set.

This can fix only `list-marker-space` and half of `ol-prefix` automatically. It leaves _unordered lists_ at indentation of _one space_, so no change is necessary here.

This needs to be manually verified, because it does break some things; for example, _admonitions_ in ordered lists must be double checked because they might not be indented the correct number of spaces.

This is because this list uses _two digit_ numbers. So correct spacing is actually _5_. We should change this to `1.` for every item instead.

**This PR transforms all NN. to 1. to avoid this issue.**

```
13.  Store the access keys for your Azure Batch account, to be used when you create a Seqera compute environment.

    :::caution
    A newly-created Azure Batch account may not be entitled to create virtual machines without making a service request to Azure.
    See [Azure Batch service quotas and limits][az-batch-quotas] for more information.
    :::
```