### PR TITLE
Pre-Boston clean-up and move to Public Preview

### DIFF
--- a/platform_versioned_docs/version-23.4.0/data/data-studios.mdx
+++ b/platform_versioned_docs/version-23.4.0/data/data-studios.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Data Studios"
-description: "Data Studios private preview."
-date: "12 March 2024"
+description: "Data Studios Public Preview."
+date: "17 May 2024"
 tags: [data, studios]
 ---
 
-Data Studios is a unified platform where you can host a combination of container images and compute environments for interactive analysis using your preferred tools, like Jupyter notebooks, RStudio, and Visual Studio Code IDEs. Each data studio session is an individual interactive environment that encapsulates the live environment for dynamic data analysis.
+Data Studios is a unified platform where you can host a combination of container images and compute environments for interactive tertiary analysis using your preferred tools, like JupyterLab and RStudio Notebooks, or Visual Studio Code IDEs. Each data studio session is an individual interactive environment that encapsulates the live environment for dynamic data analysis.
 
 :::note
-Data Studios is currently in **private preview** and is not yet generally available. To request access, please contact your Seqera account manager.
+Data Studios is currently in **Public Preview**.
 :::
 
 **Requirements**
@@ -25,7 +25,7 @@ Currently, Data Studios only supports AWS Batch compute environments that **do n
 
 ## Overview
 
-Select the **Data Studios** tab to view all data studios. The list includes the name, cloud provider, analysis template, region, creator, creation date, and the status of each session. In this view, you can add a new data studio, as well as start, stop, and connect to an existing data studio. You can dynamically filter the list of data studio sessions using the search bar.
+Select the **Data Studios** tab to view all data studios. The list includes the name, cloud provider, analysis template, region, author, creation date, and the status of each session. In this view, you can add a new data studio session, as well as start, stop, and connect to an existing data studio session. You can dynamically filter the list of data studio sessions using the search bar and searching by name (default), author username, or compute environment name. Selecting the session name opens a detailed view of the data studio, displaying configuration information.
 
 ## Add a data studio
 
@@ -38,19 +38,19 @@ This functionality is available to users with the **Maintain** role and above.
 5. Optional: Enter CPU and memory allocations. The default values are 2 CPUs and 8192 MB memory (RAM).
 6. Select **Add**.
 
-You'll be returned to the Data Studios landing page that displays the list of data studios in your workspace. The data studio you created will be listed with the status **stopped**.
+You'll be returned to the Data Studios landing page that displays the list of data studios in your workspace. The data studio you created will be listed with the status **stopped**. You can inspect the configuration details by selecting the data studio session name.
 
 :::note
-By default, Data Studios only has read permissions to mounted data paths. Write permissions can be added for specific cloud storage buckets during the compute environment configuration by defining additional **Allowed S3 Buckets**. This means that data can be written from the data studio session back to the cloud storage path mounted. To stop potential data loss, only one data studio session per workspace can mount a unique data path. When adding a new data studio, data paths already mounted to other running data studios are unavailable. If a new file is uploaded to the cloud storage bucket path while a session is running, the file may not be available to the data studio session immediately.
+By default, data studio sessions only have read permissions to mounted data paths. Write permissions can be added for specific cloud storage buckets during the compute environment configuration by defining additional **Allowed S3 Buckets**. This means that data can be written from the data studio session back to the cloud storage path(s) mounted. To stop potential data loss, only one data studio session per workspace can mount a unique data path. When adding a new data studio, data paths already mounted to other running data studios are unavailable. If a new file is uploaded to the cloud storage bucket path while a session is running, the file may not be available to the data studio session immediately.
 :::
 
 ### About container image templates
 
-Data Studios currently provides three container image templates: JupyterLab, RStudio Server, and Visual Studio Code. The image templates install a very limited number of packages when the Data Studio session container is built.
+Data Studios currently provides three container image templates: JupyterLab, RStudio Server, and Visual Studio Code. The image templates install a very limited number of packages when the data studio session container is built. Users have permission to install additional packages as needed.
 
 **JupyterLab**
 
-The following [conda-forge](https://conda-forge.org/) packages are available by default:
+The default user is the `root` account. The following [conda-forge](https://conda-forge.org/) packages are available by default:
 
 - `python`
 - `pip`
@@ -72,24 +72,24 @@ The following [conda-forge](https://conda-forge.org/) packages are available by 
 - `nb_black`
 - `qgrid`
 
-To install additional packages, execute `!pip install <packagename>` commands in your notebook environment.
+To install additional Python packages, execute `!pip install <packagename>` commands in your notebook environment. Additional system-level packages can be installed in a terminal window using `apt install <packagename>`.
 
 **RStudio Server**
 
-To install packages, execute `install.packages("<packagename>")` commands in your notebook environment.
+The default user is the `rstudio` account and has [sudo](https://en.wikipedia.org/wiki/Sudo) privileges. To install R packages, execute `install.packages("<packagename>")` commands in your notebook environment. Additional system-level packages can be installed in a terminal window using `sudo apt install <packagename>`.
 
 **Visual Studio Code**
 
-To install extensions, click the **Extensions** button.
+The default user is the `root` account. To install extensions, select **Extensions**. Additional system-level packages can be installed in a terminal window using `apt install <packagename>`.
 
 ## Start a data studio
 
 This functionality is available to users with the **Maintain** role and above.
 
-A data studio needs to be started before you can connect to it. From the list in your workspace, select the three dots next to the status message for the data studio you want to start, then select **Start**. A new browser tab will open that displays the startup state of the data studio. Once the data studio has successfully started running, you can connect to it. A data studio will run until it is stopped manually or it encounters a technical issue.
+A data studio needs to be started before you can connect to it. From the list in your workspace, select the three dots next to the status message for the data studio you want to start, then select **Start**. You can optionally change the configuration of the data studio, then select **Start in new tab**. A new browser tab will open that displays the startup state of the data studio. Once the data studio has successfully started running, you can connect to it. A data studio will run until it is stopped manually or it encounters a technical issue.
 
 :::note
-A data studio session uses resources until it's **stopped**.
+A data studio session consumes resources until it's **stopped**.
 :::
 
 Once a data studio session is in a **running** state, you can connect to it, obtain the public link to the session to share with collaborators inside your workspace, and stop it.
@@ -127,10 +127,10 @@ This functionality is available to all user roles excluding the **View** role.
 To connect to a running data studio session, select the three dots next to the status message and choose **Connect**. A new browser tab will open, displaying the status of the data studio session. Select **Connect**.
 
 :::warning
-An active connection to a data studio session will not prevent administrative actions that might disrupt that connection. For example, a data studio can be stopped by another workspace user while you are in the session, the underlying credentials can be changed, or the compute environment can be deleted. These are independent actions and the user in the session won't be alerted to any changes - the only alert will be a server connection error in the session browser tab.
+An active connection to a data studio session will not prevent administrative actions that might disrupt that connection. For example, a data studio can be stopped by another workspace user while you are active in the session, the underlying credentials can be changed, or the compute environment can be deleted. These are independent actions and the user in the session won't be alerted to any changes - the only alert will be a server connection error in the active session browser tab.
 :::
 
-Once connected, the data studio session list will update to display the status of `running` and any user connected to the session will have their avatar displayed under the status.
+Once connected, the data studio session list will update to display the status of **running** and any connected user will have their avatar displayed under the status in both the list of Data Studios and in each data studio session detail page.
 
 ![](./_images/data_studios.png)
 
@@ -138,7 +138,7 @@ Once connected, the data studio session list will update to display the status o
 
 This functionality is available to all user roles excluding the **View** role.
 
-To share a link to a running data studio with collaborators inside your workspace, select the three dots next to the status message for the data studio you want to share, then select **Copy data studio URL**. Using this link other authenticated users can access the session directly.
+To share a link to a running data studio with collaborators inside your workspace, select the three dots next to the status message for the data studio you want to share, then select **Copy data studio URL**. Using this link, other authenticated users can access the session directly.
 
 :::note
 Collaborators need valid workspace permissions to connect to the running data studio.
@@ -148,19 +148,15 @@ Collaborators need valid workspace permissions to connect to the running data st
 
 This functionality is available to all user roles with the **Maintain** role and above.
 
-To stop a running session, select the three dots next to the status message and then select **Stop**. The status will change from **running** to **stopped**. When a data studio session is stopped, the compute resources it's using are deallocated. You can stop a session at any time.
+To stop a running data studio session, select the three dots next to the status message and then select **Stop**. The status will change from **running** to **stopped**. When a data studio session is stopped, the compute resources it's using are deallocated. You can stop a session at any time, except when it is **starting**.
 
-Stopping a running session creates a new checkpoint.
-
-:::note
-Make sure you save before you stop a data studio.
-:::
+Stopping a running data studio creates a new checkpoint.
 
 ## Restart a stopped data studio
 
 This functionality is available to all user roles with the **Maintain** role and above.
 
-When you restart a stopped session, the session uses the most recent checkpoint.
+When you restart a stopped data studio session, the session uses the most recent checkpoint.
 
 ## Start a new data studio from a checkpoint
 
@@ -176,9 +172,13 @@ You can only delete a data studio when it's **stopped**. Select the three dots n
 
 ## Data studio checkpoints
 
-When you start a data studio, it automatically creates a *checkpoint*. A checkpoint saves changes that you make to the data studio root filesystem and stores it in the compute environment's pipeline work directory.
+When you start a data studio session, it automatically creates a *checkpoint*. A checkpoint saves changes that you make to the data studio root filesystem and stores it in the compute environment's pipeline work directory in the `.studios/checkpoints` directory under a unique name.
 
-When you restart a data studio, or start a new data studio from a previously created checkpoint, changes such as installed software packages and configuration files are restored and made available in the data studio session. Changes made to mounted datasets are not included in a checkpoint.
+:::note
+Running data studios create a new checkpoint, or snapshot, every five minutes.
+:::
+
+When you stop and start a data studio session, or start a new data studio session from a previously created checkpoint, changes such as installed software packages and configuration files are restored and made available in the data studio session. Changes made to mounted datasets are not included in a checkpoint.
 
 ## Data studio statuses
 
@@ -187,20 +187,20 @@ Data studios have the following possible statuses:
 - **starting**: The data studio is initializing.
 - **running**: When a data studio session is **running**, you can connect to it, copy the data studio URL, or stop it. In addition, the session can continue to process requests/run computations in the absence of an ongoing connection.
 - **stopping**: The recently-running session is in the process of being stopped.
-- **stopped**: When a session is stopped, the associated compute resources are deallocated and any unsaved state is lost. You can start a session or delete the data studio when it's in this state.
-- **errored**: This state most often indicates that there has been an error starting the data studio but it is in a **stopped** state. There might be errors reported by the data studio session itself but these currently will be overwritten with a **running** status if the studio is still running. If you encounter an error with the private preview release of Data Studios, please reach out to your Seqera account manager.
+- **stopped**: When a session is stopped, the associated compute resources are deallocated. You can start or delete the data studio when it's in this state.
+- **errored**: This state most often indicates that there has been an error starting the data studio session but it is in a **stopped** state. There might be errors reported by the session itself but these currently will be overwritten with a **running** status if the data studio session is still running. If you encounter an error with the Public-Preview release of Data Studios, please reach out to your Seqera account manager.
 
 ## Troubleshooting
 
 ### Viewing all mounted datasets
 
-In your tertiary analysis environment, open a new Terminal and type `ls -la /workspace/data`. This displays all the mounted datasets available in the current data studio session.
+In your tertiary analysis environment, open a new terminal and type `ls -la /workspace/data`. This displays all the mounted datasets available in the current data studio.
 
 ![](./_images/data_studios_notebook_fusion.png)
 
-### My data studio is stuck in **starting** status
+### My data studio is stuck in **starting**
 
-If your data studio doesn't advance from **starting** status to **running** status within 30 minutes, and you have access to the AWS Console for your organization, check that the AWS Batch compute environment associated with the session is in the **ENABLED** state with a **VALID** status. You can also check the **Compute resources** settings. Contact your organization's AWS administrator if you don't have access to the AWS Console.
+If your data studio doesn't advance from **starting** status to **running** status within 30 minutes, and you have access to the AWS Console for your organization, check that the AWS Batch compute environment associated with the data studio session is in the **ENABLED** state with a **VALID** status. You can also check the **Compute resources** settings. Contact your organization's AWS administrator if you don't have access to the AWS Console.
 
 If sufficient compute environment resources are unavailable, **Stop** your data studio and any others that may be running before trying again. If you have access to the AWS Console for your organization, you can terminate a specific data studio from the AWS Batch Jobs page (filtering by compute environment queue).
 
@@ -208,24 +208,23 @@ If sufficient compute environment resources are unavailable, **Stop** your data 
 
 The **errored** status is generally related to issues encountered when creating the data studio resources in the compute environment (e.g., invalid credentials, insufficient permissions, network issues). It can also be related to insufficient compute resources, which are set in your compute environment configuration. Contact your organization's AWS administrator if you don't have access to the AWS Console. Please also reach out to your account manager so we can investigate the issue.
 
-### My data studio can't be stopped
+### My data studio can't be **stopped**
 
-If you're not able to stop a data studio, it's usually because the job running the studio failed for some reason. In this case, and if you have access to the AWS Console for your organization, you can stop the data studio from the compute environment screen. Contact your organization's AWS administrator if you don't have access to the AWS Console. Also contact your Seqera account manager so we can investigate the issue.
+If you're not able to stop a data studio session, it's usually because the Batch job running the data studio failed for some reason. In this case, and if you have access to the AWS Console for your organization, you can stop the data studio from the compute environment screen. Contact your organization's AWS administrator if you don't have access to the AWS Console. Also contact your Seqera account manager so we can investigate the issue.
 
 ### My data studio performance is poor
 
-A slow or unresponsive data studio may be due to its AWS Batch compute environment being utilized for other jobs, such as running Nextflow pipelines. The compute environment is responsible for scheduling jobs to the available compute resources. Data studio sessions compete for resources with the Nextflow pipeline head job and Seqera does not currently have an established pattern of precedence.
+A slow or unresponsive data studio may be due to its AWS Batch compute environment being utilized for other jobs, such as running Nextflow pipelines. The compute environment is responsible for scheduling jobs to the available compute resources. Data Studio sessions compete for resources with the Nextflow pipeline head job and Seqera does not currently have an established pattern of precedence.
 
 If you have access to the AWS Console for your organization, check the jobs associated with the AWS Batch compute environment and compare with its **Compute resources** settings.
 
 ### What happens if the memory allocation of the data studio is exceeded?
 
-The running container in the AWS Batch compute environment inherits the memory limits specified by the data studio configuration when adding or starting the session. The kernel then handles the memory as if running natively on Linux. Linux can overcommit memory, leading to possible out-of-memory errors in a container environment. The kernel has protections in place to prevent this, but it can happen, and in this case, the process is killed. This can manifest as a performance lag, killed subprocesses, or at worst, a killed data studio session.
+The running container in the AWS Batch compute environment inherits the memory limits specified by the data studio configuration when adding or starting the data studio session. The kernel then handles the memory as if running natively on Linux. Linux can overcommit memory, leading to possible out-of-memory errors in a container environment. The kernel has protections in place to prevent this, but it can happen, and in this case, the process is killed. This can manifest as a performance lag, killed subprocesses, or at worst, a killed data studio session. Running data studio sessions have automated snapshots created every five minutes, so if the running container is killed only those changes made after the prior snapshot creation are lost.
 
 ### All my datasets are read-only
 
-By default, AWS Batch compute environments that are created with Batch Forge restrict access to S3 to the working directory only, unless additional **Allowed S3 Buckets** are specified.
-If the compute environment does not have write access to the mounted dataset, it will be mounted as read-only.
+By default, AWS Batch compute environments that are created with Batch Forge restrict access to S3 to the working directory only, unless additional **Allowed S3 Buckets** are specified. If the compute environment does not have write access to the mounted dataset, it will be mounted as read-only.
 
 ### What happens when the allocated storage for the data studio is exceeded?
 

--- a/platform_versioned_sidebars/version-23.4.0-sidebars.json
+++ b/platform_versioned_sidebars/version-23.4.0-sidebars.json
@@ -54,6 +54,7 @@
           "label": "Data",
           "items": [
             "data/data-explorer",
+            "data/data-studios",
             "data/datasets"
           ]
         },


### PR DESCRIPTION
Clean up:
1. Remove all new references to the term "session" - we consistently just call sessions "data studios".
2. Remove incorrect information about non-saved state being lost - we now have session persistence.
3. Add a note that checkpoints/snapshots are created every five minutes in running data studios. Also add to relevant troubleshooting section.
4. Consistently apply formatting for actions.
5. Add default users (`root` and `rstudio`) and how to install system packages using `apt`.