### PR TITLE
[24.2 release docs] Add Gobal Nextflow config field to compute environment pages

### DIFF
--- a/platform_versioned_docs/version-24.1/compute-envs/aws-batch.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/aws-batch.mdx
@@ -179,7 +179,9 @@ Extensive benchmarking of Fusion v2 has demonstrated that the increased cost ass
 
 24. Select **Dispose resources** to automatically delete these AWS resources if you delete the compute environment in Seqera Platform.
 25. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-26. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+26. Expand **Staging options** to include:
+  - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+  - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
 27. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
 28. Configure any advanced options described in the next section, as needed.
 29. Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before you are ready to [launch pipelines](../launch/launchpad.mdx).
@@ -267,29 +269,33 @@ Your Seqera compute environment uses resources that you may be charged for in yo
 **Create a manual Seqera compute environment**
 
 1. In a workspace, select **Compute environments > New environment**.
-2. Enter a descriptive name for this environment, e.g., _AWS Batch Manual (eu-west-1)_.
-3. Select **AWS Batch** as the target platform.
-4. Select **+** to add new credentials.
-5. Enter a name for the credentials, e.g., _AWS Credentials_.
-6. Enter the **Access key** and **Secret key** for your IAM user.
+1. Enter a descriptive name for this environment, e.g., _AWS Batch Manual (eu-west-1)_.
+1. Select **AWS Batch** as the target platform.
+1. Select **+** to add new credentials.
+1. Enter a name for the credentials, e.g., _AWS Credentials_.
+1. Enter the **Access key** and **Secret key** for your IAM user.
 
-  :::note
-  You can create multiple credentials in your Seqera environment. See [Credentials](../credentials/overview.mdx).
-  :::
+    :::note
+    You can create multiple credentials in your Seqera environment. See [Credentials](../credentials/overview.mdx).
+    :::
 
-7. Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
-8. Enter an S3 bucket path for the **Pipeline work directory**, e.g., `s3://seqera-bucket`. This bucket must be in the same region chosen in the previous step.
+1. Select a **Region**, e.g., _eu-west-1 - Europe (Ireland)_.
+1. Enter an S3 bucket path for the **Pipeline work directory**, e.g., `s3://seqera-bucket`. This bucket must be in the same region chosen in the previous step.
 
-  :::note
-  When you specify an S3 bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. Seqera adds a `cloudcache` block to the Nextflow configuration file for all runs executed with this compute environment. This block includes the path to a `cloudcache` folder in your work directory, e.g., `s3://seqera-bucket/cloudcache/.cache`. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
-  :::
+    :::note
+    When you specify an S3 bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. Seqera adds a `cloudcache` block to the Nextflow configuration file for all runs executed with this compute environment. This block includes the path to a `cloudcache` folder in your work directory, e.g., `s3://seqera-bucket/cloudcache/.cache`. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
+    :::
 
-9. Set the **Config mode** to **Manual**.
-10. Enter the **Head queue**, which is the name of the AWS Batch queue that the Nextflow main job will run.
-11. Enter the **Compute queue**, which is the name of the AWS Batch queue where tasks will be submitted.
-12. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
-13. Configure any advanced options described in the next section, as needed.
-14. Select **Create** to finalize the compute environment setup.
+1. Set the **Config mode** to **Manual**.
+1. Enter the **Head queue**, which is the name of the AWS Batch queue that the Nextflow main job will run.
+1. Enter the **Compute queue**, which is the name of the AWS Batch queue where tasks will be submitted.
+1. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1. Expand **Staging options** to include:
+    - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+1. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1. Configure any advanced options described in the next section, as needed.
+1. Select **Create** to finalize the compute environment setup.
 
 ### Advanced options
 

--- a/platform_versioned_docs/version-24.1/compute-envs/aws-batch.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/aws-batch.mdx
@@ -181,7 +181,7 @@ Extensive benchmarking of Fusion v2 has demonstrated that the increased cost ass
 25. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 26. Expand **Staging options** to include:
   - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-  - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+  - Global Nextflow configuration settings for all pipeline runs launched with this compute environment. Configuration settings in this field override the same values in the pipeline Nextflow config file. 
 27. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
 28. Configure any advanced options described in the next section, as needed.
 29. Select **Create** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before you are ready to [launch pipelines](../launch/launchpad.mdx).
@@ -292,7 +292,7 @@ Your Seqera compute environment uses resources that you may be charged for in yo
 1. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 1. Expand **Staging options** to include:
     - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+    - Global Nextflow configuration settings for all pipeline runs launched with this compute environment. Configuration settings in this field override the same values in the pipeline Nextflow config file. 
 1. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
 1. Configure any advanced options described in the next section, as needed.
 1. Select **Create** to finalize the compute environment setup.

--- a/platform_versioned_docs/version-24.1/compute-envs/azure-batch.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/azure-batch.mdx
@@ -133,40 +133,42 @@ Batch Forge automatically creates resources that you may be charged for in your 
 Create a Batch Forge Azure Batch compute environment:
 
 1. In a workspace, select **Compute Environments > New Environment**.
-2. Enter a descriptive name, e.g., _Azure Batch (east-us)_.
-3. Select **Azure Batch** as the target platform.
-4. Choose existing Azure credentials or add a new credential. If you are using existing credentials, skip to step 7.
+1. Enter a descriptive name, e.g., _Azure Batch (east-us)_.
+1. Select **Azure Batch** as the target platform.
+1. Choose existing Azure credentials or add a new credential. If you are using existing credentials, skip to step 7.
 
     :::tip
     You can create multiple credentials in your Seqera environment.
     :::
 
-5. Enter a name for the credentials, e.g., _Azure Credentials_.
-6. Add the **Batch account** and **Blob Storage** account names and access keys.
-7. Select a **Region**, e.g., _eastus_.
-8. In the **Pipeline work directory** field, enter the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
+1. Enter a name for the credentials, e.g., _Azure Credentials_.
+1. Add the **Batch account** and **Blob Storage** account names and access keys.
+1. Select a **Region**, e.g., _eastus_.
+1. In the **Pipeline work directory** field, enter the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
 
     :::note
     When you specify a Blob Storage bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
     :::
 
-9. Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers][wave-docs] for more information.
-10. Select **Enable Fusion v2** to allow access to your Azure Blob Storage data via the [Fusion v2][nf-fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled. See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
-11. Set the **Config mode** to **Batch Forge**.
-12. Enter the default **VMs type**, depending on your quota limits set previously. The default is _Standard_D4_v3_.
-13. Enter the **VMs count**. If autoscaling is enabled (default), this is the maximum number of VMs you wish the pool to scale up to. If autoscaling is disabled, this is the fixed number of virtual machines in the pool.
-14. Enable **Autoscale** to scale up and down automatically, based on the number of pipeline tasks. The number of VMs will vary from **0** to **VMs count**.
-15. Enable **Dispose resources** for Seqera to automatically delete the Batch pool if the compute environment is deleted on the platform.
-16. Select or create [**Container registry credentials**](../credentials/azure_registry_credentials.mdx) to authenticate a registry (used by the [Wave containers](https://www.nextflow.io/docs/latest/wave.html) service). It is recommended to use an [Azure Container registry](https://azure.microsoft.com/en-gb/products/container-registry) within the same region for maximum performance.
-17. Apply [**Resource labels**](../resource-labels/overview.mdx). This will populate the **Metadata** fields of the Azure Batch pool.
-18. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre-and-post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-19. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
-20. Configure any advanced options you need:
+1. Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers][wave-docs] for more information.
+1. Select **Enable Fusion v2** to allow access to your Azure Blob Storage data via the [Fusion v2][nf-fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled. See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.
+1. Set the **Config mode** to **Batch Forge**.
+1. Enter the default **VMs type**, depending on your quota limits set previously. The default is _Standard_D4_v3_.
+1. Enter the **VMs count**. If autoscaling is enabled (default), this is the maximum number of VMs you wish the pool to scale up to. If autoscaling is disabled, this is the fixed number of virtual machines in the pool.
+1. Enable **Autoscale** to scale up and down automatically, based on the number of pipeline tasks. The number of VMs will vary from **0** to **VMs count**.
+1. Enable **Dispose resources** for Seqera to automatically delete the Batch pool if the compute environment is deleted on the platform.
+1. Select or create [**Container registry credentials**](../credentials/azure_registry_credentials.mdx) to authenticate a registry (used by the [Wave containers](https://www.nextflow.io/docs/latest/wave.html) service). It is recommended to use an [Azure Container registry](https://azure.microsoft.com/en-gb/products/container-registry) within the same region for maximum performance.
+1. Apply [**Resource labels**](../resource-labels/overview.mdx). This will populate the **Metadata** fields of the Azure Batch pool.
+1. Expand **Staging options** to include:
+    - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+1. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1. Configure any advanced options you need:
 
     - Use **Jobs cleanup policy** to control how Nextflow process jobs are deleted on completion. Active jobs consume the quota of the Azure Batch account. By default, jobs are terminated by Nextflow and removed from the quota when all tasks succesfully complete. If set to _Always_, all jobs are deleted by Nextflow after pipeline completion. If set to _Never_, jobs are never deleted. If set to _On success_, successful tasks are removed but failed tasks will be left for debugging purposes.
     - Use **Token duration** to control the duration of the SAS token generated by Nextflow. This must be as long as the longest period of time the pipeline will run.
 
-21. Select **Add** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before the compute environment is ready to launch pipelines.
+1. Select **Add** to finalize the compute environment setup. It will take a few seconds for all the resources to be created before the compute environment is ready to launch pipelines.
 
 **See [Launch pipelines](../launch/launchpad.mdx) to start executing workflows in your Azure Batch compute environment.**
 
@@ -181,38 +183,40 @@ Your Seqera compute environment uses resources that you may be charged for in yo
 **Create a manual Seqera Azure Batch compute environment**
 
 1. In a workspace, select **Compute Environments > New Environment**.
-2. Enter a descriptive name for this environment, e.g., _Azure Batch (east-us)_.
-3. Select **Azure Batch** as the target platform.
-4. Select your existing Azure credentials or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
+1. Enter a descriptive name for this environment, e.g., _Azure Batch (east-us)_.
+1. Select **Azure Batch** as the target platform.
+1. Select your existing Azure credentials or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
 
     :::tip
     You can create multiple credentials in your Seqera environment.
     :::
 
-5. Enter a name, e.g., _Azure Credentials_.
-6. Add the **Batch account** and **Blob Storage** credentials you created previously.
-7. Select a **Region**, e.g., _eastus (East US)_.
-8. In the **Pipeline work directory** field, add the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
+1. Enter a name, e.g., _Azure Credentials_.
+1. Add the **Batch account** and **Blob Storage** credentials you created previously.
+1. Select a **Region**, e.g., _eastus (East US)_.
+1. In the **Pipeline work directory** field, add the Azure blob container created previously, e.g., `az://towerrgstorage-container/work`.
 
     :::note
     When you specify a Blob Storage bucket as your work directory, this bucket is used for the Nextflow [cloud cache](https://www.nextflow.io/docs/latest/cache-and-resume.html#cache-stores) by default. You can specify an alternative cache location with the **Nextflow config file** field on the pipeline [launch](../launch/launchpad.mdx#launch-form) form.
     :::
 
-9. Set the **Config mode** to **Manual**.
-10. Enter the **Compute Pool name**. This is the name of the Azure Batch pool you created previously in the Azure Batch account.
+1. Set the **Config mode** to **Manual**.
+1. Enter the **Compute Pool name**. This is the name of the Azure Batch pool you created previously in the Azure Batch account.
 
     :::note
     The default Azure Batch implementation uses a single pool for head and compute nodes. To use separate pools for head and compute nodes (e.g., to use low-priority VMs for compute jobs), see [this FAQ entry](../faqs.mdx#azure).
     :::
 
-12. If the selected Azure Batch Pool has an attached user-assigned **Managed identity**, select it here.
-13. Define custom **Environment Variables** for the **Head Job** and/or **Compute Jobs**.
-14. Configure any necessary advanced options:
-
+1. Enter a user-assigned **Managed identity client ID**, if one is attached to your Azure Batch pool. See [Managed Identity](#managed-identity) below.
+1. Apply [**Resource labels**](../resource-labels/overview.mdx). This will populate the **Metadata** fields of the Azure Batch pool.
+1. Expand **Staging options** to include:
+    - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+1. Define custom **Environment Variables** for the **Head Job** and/or **Compute Jobs**.
+1. Configure any necessary advanced options:
     - Use **Jobs cleanup policy** to control how Nextflow process jobs are deleted on completion. Active jobs consume the quota of the Azure Batch account. By default, jobs are terminated by Nextflow and removed from the quota when all tasks succesfully complete. If set to _Always_, all jobs are deleted by Nextflow after pipeline completion. If set to _Never_, jobs are never deleted. If set to _On success_, successful tasks are removed but failed tasks will be left for debugging purposes.
     - Use **Token duration** to control the duration of the SAS token generated by Nextflow. This must be as long as the longest period of time the pipeline will run.
-
-15. Select **Add** to complete the compute environment setup. The creation of resources will take a few seconds, after which you can launch pipelines.
+1. Select **Add** to complete the compute environment setup. The creation of resources will take a few seconds, after which you can launch pipelines.
 
 ### Managed identity
 

--- a/platform_versioned_docs/version-24.1/compute-envs/azure-batch.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/azure-batch.mdx
@@ -161,7 +161,7 @@ Create a Batch Forge Azure Batch compute environment:
 1. Apply [**Resource labels**](../resource-labels/overview.mdx). This will populate the **Metadata** fields of the Azure Batch pool.
 1. Expand **Staging options** to include:
     - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+    - Global Nextflow configuration settings for all pipeline runs launched with this compute environment. Configuration settings in this field override the same values in the pipeline Nextflow config file. 
 1. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
 1. Configure any advanced options you need:
 
@@ -211,7 +211,7 @@ Your Seqera compute environment uses resources that you may be charged for in yo
 1. Apply [**Resource labels**](../resource-labels/overview.mdx). This will populate the **Metadata** fields of the Azure Batch pool.
 1. Expand **Staging options** to include:
     - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+    - Global Nextflow configuration settings for all pipeline runs launched with this compute environment. Configuration settings in this field override the same values in the pipeline Nextflow config file. 
 1. Define custom **Environment Variables** for the **Head Job** and/or **Compute Jobs**.
 1. Configure any necessary advanced options:
     - Use **Jobs cleanup policy** to control how Nextflow process jobs are deleted on completion. Active jobs consume the quota of the Azure Batch account. By default, jobs are terminated by Nextflow and removed from the quota when all tasks succesfully complete. If set to _Always_, all jobs are deleted by Nextflow after pipeline completion. If set to _Never_, jobs are never deleted. If set to _On success_, successful tasks are removed but failed tasks will be left for debugging purposes.

--- a/platform_versioned_docs/version-24.1/compute-envs/eks.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/eks.mdx
@@ -91,7 +91,9 @@ The **Storage claim** isn't needed when Fusion v2 is enabled.
 :::
 
 14. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-15. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+15. Expand **Staging options** to include:
+    - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
 16. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
 17. Configure any advanced options described in the next section, as needed.
 18. Select **Create** to finalize the compute environment setup.

--- a/platform_versioned_docs/version-24.1/compute-envs/eks.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/eks.mdx
@@ -93,7 +93,7 @@ The **Storage claim** isn't needed when Fusion v2 is enabled.
 14. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 15. Expand **Staging options** to include:
     - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+    - Global Nextflow configuration settings for all pipeline runs launched with this compute environment. Configuration settings in this field override the same values in the pipeline Nextflow config file. 
 16. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
 17. Configure any advanced options described in the next section, as needed.
 18. Select **Create** to finalize the compute environment setup.

--- a/platform_versioned_docs/version-24.1/compute-envs/gke.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/gke.mdx
@@ -87,7 +87,7 @@ After you've prepared your Kubernetes cluster and granted cluster access to your
 1. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 1. Expand **Staging options** to include:
     - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+    - Global Nextflow configuration settings for all pipeline runs launched with this compute environment. Configuration settings in this field override the same values in the pipeline Nextflow config file. 
 1. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
 1. Configure any advanced options described in the next section, as needed.
 1. Select **Create** to finalize the compute environment setup.

--- a/platform_versioned_docs/version-24.1/compute-envs/gke.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/gke.mdx
@@ -51,56 +51,46 @@ Your Seqera compute environment uses resources that you may be charged for in yo
 After you've prepared your Kubernetes cluster and granted cluster access to your service account, create a Seqera GKE compute environment:
 
 1. In a Seqera workspace, select **Compute environments > New environment**.
+1. Enter a descriptive name for this environment, e.g., _Google GKE (europe-west1)_.
+1. From the **Provider** drop-down, select **Google GKE**.
+1. Under **Storage**, select either **Fusion storage** (recommended) or **Legacy storage**. The [Fusion v2](../supported_software/fusion/fusion.mdx) virtual distributed file system allows access to your Google Cloud-hosted data (`gs://` URLs). This eliminates the need to configure a shared file system in your Kubernetes cluster. See [Fusion v2](#fusion-v2) below.
+1. From the **Credentials** drop-down menu, select existing GKE credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 8.
+1. Enter a name for the credentials, e.g., _GKE Credentials_.
+1. Enter the **Service account key** for your Google service account.
 
-2. Enter a descriptive name for this environment, e.g., _Google GKE (europe-west1)_.
+    :::tip
+    You can create multiple credentials in your Seqera environment. See [Credentials](../credentials/overview.mdx).
+    :::
 
-3. From the **Provider** drop-down, select **Google GKE**.
+1. Select the **Location** of your GKE cluster.
 
-4. Under **Storage**, select either **Fusion storage** (recommended) or **Legacy storage**. The [Fusion v2](../supported_software/fusion/fusion.mdx) virtual distributed file system allows access to your Google Cloud-hosted data (`gs://` URLs). This eliminates the need to configure a shared file system in your Kubernetes cluster. See [Fusion v2](#fusion-v2) below.
+    :::caution
+    GKE clusters can be either regional or zonal. For example, `us-west1` identifies the United States West-Coast _region_, which has three _zones_: `us-west1-a`, `us-west1-b`, and `us-west1-c`.
 
-5. From the **Credentials** drop-down menu, select existing GKE credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 8.
+    Seqera Platform's auto-completion only shows regions. You should manually edit this field if you're using a zonal GKE cluster.
+    :::
 
-6. Enter a name for the credentials, e.g., _GKE Credentials_.
+1. Select or enter the **Cluster name** of your GKE cluster.
+1. Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is _tower-nf_ by default.
+1. Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is _tower-launcher-sa_ by default.
 
-7. Enter the **Service account key** for your Google service account.
+    :::note
+    If you enable Fusion v2 (**Fusion storage** in step 4 above), the head service account must have access to the Google Cloud storage bucket specified as your work directory.
+    :::
 
-:::tip
-You can create multiple credentials in your Seqera environment. See [Credentials](../credentials/overview.mdx).
-:::
+1. Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in the provided examples.
 
-8. Select the **Location** of your GKE cluster.
+    :::note
+    The **Storage claim** isn't needed when Fusion v2 is enabled.
+    :::
 
-:::caution
-GKE clusters can be either regional or zonal. For example, `us-west1` identifies the United States West-Coast _region_, which has three _zones_: `us-west1-a`, `us-west1-b`, and `us-west1-c`.
-
-Seqera Platform's auto-completion only shows regions. You should manually edit this field if you're using a zonal GKE cluster.
-:::
-
-9. Select or enter the **Cluster name** of your GKE cluster.
-
-10. Specify the **Namespace** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is _tower-nf_ by default.
-
-11. Specify the **Head service account** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This is _tower-launcher-sa_ by default.
-
-:::note
-If you enable Fusion v2 (**Fusion storage** in step 4 above), the head service account must have access to the Google Cloud storage bucket specified as your work directory.
-:::
-
-12. Specify the **Storage claim** created in the [cluster preparation](../compute-envs/k8s.mdx#cluster-preparation) instructions. This serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in the provided examples.
-
-:::note
-The **Storage claim** isn't needed when Fusion v2 is enabled.
-:::
-
-13. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-
-14. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-
-15. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
-
-16. Configure any advanced options described in the next section, as needed.
-
-17. Select **Create** to finalize the compute environment setup.
+1. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1. Expand **Staging options** to include:
+    - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+1. Specify custom **Environment variables** for the **Head job** and/or **Compute jobs**.
+1. Configure any advanced options described in the next section, as needed.
+1. Select **Create** to finalize the compute environment setup.
 
 ### Advanced options
 
@@ -131,27 +121,27 @@ To use [Fusion v2](../supported_software/fusion/fusion.mdx) in your Seqera GKE c
 
 1. Ensure the **Workload Identity** feature is enabled for the cluster:
 
-- **Enable Workload Identity** in the cluster **Security** settings.
-- **Enable GKE Metadata Server** in the node group **Security** settings.
+    - **Enable Workload Identity** in the cluster **Security** settings.
+    - **Enable GKE Metadata Server** in the node group **Security** settings.
 
-2. Allow the IAM service account access to your Google storage bucket:
+1. Allow the IAM service account access to your Google storage bucket:
 
-```shell
-gcloud storage buckets add-iam-policy-binding gs://<YOUR-BUCKET> --role roles/storage.objectAdmin --member serviceAccount:<IAM-SERVICE-ACCOUNT>@<GOOGLE-CLOUD-PROJECT>.iam.gserviceaccount.com
-```
+    ```shell
+    gcloud storage buckets add-iam-policy-binding gs://<YOUR-BUCKET> --role roles/storage.objectAdmin --member serviceAccount:<IAM-SERVICE-ACCOUNT>@<GOOGLE-CLOUD-PROJECT>.iam.gserviceaccount.com
+    ```
 
-The role must have at least `storage.objects.create`, `storage.objects.get`, and `storage.objects.list` permissions.
+    The role must have at least `storage.objects.create`, `storage.objects.get`, and `storage.objects.list` permissions.
 
-3. Allow the Kubernetes service account to impersonate the IAM service account:
+1. Allow the Kubernetes service account to impersonate the IAM service account:
 
-```shell
-gcloud iam service-accounts add-iam-policy-binding <IAM-SERVICE-ACCOUNT>@<GOOGLE-CLOUD-PROJECT>.iam.gserviceaccount.com --role roles/iam.workloadIdentityUser --member "serviceAccount:<GOOGLE-CLOUD-PROJECT>.svc.id.goog[<GKE-NAMESPACE>/<GKE-SERVICE-ACCOUNT>]"
-```
+    ```shell
+    gcloud iam service-accounts add-iam-policy-binding <IAM-SERVICE-ACCOUNT>@<GOOGLE-CLOUD-PROJECT>.iam.gserviceaccount.com --role roles/iam.workloadIdentityUser --member "serviceAccount:<GOOGLE-CLOUD-PROJECT>.svc.id.goog[<GKE-NAMESPACE>/<GKE-SERVICE-ACCOUNT>]"
+    ```
 
-4. Annotate the Kubernetes service account with the email address of the IAM service account:
+1. Annotate the Kubernetes service account with the email address of the IAM service account:
 
-```shell
-kubectl annotate serviceaccount <GKE-SERVICE-ACCOUNT> --namespace <GKE-NAMESPACE> iam.gke.io/gcp-service-account=<IAM-SERVICE-ACCOUNT>@<GOOGLE-CLOUD-PROJECT>.iam.gserviceaccount.com
-```
+    ```shell
+    kubectl annotate serviceaccount <GKE-SERVICE-ACCOUNT> --namespace <GKE-NAMESPACE> iam.gke.io/gcp-service-account=<IAM-SERVICE-ACCOUNT>@<GOOGLE-CLOUD-PROJECT>.iam.gserviceaccount.com
+    ```
 
 See the [GKE documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to) for further details.

--- a/platform_versioned_docs/version-24.1/compute-envs/google-cloud-batch.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/google-cloud-batch.mdx
@@ -168,7 +168,10 @@ Apply [**Resource labels**][resource-labels] to the cloud resources consumed by 
 
 #### Scripting and environment variables
 
-Expand **Staging options** to include optional [pre- or post-run Bash scripts][pre-post-run-scripts] that execute before or after the Nextflow pipeline execution in your environment.
+Expand **Staging options** to include:
+  - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+  - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+
 
 Specify custom **Environment variables** for the head and compute jobs.
 

--- a/platform_versioned_docs/version-24.1/compute-envs/google-cloud-batch.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/google-cloud-batch.mdx
@@ -170,7 +170,7 @@ Apply [**Resource labels**][resource-labels] to the cloud resources consumed by 
 
 Expand **Staging options** to include:
   - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-  - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+  - Global Nextflow configuration settings for all pipeline runs launched with this compute environment. Configuration settings in this field override the same values in the pipeline Nextflow config file. 
 
 
 Specify custom **Environment variables** for the head and compute jobs.

--- a/platform_versioned_docs/version-24.1/compute-envs/google-cloud-lifesciences.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/google-cloud-lifesciences.mdx
@@ -123,16 +123,14 @@ You can create multiple credentials in your Seqera workspace. See [Credentials](
 9. You can enable **Preemptible** to use preemptible instances, which have significantly reduced cost compared to on-demand instances.
 10. You can use a **Filestore file system** to automatically mount a Google Filestore volume in your pipelines.
 11. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-12. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+12. Expand **Staging options** to include:
+    - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
 13. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 14. Configure any advanced options you need:
-
     - Enable **Use Private Address** to ensure that your Google Cloud VMs aren't accessible to the public internet.
-
     - Use **Boot disk size** to control the boot disk size of VMs.
-
     - Use **Head Job CPUs** and **Head Job Memory** to specify the CPUs and memory allocated for head jobs.
-
 15. Select **Create** to finalize the compute environment setup.
 
 See [Launch pipelines](../launch/launchpad.mdx) to start executing workflows in your Google Cloud Life Sciences compute environment.

--- a/platform_versioned_docs/version-24.1/compute-envs/google-cloud-lifesciences.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/google-cloud-lifesciences.mdx
@@ -125,7 +125,7 @@ You can create multiple credentials in your Seqera workspace. See [Credentials](
 11. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 12. Expand **Staging options** to include:
     - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+    - Global Nextflow configuration settings for all pipeline runs launched with this compute environment. Configuration settings in this field override the same values in the pipeline Nextflow config file. 
 13. Use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 14. Configure any advanced options you need:
     - Enable **Use Private Address** to ensure that your Google Cloud VMs aren't accessible to the public internet.

--- a/platform_versioned_docs/version-24.1/compute-envs/hpc.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/hpc.mdx
@@ -39,36 +39,37 @@ To create a new **HPC** compute environment:
 1.  Select your existing managed identity, SSH, or Tower Agent credentials, or select **+** and **SSH** or **Tower Agent** to add new credentials.
 1.  Enter the absolute path of the **Work directory** to be used on the cluster.
 
-  :::caution 
-  All managed identity users must be a part of the same Linux user group. The group must have access to the HPC compute environment work directory. Set group permissions for the work directory as follows (replace `sharedgroupname` and `<WORKDIR>` with your group name and work directory):
+    :::caution 
+    All managed identity users must be a part of the same Linux user group. The group must have access to the HPC compute environment work directory. Set group permissions for the work directory as follows (replace `sharedgroupname` and `<WORKDIR>` with your group name and work directory):
 
-  ```bash
-  chgrp -R sharedgroupname <WORKDIR>
-  chmod -R g+wxs <WORKDIR>
-  setfacl -Rdm g::rwX <WORKDIR>
-  ```
+    ```bash
+    chgrp -R sharedgroupname <WORKDIR>
+    chmod -R g+wxs <WORKDIR>
+    setfacl -Rdm g::rwX <WORKDIR>
+    ```
 
-  These commands change the group ownership of all files and directories in the work directory to `sharedgroupname`, ensure new files inherit the directory's group, and apply default ACL entries to allow the group read, write, and execute permissions for new files and directories. This setup facilitates shared access and consistent permissions management in the directory.
-  :::
+    These commands change the group ownership of all files and directories in the work directory to `sharedgroupname`, ensure new files inherit the directory's group, and apply default ACL entries to allow the group read, write, and execute permissions for new files and directories. This setup facilitates shared access and consistent permissions management in the directory.
+    :::
 
 1.  Enter the absolute path of the **Launch directory** to be used on the cluster. If omitted, it will be the same as the work directory.
 1.  Enter the **Login hostname**. This is usually the hostname or public IP address of the cluster's login node.
 1.  Enter the **Head queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will be submitted.
 1. Enter the **Compute queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will submit tasks.
-1. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+1. Expand **Staging options** to include:
+    - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
 1. Specify custom **Environment variables** for the head job and/or compute jobs.
 1. Configure any advanced options needed:
-
     - Use the **Nextflow queue size** to limit the number of jobs that Nextflow can submit to the scheduler at the same time.
     - Use the **Head job submit options** to add platform-specific submit options for the head job. You can optionally apply these options to compute jobs as well:
 
-  :::note
-  Once set during compute environment creation, these options can't be overridden at pipeline launch time.
-  :::
+    :::note
+    Once set during compute environment creation, these options can't be overridden at pipeline launch time.
+    :::
 
-  :::note
-  In IBM LSF compute environments, use **Unit for memory limits**, **Per job memory limits**, and **Per task reserve** to control how memory is requested for Nextflow jobs.
-  :::
+    :::note
+    In IBM LSF compute environments, use **Unit for memory limits**, **Per job memory limits**, and **Per task reserve** to control how memory is requested for Nextflow jobs.
+    :::
 
 1. Select **Create** to finalize the creation of the compute environment.
 

--- a/platform_versioned_docs/version-24.1/compute-envs/hpc.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/hpc.mdx
@@ -57,7 +57,7 @@ To create a new **HPC** compute environment:
 1. Enter the **Compute queue name**. This is the [default](https://www.nextflow.io/docs/latest/process.html#queue) cluster queue to which the Nextflow job will submit tasks.
 1. Expand **Staging options** to include:
     - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+    - Global Nextflow configuration settings for all pipeline runs launched with this compute environment. Configuration settings in this field override the same values in the pipeline Nextflow config file. 
 1. Specify custom **Environment variables** for the head job and/or compute jobs.
 1. Configure any advanced options needed:
     - Use the **Nextflow queue size** to limit the number of jobs that Nextflow can submit to the scheduler at the same time.

--- a/platform_versioned_docs/version-24.1/compute-envs/k8s.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/k8s.mdx
@@ -23,9 +23,8 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
    kubectl cluster-info
    ```
 
-2. Download the [tower-launcher.yml](../_templates/k8s/tower-launcher.yml) file.
-
-3. Create the Seqera launcher:
+1. Download the [tower-launcher.yml](../_templates/k8s/tower-launcher.yml) file.
+1. Create the Seqera launcher:
 
    ```bash
    kubectl apply -f path/to/tower-launcher.yml
@@ -33,7 +32,7 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
    This command creates a service account called `tower-launcher-sa` and the associated role bindings, all contained in a namespace called `tower-nf`. Seqera uses the service account to launch Nextflow pipelines. Use this service account name when setting up the compute environment for this Kubernetes cluster in Seqera.
 
-4. Create persistent storage. Seqera requires a `ReadWriteMany` persistent volume claim (PVC) mounted to all nodes where workflow pods will be dispatched.
+1. Create persistent storage. Seqera requires a `ReadWriteMany` persistent volume claim (PVC) mounted to all nodes where workflow pods will be dispatched.
 
    You can use any storage solution that supports the `ReadWriteMany` [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes). The setup of this storage is beyond the scope of these instructions — the right solution for you will depend on what is available for your infrastructure or cloud vendor (NFS, GlusterFS, CephFS, Amazon FSx). Ask your cluster administrator for more information.
 
@@ -41,7 +40,7 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 
    - Example PVC backed by NFS server: [tower-scratch-nfs.yml](../_templates/k8s/tower-scratch-nfs.yml)
 
-5. Apply the appropriate PVC configuration to your cluster:
+1. Apply the appropriate PVC configuration to your cluster:
 
    ```bash
    kubectl apply -f <PVC_YAML_FILE>.
@@ -54,48 +53,50 @@ After you've prepared your Kubernetes cluster for Seqera integration, create a c
 **Create a Seqera Kubernetes compute environment**
 
 1. In a workspace, select **Compute environments > New environment**.
-2. Enter a descriptive name for this environment, e.g., _K8s cluster_.
-3. Select **Kubernetes** as the target platform.
-4. From the **Credentials** drop-down, select existing Kubernetes credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
+1. Enter a descriptive name for this environment, e.g., _K8s cluster_.
+1. Select **Kubernetes** as the target platform.
+1. From the **Credentials** drop-down, select existing Kubernetes credentials, or select **+** to add new credentials. If you choose to use existing credentials, skip to step 7.
 
-:::tip
-You can create multiple credentials in your Seqera workspace. See [Credentials](../credentials/overview.mdx).
-:::
+    :::tip
+    You can create multiple credentials in your Seqera workspace. See [Credentials](../credentials/overview.mdx).
+    :::
 
-5. Enter a name, e.g., _K8s Credentials_.
-6. Select either the **Service Account Token** or **X509 Client Certs** tab:
+1. Enter a name, such as _K8s Credentials_.
+1. Select either the **Service Account Token** or **X509 Client Certs** tab:
 
-   - To authenticate using a Kubernetes service account, enter your **Service account token**. Obtain the token with the following command:
+    - To authenticate using a Kubernetes service account, enter your **Service account token**. Obtain the token with the following command:
 
-      ```bash
-      SECRET=$(kubectl get secrets | grep <SERVICE-ACCOUNT-NAME> | cut -f1 -d ' ')
-      kubectl describe secret $SECRET | grep -E '^token' | cut -f2 -d':' | tr -d '\t'
-      ```
+        ```bash
+        SECRET=$(kubectl get secrets | grep <SERVICE-ACCOUNT-NAME> | cut -f1 -d ' ')
+        kubectl describe secret $SECRET | grep -E '^token' | cut -f2 -d':' | tr -d '\t'
+        ```
 
-      Replace `<SERVICE-ACCOUNT-NAME>` with the name of the service account created in the [cluster preparation](#cluster-preparation) instructions (default: `tower-launcher-sa`).
+        Replace `<SERVICE-ACCOUNT-NAME>` with the name of the service account created in the [cluster preparation](#cluster-preparation) instructions (default: `tower-launcher-sa`).
 
-   - To authenticate using an X509 client certificate, paste the contents of your certificate and key file (including the `-----BEGIN...-----` and `-----END...-----` lines) in the **Client certificate** and **Client Key** fields respectively. See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/certificates/) for instructions to generate your client certificate and key.
+    - To authenticate using an X509 client certificate, paste the contents of your certificate and key file (including the `-----BEGIN...-----` and `-----END...-----` lines) in the **Client certificate** and **Client Key** fields respectively. See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/certificates/) for instructions to generate your client certificate and key.
 
-7. Enter the **Control plane URL**, obtained with this command:
+1. Enter the **Control plane URL**, obtained with this command:
 
-   ```bash
-   kubectl cluster-info
-   ```
+    ```bash
+    kubectl cluster-info
+    ```
 
-   It can also be found in your `~/.kube/config` file under the `server` field corresponding to your cluster.
+    It can also be found in your `~/.kube/config` file under the `server` field corresponding to your cluster.
 
-8. Specify the **SSL certificate** to authenticate your connection.
+1. Specify the **SSL certificate** to authenticate your connection.
 
-   Find the certificate data in your `~/.kube/config` file. It is the `certificate-authority-data` field corresponding to your cluster.
+    Find the certificate data in your `~/.kube/config` file. It is the `certificate-authority-data` field corresponding to your cluster.
 
-9. Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is _tower-nf_ by default.
-10. Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is _tower-launcher-sa_ by default.
-11. Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in each of the provided examples.
-12. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
-13. Expand **Staging options** to include optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre-and-post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-14. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
-15. Configure any advanced options described below, as needed.
-16. Select **Create** to finalize the compute environment setup.
+1. Specify the **Namespace** created in the [cluster preparation](#cluster-preparation) instructions, which is _tower-nf_ by default.
+1. Specify the **Head service account** created in the [cluster preparation](#cluster-preparation) instructions, which is _tower-launcher-sa_ by default.
+1. Specify the **Storage claim** created in the [cluster preparation](#cluster-preparation) instructions, which serves as a scratch filesystem for Nextflow pipelines. The storage claim is called _tower-scratch_ in each of the provided examples.
+1. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
+1. Expand **Staging options** to include:
+    - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
+    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+1. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
+1. Configure any advanced options described below, as needed.
+1. Select **Create** to finalize the compute environment setup.
 
 See [Launch pipelines](../launch/launchpad.mdx) to start executing workflows in your Kubernetes compute environment.
 
@@ -106,13 +107,9 @@ Seqera Platform compute environments for Kubernetes include advanced options for
 **Seqera Kubernetes advanced options**
 
 - The **Storage mount path** is the file system path where the Storage claim is mounted (default: `/scratch`).
-
 - The **Work directory** is the file system path used as a working directory by Nextflow pipelines. It must be the storage mount path (default) or a subdirectory of it.
-
 - The **Compute service account** is the service account used by Nextflow to submit tasks (default: the `default` account in the given namespace).
-
 - The **Pod cleanup policy** determines when to delete terminated pods.
-
 - Use **Custom head pod specs** to provide custom options for the Nextflow workflow pod (`nodeSelector`, `affinity`, etc). For example:
 
 ```yaml
@@ -122,7 +119,5 @@ spec:
 ```
 
 - Use **Custom service pod specs** to provide custom options for the compute environment pod. See above for an example.
-
 - Use **Head Job CPUs** and **Head Job memory** to specify the hardware resources allocated to the Nextflow workflow pod.
 
-<!-- sync with DevOps about recent Ingress changes and implication for cluster prep and what we expect-->

--- a/platform_versioned_docs/version-24.1/compute-envs/k8s.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/k8s.mdx
@@ -93,7 +93,7 @@ After you've prepared your Kubernetes cluster for Seqera integration, create a c
 1. Apply [**Resource labels**](../resource-labels/overview.mdx) to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 1. Expand **Staging options** to include:
     - Optional [pre- or post-run Bash scripts](../launch/advanced.mdx#pre--post-run-scripts) that execute before or after the Nextflow pipeline execution in your environment.
-    - Global Nextflow configuration settings for all pipelines launched with this environment. Configuration values in this field override the same values in the pipeline Nextflow config file. 
+    - Global Nextflow configuration settings for all pipeline runs launched with this compute environment. Configuration settings in this field override the same values in the pipeline Nextflow config file. 
 1. You can use the **Environment variables** option to specify custom environment variables for the Head job and/or Compute jobs.
 1. Configure any advanced options described below, as needed.
 1. Select **Create** to finalize the compute environment setup.


### PR DESCRIPTION
Updates staging options instructions to include global NF config field for all compute environment pages. 
PR includes some formatting fixes. 