### PR TITLE
Add external link checking

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,29 @@
+name: Links
+
+# https://github.com/lycheeverse/lychee-action
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 18 * * *"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: --base . --verbose --no-progress './**/*.md'
+
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue


### PR DESCRIPTION
This adds external link checking as a cron job, daily. It creates a new GitHub issue when there's a new broken link found.

This rapidly checks links within the base repository, but won't check links in any of the sub-modules.

We can probably experiment with this and try to check links against builds instead of source files.