### PR TITLE
24.1.3 Enterprise patch release guidance and changelog

### DIFF
--- a/platform_versioned_docs/version-24.1/cloud/changelog.mdx
+++ b/platform_versioned_docs/version-24.1/cloud/changelog.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Changelog"
-description: "Seqera Platform changelog"
+title: "Cloud changelog"
+description: "Seqera Platform Cloud changelog"
 date: "4 July 2024"
 tags: [changelog]
 ---
@@ -59,67 +59,6 @@ tags: [changelog]
   * Rename checkpoints
 - Data Explorer:
   * Multi-download functionality
-
-### 23.4.6 Enterprise - 1 August 2024
-
-- Security patches.
-
-### 23.4.5 Enterprise - 15 July 2024
-
--  The standard email login can be disabled via `tower.yml` or an environment variable, provided an alternative OIDC provider is set up first.
-
-### 23.4.4 Enterprise - 20 March 2024
-
-- Adds support for GitHub Enterprise.
-
-### 23.4.0 Enterprise — 8 February 2024
-
-- **Breaking change:** Update `docker-compose` in deployment files to `docker compose`
-- **Breaking change:** SQL migration enhancements for MySQL 5.7 and above (see [Upgrade steps](../enterprise/release_notes/enterprise_latest.mdx#upgrade-steps))
-- Bump nf-jdk:corretto-17.0.10-jemalloc as base image
-- Upgrade Bootstrap to version 5
-- Allow previewing of Nextflow output files in Data Explorer
-- New base image nginx 1.25.3 for tower-frontend unprivileged
-- Seqera Platform Enterprise license model change — requires new licenses for existing Enterprise customers
-- Remove tower.enable.arm64 config option
-- Feature: Changed default AzBatch image to ubuntu-server
-- Feature: Set private address for head job configuration in Google Batch
-- Feature: VM instance template support for Google Batch
-
-## 2023
-
-### 23.3.0 Enterprise - 27 November 2023
-
-- Add support for Service Account, VPC and Subnetwork in Google Batch Advanced Settings
-- Add support for AWS Batch SPOT_PRICE_CAPACITY_OPTIMIZED allocation strategy
-- Add page size selector and pagination for the tasks table in the workflow details page
-- Add support for Fusion to EKS and GKE platform providers
-- Add support for Secrets for Google Batch and Google LS
-- Improve responsiveness for the workflow runs list page
-- Bump nf-launcher:j17-23.04.3
-- Add support for downloading and previewing bucket files through Data Explorer
-- Adds the possibility to specify a custom base href (useful in a reverse proxy scenario)
-- Fix disabled search bar after getting 0 results for a search in the workflow reports tab
-- Add download as json option for workflow run parameters
-- Decrease audit log lifespan to 90 days
-- Add support for uploading files through Data Explorer
-- Add support for Nextflow cloudcache plugin
-- Add support for navigating workflow and task work directories using Data Explorer
-- Apply new branding to UI and copy
-- Bump avatar file size limit to 200KB
-- Improve auto-suggested datalink name
-- Disable upload functionality on public Data Links
-- Fix tasks total number getting stuck after filtering
-- Previewing text files in Data Explorer now capped at 2000 lines to prevent browser from hanging
-- Enable instance types selection for dragen queue
-- Fix display of error messages in pipeline input form
-- Fix report preview dialog height
-- Adds a new attempt column to the task table
-- Deprecate Fusion V1
-- Add support for selecting pipeline input values using Data Explorer
-- Add a per workspace and global feature toggle for Data Explorer
-- Update Azure icon (Azure rebranding from May 2021)
-- Add support for custom network and subnetwork to Google Cloud Batch compute enviroment
 
 ### 23.3.0 Cloud - 16 October 2023
 

--- a/platform_versioned_docs/version-24.1/cloud/changelog.mdx
+++ b/platform_versioned_docs/version-24.1/cloud/changelog.mdx
@@ -4,7 +4,6 @@ description: "Seqera Platform Cloud changelog"
 date: "4 July 2024"
 tags: [changelog]
 ---
-## 2024
 
 ### 24.2.0_cycle21 Cloud - 13 August 2024
 
@@ -33,21 +32,6 @@ tags: [changelog]
 - Fix: Data Explorer search bar misalignment
 - Fix: Parameters merging in schema form without key in schema
 - Bump nf-launcher:24.04.3
-
-### 24.1.1 Enterprise - July 2024
-
-- Feature: Data Studios: Added the ability to rename data studio checkpoints 
-- Feature: Data Explorer: Added OpenAPI support for Data Explorer
-- Feature: Data Explorer: Show loading in Workflow/Task Data Explorer tab while waiting for data link cache refresh
-- Feature: Personal workspace: Datasets can now be used in personal workspaces
-- Feature: Personal workspace: Pipeline secrets can now be used in personal workspaces
-- Feature: Add Graviton3 EC2 instance family as valid NVMe instance types
-- Feature: Add new G6 EC2 instance family as valid NVMe instance types
-- Improvement: Retrieve reports from primary compute environment on NF CLI runs
-- Improvement: At nf-launcher, propagate a curl failures and exit
-- Security: Upgrade base Docker images to get upstream updates
-- Deprecate EBS autoscale in the Seqera Platform user interface
-- Bump nf-launcher:j17-23.10.1-up1
 
 ### 24.1.x Cloud - May 2024
 

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/docker/docker-compose.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.1.1
+    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.1.2
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -57,7 +57,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.1
+    image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.2
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -76,7 +76,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.1
+    image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.2
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -101,7 +101,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.1
+    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.2
     platform: linux/amd64
     networks:
       - frontend

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/docker/docker-compose.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.1.2
+    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.1.3
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -57,7 +57,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.2
+    image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.3
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -76,7 +76,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.2
+    image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.3
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -101,7 +101,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.2
+    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.3
     platform: linux/amd64
     networks:
       - frontend

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/docker/tower.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/docker/tower.yml
@@ -21,7 +21,7 @@ auth:
     duration: 30m
 
 # Set a custom application name for the Micronaut environment to deploy multiple instances from the same Enterprise account
-# Required for AWS Parameter Store configuration. For more information, see https://docs.seqera.io/platform/24.1.0/enterprise/configuration/aws_parameter_store 
+# Required for AWS Parameter Store configuration. For more information, see https://docs.seqera.io/platform/24.1/enterprise/configuration/aws_parameter_store 
 micronaut:
   application:
     name: tower-app
@@ -32,7 +32,7 @@ tower:
       - '*@org.xyz'
       - 'named_user@org.xyz'
 
-  # Seqera instance-wide configuration for authentication. For further information, see https://docs.seqera.io/platform/24.1.0/enterprise/configuration/authentication/
+  # Seqera instance-wide configuration for authentication. For further information, see https://docs.seqera.io/platform/24.1/enterprise/configuration/authentication/
   auth:
     google:
       allow-list:
@@ -41,7 +41,7 @@ tower:
       allow-list:
         - "*@org.xyz"
 
-  # Seqera instance-wide configuration for SCM providers. For further information, see https://docs.seqera.io/platform/24.1.0/enterprise/configuration/overview
+  # Seqera instance-wide configuration for SCM providers. For further information, see https://docs.seqera.io/platform/24.1/enterprise/configuration/overview
   scm:
     providers:
       github:

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-cron.yml
@@ -25,7 +25,7 @@ spec:
         #    secretName: platform-oidc-certs
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.1.1
+          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.1.2
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -39,7 +39,7 @@ spec:
             #  mountPath: /data/certs
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.1
+          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.2
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-cron.yml
@@ -25,7 +25,7 @@ spec:
         #    secretName: platform-oidc-certs
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.1.2
+          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.1.3
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -39,7 +39,7 @@ spec:
             #  mountPath: /data/certs
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.2
+          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.3
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-svc.yml
@@ -25,7 +25,7 @@ spec:
             name: tower-yml
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.1
+          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.2
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -78,7 +78,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.1
+          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.2
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-svc.yml
@@ -25,7 +25,7 @@ spec:
             name: tower-yml
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.2
+          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.3
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -78,7 +78,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.2
+          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.3
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform_versioned_docs/version-24.1/enterprise/index.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/index.mdx
@@ -84,9 +84,9 @@ container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](htt
 3. Pull the application container images:
 
    ```bash
-   docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.1
+   docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.3
 
-   docker pull cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.1
+   docker pull cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.3
    ```
 
 ## Support

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
@@ -15,7 +15,7 @@ tags: [changelog]
 - Fix: Dependency vulnerabilities 
 - Improvement: Add tag propagation for storage volumes to AWS launch template
 - Improvement: Implement custom H8 2nd-level cache to replace Redisson cache 
-- Improvement: Extend "determineTextFormat" helper function 
+- Improvement: Extend `determineTextFormat` helper function 
 
 ### 24.1.1 Enterprise - July 2024
 

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
@@ -5,7 +5,7 @@ date: "4 July 2024"
 tags: [changelog]
 ---
 
-### 24.1.2 - August 2024
+### 24.1.2 - 22 August 2024
 
 Fix: Disable launch form submit button during form validation
 Fix: Allow workDir edit during pipeline launch 

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
@@ -16,6 +16,7 @@ tags: [changelog]
 - Improvement: Add tag propagation for storage volumes to AWS launch template
 - Improvement: Implement custom H8 2nd-level cache to replace Redisson cache 
 - Improvement: Extend `determineTextFormat` helper function 
+- Bump nf-launcher:j17-24.04.4
 
 ### 24.1.1 Enterprise - July 2024
 

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
@@ -7,15 +7,15 @@ tags: [changelog]
 
 ### 24.1.2 Enterprise - 22 August 2024
 
-Fix: Disable launch form submit button during form validation
-Fix: Allow workDir edit during pipeline launch 
-Fix: Data Explorer preview for Azure Blob Storage files
-Fix: GCP resource leak 
-Fix: Remote config read issue
-Fix: Dependency vulnerabilities 
-Improvement: Add tag propagation for storage volumes to AWS launch template
-Improvement: Implement custom H8 2nd-level cache to replace Redisson cache 
-Improvement: Extend "determineTextFormat" helper function 
+- Fix: Disable launch form **Submit** button during form validation
+- Fix: Allow `workDir` edit during pipeline launch 
+- Fix: Data Explorer preview for Azure Blob Storage files
+- Fix: GCP resource leak 
+- Fix: Remote config read issue
+- Fix: Dependency vulnerabilities 
+- Improvement: Add tag propagation for storage volumes to AWS launch template
+- Improvement: Implement custom H8 2nd-level cache to replace Redisson cache 
+- Improvement: Extend `determineTextFormat` helper function 
 
 ### 24.1.1 Enterprise - July 2024
 
@@ -48,22 +48,22 @@ Improvement: Extend "determineTextFormat" helper function
 
 - **Breaking change:** Update `docker-compose` in deployment files to `docker compose`
 - **Breaking change:** SQL migration enhancements for MySQL 5.7 and above (see [Upgrade steps](../enterprise/release_notes/enterprise_latest.mdx#upgrade-steps))
+- Feature: Changed default AzBatch image to ubuntu-server
+- Feature: Set private address for head job configuration in Google Batch
+- Feature: VM instance template support for Google Batch
 - Bump nf-jdk:corretto-17.0.10-jemalloc as base image
 - Upgrade Bootstrap to version 5
 - Allow previewing of Nextflow output files in Data Explorer
 - New base image nginx 1.25.3 for tower-frontend unprivileged
 - Seqera Platform Enterprise license model change — requires new licenses for existing Enterprise customers
 - Remove tower.enable.arm64 config option
-- Feature: Changed default AzBatch image to ubuntu-server
-- Feature: Set private address for head job configuration in Google Batch
-- Feature: VM instance template support for Google Batch
 
 ## 2023
 
 ### 23.3.0 Enterprise - 27 November 2023
 
-- Add support for Service Account, VPC and Subnetwork in Google Batch Advanced Settings
-- Add support for AWS Batch SPOT_PRICE_CAPACITY_OPTIMIZED allocation strategy
+- Add support for Service Account, VPC, and Subnetwork in Google Batch Advanced Settings
+- Add support for AWS Batch `SPOT_PRICE_CAPACITY_OPTIMIZED` allocation strategy
 - Add page size selector and pagination for the tasks table in the workflow details page
 - Add support for Fusion to EKS and GKE platform providers
 - Add support for Secrets for Google Batch and Google LS

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
@@ -47,7 +47,7 @@ tags: [changelog]
 ### 23.4.0 Enterprise — 8 February 2024
 
 - **Breaking change:** Update `docker-compose` in deployment files to `docker compose`
-- **Breaking change:** SQL migration enhancements for MySQL 5.7 and above (see [Upgrade steps](../enterprise/release_notes/enterprise_latest.mdx#upgrade-steps))
+- **Breaking change:** SQL migration enhancements for MySQL 5.7 and above (see [Upgrade steps](./23.4.mdx#upgrade-steps))
 - Bump nf-jdk:corretto-17.0.10-jemalloc as base image
 - Upgrade Bootstrap to version 5
 - Allow previewing of Nextflow output files in Data Explorer

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
@@ -5,7 +5,7 @@ date: "4 July 2024"
 tags: [changelog]
 ---
 
-### 24.1.2 - 22 August 2024
+### 24.1.2 Enterprise - 22 August 2024
 
 Fix: Disable launch form submit button during form validation
 Fix: Allow workDir edit during pipeline launch 

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
@@ -5,17 +5,17 @@ date: "4 July 2024"
 tags: [changelog]
 ---
 
-### 24.1.2 Enterprise - 22 August 2024
+### 24.1.3 Enterprise - 22 August 2024
 
-- Fix: Disable launch form **Submit** button during form validation
-- Fix: Allow `workDir` edit during pipeline launch 
+- Fix: Disable launch form submit button during form validation
+- Fix: Allow workDir edit during pipeline launch 
 - Fix: Data Explorer preview for Azure Blob Storage files
 - Fix: GCP resource leak 
 - Fix: Remote config read issue
 - Fix: Dependency vulnerabilities 
 - Improvement: Add tag propagation for storage volumes to AWS launch template
 - Improvement: Implement custom H8 2nd-level cache to replace Redisson cache 
-- Improvement: Extend `determineTextFormat` helper function 
+- Improvement: Extend "determineTextFormat" helper function 
 
 ### 24.1.1 Enterprise - July 2024
 
@@ -48,22 +48,22 @@ tags: [changelog]
 
 - **Breaking change:** Update `docker-compose` in deployment files to `docker compose`
 - **Breaking change:** SQL migration enhancements for MySQL 5.7 and above (see [Upgrade steps](../enterprise/release_notes/enterprise_latest.mdx#upgrade-steps))
-- Feature: Changed default AzBatch image to ubuntu-server
-- Feature: Set private address for head job configuration in Google Batch
-- Feature: VM instance template support for Google Batch
 - Bump nf-jdk:corretto-17.0.10-jemalloc as base image
 - Upgrade Bootstrap to version 5
 - Allow previewing of Nextflow output files in Data Explorer
 - New base image nginx 1.25.3 for tower-frontend unprivileged
 - Seqera Platform Enterprise license model change — requires new licenses for existing Enterprise customers
 - Remove tower.enable.arm64 config option
+- Feature: Changed default AzBatch image to ubuntu-server
+- Feature: Set private address for head job configuration in Google Batch
+- Feature: VM instance template support for Google Batch
 
 ## 2023
 
 ### 23.3.0 Enterprise - 27 November 2023
 
-- Add support for Service Account, VPC, and Subnetwork in Google Batch Advanced Settings
-- Add support for AWS Batch `SPOT_PRICE_CAPACITY_OPTIMIZED` allocation strategy
+- Add support for Service Account, VPC and Subnetwork in Google Batch Advanced Settings
+- Add support for AWS Batch SPOT_PRICE_CAPACITY_OPTIMIZED allocation strategy
 - Add page size selector and pagination for the tasks table in the workflow details page
 - Add support for Fusion to EKS and GKE platform providers
 - Add support for Secrets for Google Batch and Google LS

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
@@ -5,7 +5,7 @@ date: "4 July 2024"
 tags: [changelog]
 ---
 
-### 24.1.3 Enterprise - 22 August 2024
+### 24.1.3 Enterprise - 23 August 2024
 
 - Fix: Disable launch form submit button during form validation
 - Fix: Allow workDir edit during pipeline launch 

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_changelog.mdx
@@ -1,0 +1,94 @@
+---
+title: " Enterprise changelog"
+description: "Seqera Platform Enterprise changelog"
+date: "4 July 2024"
+tags: [changelog]
+---
+
+### 24.1.2 - August 2024
+
+Fix: Disable launch form submit button during form validation
+Fix: Allow workDir edit during pipeline launch 
+Fix: Data Explorer preview for Azure Blob Storage files
+Fix: GCP resource leak 
+Fix: Remote config read issue
+Fix: Dependency vulnerabilities 
+Improvement: Add tag propagation for storage volumes to AWS launch template
+Improvement: Implement custom H8 2nd-level cache to replace Redisson cache 
+Improvement: Extend "determineTextFormat" helper function 
+
+### 24.1.1 Enterprise - July 2024
+
+- Feature: Data Studios: Added the ability to rename data studio checkpoints 
+- Feature: Data Explorer: Added OpenAPI support for Data Explorer
+- Feature: Data Explorer: Show loading in Workflow/Task Data Explorer tab while waiting for data link cache refresh
+- Feature: Personal workspace: Datasets can now be used in personal workspaces
+- Feature: Personal workspace: Pipeline secrets can now be used in personal workspaces
+- Feature: Add Graviton3 EC2 instance family as valid NVMe instance types
+- Feature: Add new G6 EC2 instance family as valid NVMe instance types
+- Improvement: Retrieve reports from primary compute environment on NF CLI runs
+- Improvement: At nf-launcher, propagate a curl failures and exit
+- Security: Upgrade base Docker images to get upstream updates
+- Deprecate EBS autoscale in the Seqera Platform user interface
+- Bump nf-launcher:j17-23.10.1-up1
+
+### 23.4.6 Enterprise - 1 August 2024
+
+- Security patches.
+
+### 23.4.5 Enterprise - 15 July 2024
+
+-  The standard email login can be disabled via `tower.yml` or an environment variable, provided an alternative OIDC provider is set up first.
+
+### 23.4.4 Enterprise - 20 March 2024
+
+- Adds support for GitHub Enterprise.
+
+### 23.4.0 Enterprise — 8 February 2024
+
+- **Breaking change:** Update `docker-compose` in deployment files to `docker compose`
+- **Breaking change:** SQL migration enhancements for MySQL 5.7 and above (see [Upgrade steps](../enterprise/release_notes/enterprise_latest.mdx#upgrade-steps))
+- Bump nf-jdk:corretto-17.0.10-jemalloc as base image
+- Upgrade Bootstrap to version 5
+- Allow previewing of Nextflow output files in Data Explorer
+- New base image nginx 1.25.3 for tower-frontend unprivileged
+- Seqera Platform Enterprise license model change — requires new licenses for existing Enterprise customers
+- Remove tower.enable.arm64 config option
+- Feature: Changed default AzBatch image to ubuntu-server
+- Feature: Set private address for head job configuration in Google Batch
+- Feature: VM instance template support for Google Batch
+
+## 2023
+
+### 23.3.0 Enterprise - 27 November 2023
+
+- Add support for Service Account, VPC and Subnetwork in Google Batch Advanced Settings
+- Add support for AWS Batch SPOT_PRICE_CAPACITY_OPTIMIZED allocation strategy
+- Add page size selector and pagination for the tasks table in the workflow details page
+- Add support for Fusion to EKS and GKE platform providers
+- Add support for Secrets for Google Batch and Google LS
+- Improve responsiveness for the workflow runs list page
+- Bump nf-launcher:j17-23.04.3
+- Add support for downloading and previewing bucket files through Data Explorer
+- Adds the possibility to specify a custom base href (useful in a reverse proxy scenario)
+- Fix disabled search bar after getting 0 results for a search in the workflow reports tab
+- Add download as json option for workflow run parameters
+- Decrease audit log lifespan to 90 days
+- Add support for uploading files through Data Explorer
+- Add support for Nextflow cloudcache plugin
+- Add support for navigating workflow and task work directories using Data Explorer
+- Apply new branding to UI and copy
+- Bump avatar file size limit to 200KB
+- Improve auto-suggested datalink name
+- Disable upload functionality on public Data Links
+- Fix tasks total number getting stuck after filtering
+- Previewing text files in Data Explorer now capped at 2000 lines to prevent browser from hanging
+- Enable instance types selection for dragen queue
+- Fix display of error messages in pipeline input form
+- Fix report preview dialog height
+- Adds a new attempt column to the task table
+- Deprecate Fusion V1
+- Add support for selecting pipeline input values using Data Explorer
+- Add a per workspace and global feature toggle for Data Explorer
+- Update Azure icon (Azure rebranding from May 2021)
+- Add support for custom network and subnetwork to Google Cloud Batch compute enviroment

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_latest.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_latest.mdx
@@ -76,7 +76,7 @@ Enterprise deployments that have customized this value previously will need to a
 
 ## Upgrade steps 
 
-1. This version includes an update to the Platform Enterprise H8 cache. **Do not start the upgrade while any pipelines are in a running state as active run data may be lost.**
+1. This version includes an update to the Platform Enterprise H8 cache. **Do not start the upgrade while any pipelines are in a `running` state as active run data may be lost.**
 1. This version requires a database schema update. Make a backup of your Platform database prior to upgrade.
 1. If you are upgrading from a version older than 23.4.1, update your installation to version [23.4.4](./23.4.mdx) first, before updating to 24.1.2 with the steps below.
 1. For recommended Platform memory settings, add the following environment variable to your Platform configuration values (`tower.env`, `configmap.yml`, etc. ):

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_latest.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_latest.mdx
@@ -74,13 +74,11 @@ Enterprise deployments that have customized this value previously will need to a
 1. This version includes an update to the Platform Enterprise H8 cache. **Do not start the upgrade while any pipelines are in a running state as active run data may be lost.**
 1. This version requires a database schema update. Make a backup of your Platform database prior to upgrade.
 1. If you are upgrading from a version older than 23.4.1, update your installation to version [23.4.4](./23.4.mdx) first, before updating to 24.1.2 with the steps below.
-1. We recommend adding the following environment variable to your Platform configuration values (`tower.env`, `configmap.yml`, etc. ):
-
+1. For recommended Platform memory settings, add the following environment variable to your Platform configuration values (`tower.env`, `configmap.yml`, etc. ):
     ```console 
     JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
     ```
-
-See [Upgrade installation](../upgrade.mdx) for database backup and installation upgrade guidance.
+1. See [Upgrade installation](../upgrade.mdx) for database backup and installation upgrade guidance.
 
 Docker Compose deployments require downtime while upgrading services. Restarting the application may take several minutes. See [Docker compose deployment](../docker-compose.mdx) for more information.
 

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_latest.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_latest.mdx
@@ -1,14 +1,4 @@
-# Enterprise 24.1.x
-
-:::caution 
-In order to ensure our customers have success with Seqera Platform 24.1+ we recommend pausing planned upgrades to 24.1+ on production systems until further notice. 
-
-Our team has identified an issue in a dependency library which may cause a memory leak under certain conditions at scale.  While we have not seen this issue surface in any production Enterprise deployments, we recommend pausing release plans while we work on expediting a fix with the library maintainers. 
-
-We have reached out to all users running 24.1 directly and recommend continuing Seqera Platform use as normal while waiting for a patch release. 
-
-If you have any further questions, please [contact support](https://support.seqera.io).
-:::
+# Enterprise 24.1
 
 Seqera Platform Enterprise version 24.1 introduces three new features: Data Studios (in public preview), Data Explorer, and managed identities. A number of bug fixes and performance enhancements have also been included in this major release.
 
@@ -32,10 +22,10 @@ Data Explorer is now Generally Available and supports multi-file and multi-folde
 
 User roles provide flexibility for admins to provide users with the permissions they need, without compromising security. The **Connect** user role has been added to the existing user roles with functionality related to Data Studios:
 
-- **Connect**: The ability to open a connection to a running session and interact with the contents.
-- **Maintain**: The ability to create, update, start, stop, change configuration, and delete data studio sessions.
-- **View**: The ability to list, search, and see the status/configuration/details of data studios.
-- **Launch**: The ability to open a connection to a running session and interact with the contents.
+- **Connect**: Open a connection to a running data studio session and interact with the contents.
+- **Maintain**: Create, update, start, stop, change configuration, and delete data studio sessions.
+- **View**: List, search, and view the status/configuration/details of data studios.
+- **Launch**: Open a connection to a running data studio session and interact with the contents.
 
 See [User roles](../../orgs-and-teams/roles.mdx) for more information.
 
@@ -79,65 +69,24 @@ The property that determines the expiration time of the JWT access token (used f
 	
 Enterprise deployments that have customized this value previously will need to adopt the new format.
 
-## Upgrade steps
+## Upgrade steps 
 
-:::caution 
-In order to ensure our customers have success with Seqera Platform 24.1+ we recommend pausing planned upgrades to 24.1+ on production systems until further notice. 
+1. This version includes an update to the Platform Enterprise H8 cache. **Do not start the upgrade while any pipelines are in a running state as active run data may be lost.**
+1. This version requires a database schema update. Make a backup of your Platform database prior to upgrade.
+1. If you are upgrading from a version older than 23.4.1, update your installation to version [23.4.4](./23.4.mdx) first, before updating to 24.1.2 with the steps below.
+1. We recommend adding the following environment variable to your Platform configuration values (`tower.env`, `configmap.yml`, etc. ):
 
-Our team has identified an issue in a dependency library which may cause a memory leak under certain conditions at scale.  While we have not seen this issue surface in any production Enterprise deployments, we recommend pausing release plans while we work on expediting a fix with the library maintainers. 
+    ```console 
+    JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
+    ```
 
-We have reached out to all users running 24.1 directly and recommend continuing Seqera Platform use as normal while waiting for a patch release. 
-
-If you have any further questions, please [contact support](https://support.seqera.io).
-:::
-
-This version requires a database schema update. Make a backup of your Platform database prior to upgrade. 
-
-:::info
-If you are upgrading from a version older than 23.4.1, update your installation to version [23.4.4](./23.4.mdx) first, before updating to 24.1.1 with the steps below.
-:::
+See [Upgrade installation](../upgrade.mdx) for database backup and installation upgrade guidance.
 
 Docker Compose deployments require downtime while upgrading services. Restarting the application may take several minutes. See [Docker compose deployment](../docker-compose.mdx) for more information.
 
 For Kubernetes deployments, apply the 24.1 `tower-cron.yml` to your cron pod and wait for the cron pod to be running before applying the `tower-svc.yml` to your backend pod and restarting the service. If the cron pod update is interrupted, you may need to restore the instance from your DB backup and start again. See [Kubernetes deployment](../kubernetes.mdx) for more information. 
 
-For custom deployments with third-party services such as ArgoCD, [contact support](https://support.seqera.io) for assistance during upgrade. 
-
-Follow these steps to update your DB instance and the Seqera installation:
-
-:::caution
-The database volume is persistent on the local machine by default if you use the `volumes` key in the `db` or `redis` section of your `docker-compose.yml` file to specify a local path to the DB or Redis instance. If your database is not persistent, you must back up your database before performing any application or database upgrades.
-:::
-
-1. Make a backup of the Seqera Platform database. If you use the pipeline optimization service and your `groundswell` database resides in a database instance separate from your Seqera database, make a backup of your `groundswell` database as well.
-2. Download the 24.1 versions of your deployment templates and update your Seqera container versions:
-    - [docker-compose.yml](../_templates/docker/docker-compose.yml) for Docker Compose deployments
-    - [tower-cron.yml](../_templates/k8s/tower-cron.yml) and [tower-svc.yml](../_templates/k8s/tower-svc.yml) for Kubernetes deployments
-3. Restart the application.
-4. If you're using a containerized database as part of your implementation:
-    1. Stop the application.
-    2. Upgrade the MySQL image.
-    3. Restart the application.
-5. If you're using Amazon RDS or other managed database services:
-    1. Stop the application.
-    2. Upgrade your database instance.
-    3. Restart the application.
-6. If you're using the pipeline optimization service (`groundswell` database) in a database separate from your Seqera database, update the MySQL image for your `groundswell` database instance while the application is down (during step 4 or 5 above). If you're using the same database instance for both, the `groundswell` update will happen automatically during the Seqera database update.
-
-**Custom deployment**:
-
-- Run the `/migrate-db.sh` script provided in the `migrate-db` container. This will migrate the database schema.
-- Deploy Seqera following your usual procedures.
-
-## Nextflow launcher image
-
-If you must host your nf-launcher container image on a private image registry, copy the [nf-launcher image](https://quay.io/seqeralabs/nf-launcher:j17-24.04.2) to your private registry. Then update your `tower.env` with the launch container environment variable:
-
-    `TOWER_LAUNCH_CONTAINER=<FULL_PATH_TO_YOUR_PRIVATE_IMAGE>`
-
-:::caution
-If you're using AWS Batch, you will need to [configure a custom job definition](../advanced-topics/custom-launch-container.mdx) and populate the `TOWER_LAUNCH_CONTAINER` with the job definition name instead.
-:::
+For custom deployments with third-party services such as ArgoCD, [contact support](https://support.seqera.io) for assistance during upgrade.  
 
 ## Changelog
 

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_latest.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_latest.mdx
@@ -1,4 +1,9 @@
-# Enterprise 24.1
+---
+title: " Enterprise 24.1"
+description: "Seqera Platform Enterprise version 24.1 release notes"
+date: "4 July 2024"
+tags: [changelog]
+---
 
 Seqera Platform Enterprise version 24.1 introduces three new features: Data Studios (in public preview), Data Explorer, and managed identities. A number of bug fixes and performance enhancements have also been included in this major release.
 
@@ -88,6 +93,6 @@ For custom deployments with third-party services such as ArgoCD, [contact suppor
 
 ## Changelog
 
-For a detailed list of all changes, see the Seqera [changelog](../../cloud/changelog.mdx).
+For a detailed list of all changes, see the Platform Enterprise [changelog](./enterprise_changelog.mdx).
 
 [gcp-vm-instance-template]: https://cloud.google.com/compute/docs/instance-templates

--- a/platform_versioned_docs/version-24.1/enterprise/testing.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/testing.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Test deployment"
+title: "Test installation"
 description: Test your Seqera Platform Enterprise deployment after installation
 date: "12 Feb 2024"
 tags: [testing, deployment]

--- a/platform_versioned_docs/version-24.1/enterprise/upgrade.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/upgrade.mdx
@@ -33,7 +33,7 @@ The database volume is persistent on the local machine by default if you use the
 
 ### Nextflow launcher image
 
-If you must host your nf-launcher container image on a private image registry, copy the [nf-launcher image](https://quay.io/seqeralabs/nf-launcher:j17-24.04.2) to your private registry. Then update your `tower.env` with the launch container environment variable:
+If you must host your nf-launcher container image on a private image registry, copy the [nf-launcher image](https://quay.io/seqeralabs/nf-launcher:j17-24.04.4) to your private registry. Then update your `tower.env` with the launch container environment variable:
 
     `TOWER_LAUNCH_CONTAINER=<FULL_PATH_TO_YOUR_PRIVATE_IMAGE>`
 

--- a/platform_versioned_docs/version-24.1/enterprise/upgrade.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/upgrade.mdx
@@ -38,5 +38,5 @@ If you must host your nf-launcher container image on a private image registry, c
     `TOWER_LAUNCH_CONTAINER=<FULL_PATH_TO_YOUR_PRIVATE_IMAGE>`
 
 :::caution
-If you're using AWS Batch, you will need to [configure a custom job definition](../advanced-topics/custom-launch-container.mdx) and populate the `TOWER_LAUNCH_CONTAINER` with the job definition name instead.
+If you're using AWS Batch, you will need to [configure a custom job definition](./advanced-topics/custom-launch-container.mdx) and populate the `TOWER_LAUNCH_CONTAINER` with the job definition name instead.
 :::

--- a/platform_versioned_docs/version-24.1/enterprise/upgrade.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/upgrade.mdx
@@ -13,8 +13,8 @@ The database volume is persistent on the local machine by default if you use the
 
 1. Make a backup of the Seqera Platform database. If you use the pipeline optimization service and your `groundswell` database resides in a database instance separate from your Seqera database, make a backup of your `groundswell` database as well.
 1. Download the latest versions of your deployment templates and update your Seqera container versions:
-    - [docker-compose.yml](../_templates/docker/docker-compose.yml) for Docker Compose deployments
-    - [tower-cron.yml](../_templates/k8s/tower-cron.yml) and [tower-svc.yml](../_templates/k8s/tower-svc.yml) for Kubernetes deployments
+    - [docker-compose.yml](./_templates/docker/docker-compose.yml) for Docker Compose deployments
+    - [tower-cron.yml](./_templates/k8s/tower-cron.yml) and [tower-svc.yml](./_templates/k8s/tower-svc.yml) for Kubernetes deployments
 1. Restart the application.
 1. If you're using a containerized database as part of your implementation:
     1. Stop the application.

--- a/platform_versioned_docs/version-24.1/enterprise/upgrade.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/upgrade.mdx
@@ -1,0 +1,42 @@
+---
+title: "Upgrade installation"
+description: "Platform Enterprise update guidance"
+date: "21 Aug 2024"
+tags: [enterprise, update, install]
+---
+
+Follow these steps to upgrade your database instance and Platform installation:
+
+:::caution
+The database volume is persistent on the local machine by default if you use the `volumes` key in the `db` or `redis` section of your `docker-compose.yml` file to specify a local path to the DB or Redis instance. If your database is not persistent, you must back up your database before performing any application or database upgrades.
+:::
+
+1. Make a backup of the Seqera Platform database. If you use the pipeline optimization service and your `groundswell` database resides in a database instance separate from your Seqera database, make a backup of your `groundswell` database as well.
+1. Download the latest versions of your deployment templates and update your Seqera container versions:
+    - [docker-compose.yml](../_templates/docker/docker-compose.yml) for Docker Compose deployments
+    - [tower-cron.yml](../_templates/k8s/tower-cron.yml) and [tower-svc.yml](../_templates/k8s/tower-svc.yml) for Kubernetes deployments
+1. Restart the application.
+1. If you're using a containerized database as part of your implementation:
+    1. Stop the application.
+    1. Upgrade the MySQL image.
+    1. Restart the application.
+1. If you're using Amazon RDS or other managed database services:
+    1. Stop the application.
+    1. Upgrade your database instance.
+    1. Restart the application.
+1. If you're using the pipeline optimization service (`groundswell` database) in a database separate from your Seqera database, update the MySQL image for your `groundswell` database instance while the application is down (during step 4 or 5 above). If you're using the same database instance for both, the `groundswell` update will happen automatically during the Seqera database update.
+
+### Custom deployments
+
+- Run the `/migrate-db.sh` script provided in the `migrate-db` container. This will migrate the database schema.
+- Deploy Seqera following your usual procedures.
+
+### Nextflow launcher image
+
+If you must host your nf-launcher container image on a private image registry, copy the [nf-launcher image](https://quay.io/seqeralabs/nf-launcher:j17-24.04.2) to your private registry. Then update your `tower.env` with the launch container environment variable:
+
+    `TOWER_LAUNCH_CONTAINER=<FULL_PATH_TO_YOUR_PRIVATE_IMAGE>`
+
+:::caution
+If you're using AWS Batch, you will need to [configure a custom job definition](../advanced-topics/custom-launch-container.mdx) and populate the `TOWER_LAUNCH_CONTAINER` with the job definition name instead.
+:::

--- a/platform_versioned_sidebars/version-24.1-sidebars.json
+++ b/platform_versioned_sidebars/version-24.1-sidebars.json
@@ -182,7 +182,8 @@
           "items": [
             "enterprise/docker-compose",
             "enterprise/kubernetes",
-            "enterprise/testing"          
+            "enterprise/testing",
+            "enterprise/upgrade"          
           ]
         },
         {
@@ -221,7 +222,8 @@
       "label": "Releases",
       "collapsed": true,
       "items": [
-        "cloud/changelog",        
+        "cloud/changelog",
+        "enterprise/release_notes/enterprise_changelog",       
         "enterprise/release_notes/enterprise_latest",
         {
           "type": "category",


### PR DESCRIPTION
Removes 24.1.1 upgrade warning from main Enterprise release notes. 
Adds separate Enterprise changelog
Adds Enterprise upgrade guide page, stripping out most upgrade guidance from the release notes page.
Adds 24.1.3 changelog entries.
Adds custom config and admonitions for 24.1.2 upgrade. 