### PR TITLE
Check internal links

### DIFF
--- a/.github/workflows/check-internal-links.yml
+++ b/.github/workflows/check-internal-links.yml
@@ -1,0 +1,29 @@
+name: "Internal link checking"
+
+on: [pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  check-internal-links:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Check out repo
+        uses: actions/checkout@v2
+      # Node is required for npm
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18"
+      - name: Pull & update submodules recursively
+        run: |
+          git submodule update --init --recursive
+      # Fail the build in PRs, but not for Netlify previews or production builds
+      - name: Replace credentials
+        run: |
+          sed -Ei 's/onBroken([A-Za-z]+): "warn"/onBroken\1: "throw"/g' docusaurus.config.js
+      # Install and build Docusaurus website
+      - name: Build Docusaurus website
+        run: |
+          npm install
+          npm run build


### PR DESCRIPTION
So this doesn't actually work, because reasons. ~~Unfortunately the only approach that can work is capturing output directly from Docusaurus, which is probably possible.~~

An approach similar to this can work for external links, but if run too frequently, false positives might emerge. So it can't really be a blocking check.

We can actually just fail the build:

```
Error: Docs markdown link couldn't be resolved: (../../administration/audit-logs.mdx) in "/Users/jboxman/Work/docs/platform_versioned_docs/version-24.1.1/enterprise/configuration/overview.mdx" for version 24.1.1
    at Array.forEach (<anonymous>)
```

This does mean builds do not work if there are any broken internal links:

https://docusaurus.io/docs/api/docusaurus-config#onBrokenLinks