### PR TITLE
Correct nf-launcher for 24.1.1 in baseline versions page

### DIFF
--- a/platform_versioned_docs/version-24.1.1/functionality_matrix/functionality_matrix.mdx
+++ b/platform_versioned_docs/version-24.1.1/functionality_matrix/functionality_matrix.mdx
@@ -13,7 +13,7 @@ If no Nextflow version is specified in your configuration, Seqera defaults to th
 
 | Platform version | nf-launcher version | Nextflow version | Fusion version |
 | ---------------- | ------------------- | ---------------- | -------------- |
-| 24.1.1           | j17-23.10.1         | 24.04.2          | 2.3            |
+| 24.1.1           | j17-23.10.1-up1     | 24.04.2          | 2.3            |
 | 23.4.4           | j17-23.10.1         | 23.10.1          | 2.2            |
 | 23.4.3           | j17-23.10.1         | 23.10.1          | 2.2            |
 | 23.4.2           | j17-23.10.1         | 23.10.1          | 2.2            |
@@ -23,6 +23,5 @@ If no Nextflow version is specified in your configuration, Seqera defaults to th
 | 23.3.0           | j17-23.04.3         | 23.04.3          | 2.1            |
 | 23.2.0           | j17.23.04.2-up3     | 23.04.2          | 2.1            |
 | 23.1.3           | j17-23.04.1         | 23.04.1          | 2.1            |
-| 22.4.1           | j17-22.10.6         | 22.10.6          | -              |
 
 nf-launcher versions prefixed with j17 refer to Java version 17; j11 refers to Java 11.

--- a/platform_versioned_docs/version-24.1.1/functionality_matrix/functionality_matrix.mdx
+++ b/platform_versioned_docs/version-24.1.1/functionality_matrix/functionality_matrix.mdx
@@ -13,7 +13,7 @@ If no Nextflow version is specified in your configuration, Seqera defaults to th
 
 | Platform version | nf-launcher version | Nextflow version | Fusion version |
 | ---------------- | ------------------- | ---------------- | -------------- |
-| 24.1.1           | j17-23.10.1-up1     | 24.04.2          | 2.3            |
+| 24.1.1           | j17-23.10.1-up1     | 23.10.1          | 2.2            |
 | 23.4.4           | j17-23.10.1         | 23.10.1          | 2.2            |
 | 23.4.3           | j17-23.10.1         | 23.10.1          | 2.2            |
 | 23.4.2           | j17-23.10.1         | 23.10.1          | 2.2            |


### PR DESCRIPTION
Correct baseline versions page to reflect j17-23.10.1-up1 as the launcher image for ENT 24.1.1, per https://github.com/seqeralabs/platform/blob/v24.1.1-enterprise/tower-services/src/main/groovy/io/seqera/tower/service/TowerServiceImpl.groovy#L43