### PR TITLE
Experimental work in using Material Design icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "clsx": "^1.2.1",
         "docusaurus-remark-plugin-tab-blocks": "^3.0.0",
         "framer-motion": "^11.0.0",
+        "mdi-react": "^9.4.0",
         "postcss-import": "^15.1.0",
         "postcss-nesting": "^12.0.1",
         "prism-react-renderer": "^2.1.0",
@@ -10584,6 +10585,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdi-react": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/mdi-react/-/mdi-react-9.4.0.tgz",
+      "integrity": "sha512-3McdJimHT2CO+bSDGgJ1SSmU6HvXLEwLdfFi3M/nQT4aauvVxIbIGTCI8eOCcPtkyVyVuZRcCZ7Gw0oaGldYLw==",
+      "peerDependencies": {
+        "react": ">=0.14.0"
       }
     },
     "node_modules/mdn-data": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "clsx": "^1.2.1",
     "docusaurus-remark-plugin-tab-blocks": "^3.0.0",
     "framer-motion": "^11.0.0",
+    "mdi-react": "^9.4.0",
     "postcss-import": "^15.1.0",
     "postcss-nesting": "^12.0.1",
     "prism-react-renderer": "^2.1.0",

--- a/src/css/misc.css
+++ b/src/css/misc.css
@@ -58,3 +58,11 @@ html.plugin-id-fusion {
     }
   }
 }
+
+/**
+Material Design Icons (SVG)
+*/
+.mdi-icon {
+  vertical-align: middle;
+  margin: -4px;
+}


### PR DESCRIPTION
This could be useful.

<img width="750" alt="Screenshot 2024-04-23 at 11 53 19 AM" src="https://github.com/seqeralabs/docs/assets/141646877/903ab52e-fd7f-4be8-8be7-1127b1c46119">

This needs `vertical-align: middle` CSS. Possibly `margin: -2px` as well.

https://www.npmjs.com/package/mdi-react