### PR TITLE
Prevent Git conflict markers from getting published

### DIFF
--- a/.github/workflows/no-conflict-markers.yml
+++ b/.github/workflows/no-conflict-markers.yml
@@ -1,0 +1,16 @@
+# https://stackoverflow.com/a/76322606
+name: No unresolved conflicts
+on:
+  pull_request:
+    branches: [ master ]
+jobs:
+  detect-unresolved-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: List files with merge conflict markers
+        run: git --no-pager grep "<<<<<<<" ":(exclude).github/" || true
+      - name: Fail or succeed job if any files with merge conflict markers have been checked in
+        # Find lines containing "<<<<<<<", then count the number of lines.
+        # 0 matching lines results in exit code 0, i.e. success.
+        run: exit $(git grep "<<<<<<<" ":(exclude).github/" | wc --lines)


### PR DESCRIPTION
This would be cool if it works; supposed to prevent merges if `>>>>>` conflict markers are present, meaning someone accidentally committed a merge conflict block.