### PR TITLE
Removed Graviton3 reference in 23.3 documentation

### DIFF
--- a/platform_versioned_docs/version-23.3.0/compute-envs/aws-batch.mdx
+++ b/platform_versioned_docs/version-23.3.0/compute-envs/aws-batch.mdx
@@ -158,7 +158,7 @@ Fargate requires the Fusion v2 file system and a **spot** provisioning model. Fa
 :::
 
 19. Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. See [GPU usage](./overview.mdx#aws-batch) for more information.
-20. Select **Use Graviton CPU architecture** to execute on Graviton-based EC2 instances (ARM64 CPU architecture). When enabled, `c6g` instance types are used by default for compute jobs. You can specify your own **Instance types** under [**Advanced options**](#advanced-options). Seqera Platform supports all AWS Batch-compatible Graviton2 instance types.
+20. Select **Use Graviton CPU architecture** to execute on Graviton-based EC2 instances (ARM64 CPU architecture). When enabled, `c6g` instance types are used by default for compute jobs. You can specify your own **Instance types** under [**Advanced options**](#advanced-options). Seqera Platform supports all AWS Batch-compatible Graviton2 instance types. In 23.3, Graviton3 instances are supported without the fast instance storage option. From v23.4, there is full Graviton3 support.
 
     :::note
     Graviton requires Fargate, Wave containers, and Fusion v2 file system to be enabled. This feature is not compatible with GPU-based architecture. 

--- a/platform_versioned_docs/version-23.3.0/compute-envs/aws-batch.mdx
+++ b/platform_versioned_docs/version-23.3.0/compute-envs/aws-batch.mdx
@@ -158,7 +158,7 @@ Fargate requires the Fusion v2 file system and a **spot** provisioning model. Fa
 :::
 
 19. Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. See [GPU usage](./overview.mdx#aws-batch) for more information.
-20. Select **Use Graviton CPU architecture** to execute on Graviton-based EC2 instances (ARM64 CPU architecture). When enabled, `c6g` instance types are used by default for compute jobs. You can specify your own **Instance types** under [**Advanced options**](#advanced-options). Seqera Platform supports all AWS Batch-compatible Graviton2 and Graviton3 instance types.
+20. Select **Use Graviton CPU architecture** to execute on Graviton-based EC2 instances (ARM64 CPU architecture). When enabled, `c6g` instance types are used by default for compute jobs. You can specify your own **Instance types** under [**Advanced options**](#advanced-options). Seqera Platform supports all AWS Batch-compatible Graviton2 instance types.
 
     :::note
     Graviton requires Fargate, Wave containers, and Fusion v2 file system to be enabled. This feature is not compatible with GPU-based architecture. 


### PR DESCRIPTION
Addresses https://seqera.atlassian.net/browse/EDU-156

Note: This change is only in the 23.3 documentation. 