### PR TITLE
24.2 minor features

### DIFF
--- a/platform_versioned_docs/version-24.1/getting-started/quickstart-demo/add-pipelines.mdx
+++ b/platform_versioned_docs/version-24.1/getting-started/quickstart-demo/add-pipelines.mdx
@@ -27,6 +27,9 @@ To import the `nf-core/rnaseq` pipeline:
     :::
 1. Select the Platform **Organization**, **Workspace**, and **Compute environment** for the imported pipeline. 
 1. (Optional) Customize the **Pipeline Name** and **Pipeline Description**.
+    :::note
+    Pipeline names must be unique per workspace.
+    :::
 1. Select **Add Pipeline**. 
 
 ![Seqera Pipelines add to Launchpad](assets/seqera-pipelines-add-pipeline.gif)
@@ -43,7 +46,7 @@ To launch pipelines directly with CLI tools, select the **Launch Pipeline** tab 
 
 From your workspace Launchpad, select **Add Pipeline** and specify the following pipeline details:
 
-- **Name**: `nf-core/rnaseq`, or a custom name of your choice. 
+- **Name**: `nf-core/rnaseq`, or a custom name of your choice. Pipeline names must be unique per workspace. 
 - (*Optional*) **Description**: A summary of the pipeline or any information that may be useful to workspace participants when selecting a pipeline to launch. 
 - (*Optional*) **Labels**: Categorize the pipeline according to arbitrary criteria (such as reference genome version) that may help workspace participants to select the appropriate pipeline for their analysis.
 - **Compute environment**: Select an existing workspace [compute environment](../../compute-envs/overview.mdx).

--- a/platform_versioned_docs/version-24.1/launch/launchpad.mdx
+++ b/platform_versioned_docs/version-24.1/launch/launchpad.mdx
@@ -21,6 +21,8 @@ The list layout is the default **Launchpad** view. Use the toggle next to the **
 
 :::note
 In Seqera Enterprise version 24.1, the stepped launch form described below must be enabled with the `TOWER_STEPPED_LAUNCH_FORM_ALLOWED_WORKSPACES` [environment variable](../enterprise/configuration/overview.mdx#core-features). Without this configuration, version 24.1 defaults to the [classic launch form](../../version-23.4/launch/launchpad.mdx#launch-form).
+
+Platform Cloud accounts use the [classic launch form](../../version-23.4/launch/launchpad.mdx#launch-form) by default — [contact us](https://seqera.io/contact-us/) to enable the new stepped launch form. 
 :::
 
 The launch form is used to launch pipelines and to add pipelines to the **Launchpad**. Select **Launch** next to a saved pipeline in the list, or select **launch a run without configuration** to perform a quick launch of an unsaved pipeline.
@@ -32,23 +34,15 @@ For saved pipelines, **General config** and **Run parameters** fields are prefil
 ### General config 
 
 - **Pipeline to launch**: A Git repository name or URL. For saved pipelines, this is prefilled and cannot be edited. Private repositories require [access credentials](../credentials/overview.mdx).
-
   :::note
   Nextflow pipelines are Git repositories that can reside on any public or private Git-hosting platform. See [Git integration](../git/overview.mdx) in the Seqera docs and [Pipeline sharing](https://www.nextflow.io/docs/latest/sharing.html) in the Nextflow docs for more details.
   :::
-
 - **Revision number**: A valid repository commit ID, tag, or branch name. For saved pipelines, this is prefilled and cannot be edited.
-
 - **Config profiles**: One or more [configuration profile](https://www.nextflow.io/docs/latest/config.html#config-profiles) names to use for the execution. Config profiles must be defined in the `nextflow.config` file in the pipeline repository.
-
 - **Workflow run name**: A unique identifier for the run, pre-filled with a random name. This can be customized.
-
 - **Labels**: Assign new or existing [labels](../labels/overview.mdx) to the run.
-
 - **Compute environment**: The [compute environment](../compute-envs/overview.mdx) where the run will be launched.
-
 - **Work directory**: The cloud storage or file system path where pipeline scratch data is stored. Seqera will create a scratch sub-folder if only a cloud bucket location is specified. Use file system paths for local or HPC compute environments.
-
   :::note
   The credentials associated with the compute environment must have access to the work directory.
   :::
@@ -97,6 +91,9 @@ For more information on relaunch and resume, see [Nextflow cache and resume](./c
 
 From the **Launchpad**, select **Add pipeline** to add a new pipeline with pre-saved parameters to your workspace. The fields on the new pipeline form are similar to the pipeline launch form.
 
+:::note
+Pipeline names must be unique per workspace.
+:::
 :::tip
 To create your own customized Nextflow schema for your pipeline, see [Pipeline schema](../pipeline-schema/overview.mdx) and the `nf-core` workflows that have adopted this. [nf-core/eager](https://github.com/nf-core/eager/blob/master/nextflow_schema.json) and [nf-core/rnaseq](https://github.com/nf-core/rnaseq/blob/master/nextflow_schema.json) are good examples.
 :::
@@ -114,5 +111,5 @@ Workspace maintainers can edit existing pipeline details. Select the options men
 Select **Update** when you are ready to save the updated pipeline.
 
 :::note
-Workspace maintainers can edit pipeline names from the **Edit pipeline** page.
+Workspace maintainers can edit pipeline names from the **Edit pipeline** page. Pipeline names must be unique per workspace.
 :::

--- a/platform_versioned_docs/version-24.1/launch/launchpad.mdx
+++ b/platform_versioned_docs/version-24.1/launch/launchpad.mdx
@@ -20,7 +20,7 @@ The list layout is the default **Launchpad** view. Use the toggle next to the **
 ## Launch form
 
 :::note
-In Seqera Enterprise version 24.1, the stepped launch form described below must be enabled with the `TOWER_STEPPED_LAUNCH_FORM_ALLOWED_WORKSPACES` [environment variable](../enterprise/configuration/overview.mdx#core-features). Without this configuration, version 24.1 defaults to the [classic launch form](../../version-23.4/launch/launchpad.mdx#launch-form).
+In Platform Enterprise version 24.1, the stepped launch form described below must be enabled with the `TOWER_STEPPED_LAUNCH_FORM_ALLOWED_WORKSPACES` [environment variable](../enterprise/configuration/overview.mdx#core-features). Without this configuration, version 24.1 defaults to the [classic launch form](../../version-23.4/launch/launchpad.mdx#launch-form).
 
 Platform Cloud accounts use the [classic launch form](../../version-23.4/launch/launchpad.mdx#launch-form) by default — [contact us](https://seqera.io/contact-us/) to enable the new stepped launch form. 
 :::

--- a/platform_versioned_docs/version-24.1/resource-labels/overview.mdx
+++ b/platform_versioned_docs/version-24.1/resource-labels/overview.mdx
@@ -85,6 +85,7 @@ When the compute environment is created with Forge, the following resources will
 - Spot Fleet role
 - Execution role
 - Instance Profile role
+- Launch template
 
 **Submission time**
 


### PR DESCRIPTION
Docs updates for 24.2:
- Feature: Add flexibility for pipeline names in workspaces
- Feature: Add tag propagation to launch templates
- New launch form is feature-toggled in Cloud — this PR adds an admonition to contact Seqera to enable it. 