### PR TITLE
Update Platform / Nextflow base versions

### DIFF
--- a/platform_versioned_docs/version-23.4.0/functionality_matrix/functionality_matrix.mdx
+++ b/platform_versioned_docs/version-23.4.0/functionality_matrix/functionality_matrix.mdx
@@ -1,24 +1,29 @@
 ---
-title: "Platform / Nextflow compatibility"
-description: "Platform / nf-launcher / Nextflow version compatibility matrix"
+title: "Platform / Nextflow base versions"
+description: "Platform / nf-launcher / Nextflow base versions"
 date: "21 Apr 2023"
 tags: [compatibility, nextflow, nf-launcher]
 ---
 
-Each Seqera Platform version makes use of `nf-launcher` to determine the Nextflow version used as its baseline. This Nextflow version can be overridden with the `NXF_VER` environment variable in your `nextflow.conf` file, but note that Seqera may not work reliably with Nextflow versions other than the baseline version.
+Each Seqera Platform version makes use of `nf-launcher` to determine the Nextflow version used as its baseline. This Nextflow version can be overridden with the `NXF_VER` environment variable in your `nextflow.config` file, but note that Seqera may not work reliably with Nextflow versions other than the baseline version.
 
 We officially support the two latest major releases (22.3.x, 22.4.x, etc) at any given time.
 
 nf-launcher versions prefixed with j17 refer to Java version 17; j11 refers to Java 11.
 
-| Platform version | nf-launcher version | Nextflow version |
-| ------------- | ------------------- | ---------------- |
-| 23.4.0        | j17-23.04.3         | 23.04.3          |
-| 23.3.0        | j17-23.04.3         | 23.04.3          |
-| 23.2.0        | j17.23.04.2-up3     | 23.04.2          |
-| 23.1.3        | j17-23.04.1         | 23.04.1          |
-| 22.4.1        | j17-22.10.6         | 22.10.6          |
-| 22.4.0        | j17-22.10.6         | 22.10.6          |
+| Platform version | nf-launcher version | Nextflow version | Fusion version |
+| ---------------- | ------------------- | ---------------- | -------------- |
+| 23.4.4           | j17-23.10.1         | 23.10.1          | 2.2            |
+| 23.4.3           | j17-23.10.1         | 23.10.1          | 2.2            |
+| 23.4.2           | j17-23.10.1         | 23.10.1          | 2.2            |
+| 23.4.1           | j17-23.10.1         | 23.10.1          | 2.2            |
+| 23.4.0           | j17-23.04.3         | 23.04.3          | 2.1            |
+| 23.3.0           | j17-23.04.3         | 23.04.3          | 2.1            |
+| 23.3.0           | j17-23.04.3         | 23.04.3          | 2.1            |
+| 23.2.0           | j17.23.04.2-up3     | 23.04.2          | 2.1            |
+| 23.1.3           | j17-23.04.1         | 23.04.1          | 2.1            |
+| 22.4.1           | j17-22.10.6         | 22.10.6          | -              |
+| 22.4.0           | j17-22.10.6         | 22.10.6          | -              |
 
 ---
 


### PR DESCRIPTION
* Rename page to be "base versions" instead of mentioning compatibility
* Add missing Platform patch releases, with associated nf-launcher and Nextflow versions
* Add column for Fusion version
* Fix error in `nextflow.config` filename

For reference:
* Nextflow <> Fusion version pairings can be found [here](https://github.com/nextflow-io/nextflow/blob/c713ad510b76e6483d16292b4a66f6eb05773d36/modules/nextflow/src/main/groovy/nextflow/fusion/FusionConfig.groovy#L37).
* Platform <> Launcher version pairings (and so, Nextflow) can be found [here](https://github.com/seqeralabs/platform/blob/b6cc5eaba93b264959d1ae4e827b30969221d61b/tower-services/src/main/groovy/io/seqera/tower/service/TowerServiceImpl.groovy#L43).

@netlify /platform/23.4.0/functionality_matrix