### PR TITLE
Correct label limits

### DIFF
--- a/platform_versioned_docs/version-23.3.0/labels/overview.mdx
+++ b/platform_versioned_docs/version-23.3.0/labels/overview.mdx
@@ -18,7 +18,7 @@ Label names must contain a minimum of 2 and a maximum of 39 alphanumeric charact
 - Label names cannot begin or end with dashes `-` or underscores `_`.
 - Label names cannot contain a consecutive combination of `-` or `_` characters (`--`, `__`, `-_`, etc.)
 - A maximum of 25 labels can be applied to each resource.
-- A maximum of 100 labels can be used in each workspace.
+- A maximum of 1000 labels can be used in each workspace.
 
 ### Create and apply labels
 

--- a/platform_versioned_docs/version-23.3.0/resource-labels/overview.mdx
+++ b/platform_versioned_docs/version-23.3.0/resource-labels/overview.mdx
@@ -116,7 +116,7 @@ To include the cost information associated with your resource labels in your AWS
 - The key and value cannot begin or end with dashes `-` or underscores `_`.
 - The key and value cannot contain a consecutive combination of `-` or `_` characters (`--`, `__`, `-_`, etc.)
 - A maximum of 25 resource labels can be applied to each resource.
-- A maximum of 100 resource labels can be used in each workspace.
+- A maximum of 1000 resource labels can be used in each workspace.
 - Keys and values cannot start with `aws` or `user`, as these are reserved prefixes appended to tags by AWS.
 - Keys and values are case-sensitive in AWS.
 
@@ -143,7 +143,7 @@ When the compute environment is created with Forge, the following resources will
 - The key and value cannot begin or end with dashes `-` or underscores `_`.
 - The key and value cannot contain a consecutive combination of `-` or `_` characters (`--`, `__`, `-_`, etc.)
 - A maximum of 25 resource labels can be applied to each resource.
-- A maximum of 100 resource labels can be used in each workspace.
+- A maximum of 1000 resource labels can be used in each workspace.
 - Keys and values in Google Cloud Resource Manager may contain only lowercase letters. Resource labels created with uppercase characters are changed to lowercase before propagating to Google Cloud.
 
 See [here](https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements) for more information on Google Cloud Resource Manager labeling.
@@ -162,7 +162,7 @@ When creating an Azure Batch compute environment with Forge, resource labels are
 - The key and value cannot begin or end with dashes `-` or underscores `_`.
 - The key and value cannot contain a consecutive combination of `-` or `_` characters (`--`, `__`, `-_`, etc.)
 - A maximum of 25 resource labels can be applied to each resource.
-- A maximum of 100 resource labels can be used in each workspace.
+- A maximum of 1000 resource labels can be used in each workspace.
 - Keys are case-insensitive, but values are case-sensitive.
 - Microsoft advises against using a non-English language in your resource labels, as this can lead to decoding progress failure while loading your VM's metadata.
 
@@ -197,6 +197,6 @@ The following resources will be tagged using the labels associated with the comp
 - The key and value cannot begin or end with dashes `-` or underscores `_`.
 - The key and value cannot contain a consecutive combination of `-` or `_` characters (`--`, `__`, `-_`, etc.)
 - A maximum of 25 resource labels can be applied to each resource.
-- A maximum of 100 resource labels can be used in each workspace.
+- A maximum of 1000 resource labels can be used in each workspace.
 
 See [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) for more information on Kubernetes object labeling.

--- a/platform_versioned_docs/version-23.4.0/labels/overview.mdx
+++ b/platform_versioned_docs/version-23.4.0/labels/overview.mdx
@@ -18,7 +18,7 @@ Label names must contain a minimum of 2 and a maximum of 39 alphanumeric charact
 - Label names cannot begin or end with dashes `-` or underscores `_`.
 - Label names cannot contain a consecutive combination of `-` or `_` characters (`--`, `__`, `-_`, etc.)
 - A maximum of 25 labels can be applied to each resource.
-- A maximum of 100 labels can be used in each workspace.
+- A maximum of 1000 labels can be used in each workspace.
 
 ### Create and apply labels
 

--- a/platform_versioned_docs/version-23.4.0/resource-labels/overview.mdx
+++ b/platform_versioned_docs/version-23.4.0/resource-labels/overview.mdx
@@ -116,7 +116,7 @@ To include the cost information associated with your resource labels in your AWS
 - The key and value cannot begin or end with dashes `-` or underscores `_`.
 - The key and value cannot contain a consecutive combination of `-` or `_` characters (`--`, `__`, `-_`, etc.)
 - A maximum of 25 resource labels can be applied to each resource.
-- A maximum of 100 resource labels can be used in each workspace.
+- A maximum of 1000 resource labels can be used in each workspace.
 - Keys and values cannot start with `aws` or `user`, as these are reserved prefixes appended to tags by AWS.
 - Keys and values are case-sensitive in AWS.
 
@@ -143,7 +143,7 @@ When the compute environment is created with Forge, the following resources will
 - The key and value cannot begin or end with dashes `-` or underscores `_`.
 - The key and value cannot contain a consecutive combination of `-` or `_` characters (`--`, `__`, `-_`, etc.)
 - A maximum of 25 resource labels can be applied to each resource.
-- A maximum of 100 resource labels can be used in each workspace.
+- A maximum of 1000 resource labels can be used in each workspace.
 - Keys and values in Google Cloud Resource Manager may contain only lowercase letters. Resource labels created with uppercase characters are changed to lowercase before propagating to Google Cloud.
 
 See [here](https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements) for more information on Google Cloud Resource Manager labeling.
@@ -162,7 +162,7 @@ When creating an Azure Batch compute environment with Forge, resource labels are
 - The key and value cannot begin or end with dashes `-` or underscores `_`.
 - The key and value cannot contain a consecutive combination of `-` or `_` characters (`--`, `__`, `-_`, etc.)
 - A maximum of 25 resource labels can be applied to each resource.
-- A maximum of 100 resource labels can be used in each workspace.
+- A maximum of 1000 resource labels can be used in each workspace.
 - Keys are case-insensitive, but values are case-sensitive.
 - Microsoft advises against using a non-English language in your resource labels, as this can lead to decoding progress failure while loading your VM's metadata.
 
@@ -197,6 +197,6 @@ The following resources will be tagged using the labels associated with the comp
 - The key and value cannot begin or end with dashes `-` or underscores `_`.
 - The key and value cannot contain a consecutive combination of `-` or `_` characters (`--`, `__`, `-_`, etc.)
 - A maximum of 25 resource labels can be applied to each resource.
-- A maximum of 100 resource labels can be used in each workspace.
+- A maximum of 1000 resource labels can be used in each workspace.
 
 See [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) for more information on Kubernetes object labeling.


### PR DESCRIPTION
Update label and resource label limits to 1000 on Labels overview and Resource labels overview pages, versions 23.3 and 23.4.