### PR TITLE
Update Data Studios config variables on configuration overview, point to DS deployment page

### DIFF
--- a/platform_versioned_docs/version-24.1.0/enterprise/configuration/configtables/data_features_env.yml
+++ b/platform_versioned_docs/version-24.1.0/enterprise/configuration/configtables/data_features_env.yml
@@ -30,22 +30,17 @@
     Data Explorer download file size limit. **Increasing this value may degrade performance.** 
   Value:                'Default: `25MB`'
 -
-  Environment variable:            '`TOWER_DATA_STUDIO_ALLOWED_WORKSPACES`'
-  Description: > 
-    Enable [Data Studios](https://docs.seqera.io/platform/latest/data/data-studios) in the specified workspaces. To enable Data Studios for all workspaces, do not include this variable in your environment file.
-  Value:                'Example: `<workspace-id1>,<workspace-id2>`'
--
   Environment variable:            '`TOWER_DATA_STUDIO_CONNECT_URL`'
   Description: >
-    The URL of the Data Studios connect proxy. The connect proxy is used internally by Seqera Platform.
+    The URL of the Data Studios connect proxy. The connect proxy is used internally by Seqera Platform. See [Data Studios deployment](https://docs.seqera.io/platform/24.1.0/enterprise/data-studios).
   Value:                'Example: `https://connect.example.com/`'
 -
   Environment variable:            '`TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN`'
   Description: > 
-    An access token used to register new clients in Seqera Platform. Any alphanumeric value is allowed.
+    An access token used to register new clients in Seqera Platform. Any alphanumeric value is allowed. See [Data Studios deployment](https://docs.seqera.io/platform/24.1.0/enterprise/data-studios).
   Value:                'd5XDoRzHpWo1c............mDnfBpB'
 -
   Environment variable:            '`TOWER_OIDC_PEM_PATH`'
   Description: > 
-    The file path to a PEM certificate used to sign the OIDC tokens for the OpenID connect provider. This variable is required for Docker-based installations. For Kubernetes-based installations, this variable is included as part of the backend container deployment.
+    The file path to a PEM certificate used to sign the OIDC tokens for the OpenID connect provider. See [Data Studios deployment](https://docs.seqera.io/platform/24.1.0/enterprise/data-studios).
   Value:                'Example: `/data-studios-rsa.pem`'


### PR DESCRIPTION
Removes the Data Studios allowed workspaces environment variable from the main configuration overview and links to the Data Studios deployment page for guidance.