### PR TITLE
fix: reference to S3-hosted data in GCP CE docs

### DIFF
--- a/platform_versioned_docs/version-23.1/compute-envs/google-cloud-batch.mdx
+++ b/platform_versioned_docs/version-23.1/compute-envs/google-cloud-batch.mdx
@@ -128,7 +128,7 @@ To create a new compute environment for Google Cloud in Tower:
 
 9. Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
 
-10. Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). <!--(re-added once we have GCP Fusion instructions) See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.-->
+10. Select **Enable Fusion v2** to allow access to your GCS-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). <!--(re-added once we have GCP Fusion instructions) See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.-->
 
 11. Enable **Spot** to use spot instances, which have significantly reduced cost compared to on-demand instances.
 

--- a/platform_versioned_docs/version-23.2/compute-envs/google-cloud-batch.mdx
+++ b/platform_versioned_docs/version-23.2/compute-envs/google-cloud-batch.mdx
@@ -128,7 +128,7 @@ To create a new compute environment for Google Cloud in Tower:
 
 9. Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
 
-10. Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). <!--(re-added once we have GCP Fusion instructions) See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.-->
+10. Select **Enable Fusion v2** to allow access to your GCS-hosted data via the [Fusion v2](https://www.nextflow.io/docs/latest/fusion.html) virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled (see above). <!--(re-added once we have GCP Fusion instructions) See [Fusion file system](../supported_software/fusion/fusion.mdx) for configuration details.-->
 
 11. Enable **Spot** to use spot instances, which have significantly reduced cost compared to on-demand instances.
 

--- a/platform_versioned_docs/version-23.3/compute-envs/google-cloud-batch.mdx
+++ b/platform_versioned_docs/version-23.3/compute-envs/google-cloud-batch.mdx
@@ -140,7 +140,7 @@ After your Google Cloud resources have been created, create a new Seqera compute
     :::
 
 9. (_Optional_) Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers][wave-docs] for more information.
-10. (_Optional_) Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2][fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled in the previous step. See [Fusion file system][platform-fusion-docs] for configuration details.
+10. (_Optional_) Select **Enable Fusion v2** to allow access to your GCS-hosted data via the [Fusion v2][fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled in the previous step. See [Fusion file system][platform-fusion-docs] for configuration details.
 11. Enable **Spot** to use spot instances, which have significantly reduced cost compared to on-demand instances.
 12. Apply [**Resource labels**][resource-labels] to the cloud resources consumed by this compute environment. Workspace default resource labels are prefilled.
 13. Expand **Staging options** to include optional [pre- or post-run Bash scripts][pre-post-run-scripts] that execute before or after the Nextflow pipeline execution in your environment.

--- a/platform_versioned_docs/version-23.4/compute-envs/google-cloud-batch.mdx
+++ b/platform_versioned_docs/version-23.4/compute-envs/google-cloud-batch.mdx
@@ -154,7 +154,7 @@ When you specify a Cloud Storage bucket as your work directory, this bucket is u
 
 Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers][wave-docs] for more information.
 
-Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2][fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled in the previous step. See [Fusion file system][platform-fusion-docs] for configuration details.
+Select **Enable Fusion v2** to allow access to your GCS-hosted data via the [Fusion v2][fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled in the previous step. See [Fusion file system][platform-fusion-docs] for configuration details.
 
 :::note
 Wave containers and Fusion v2 are recommended features for added capability and improved performance, but neither are required to execute workflows in your compute environment.

--- a/platform_versioned_docs/version-24.1/compute-envs/google-cloud-batch.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/google-cloud-batch.mdx
@@ -154,7 +154,7 @@ When you specify a Cloud Storage bucket as your work directory, this bucket is u
 
 Select **Enable Wave containers** to facilitate access to private container repositories and provision containers in your pipelines using the Wave containers service. See [Wave containers][wave-docs] for more information.
 
-Select **Enable Fusion v2** to allow access to your S3-hosted data via the [Fusion v2][fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled in the previous step. See [Fusion file system][platform-fusion-docs] for configuration details.
+Select **Enable Fusion v2** to allow access to your GCS-hosted data via the [Fusion v2][fusion-docs] virtual distributed file system. This speeds up most data operations. The Fusion v2 file system requires Wave containers to be enabled in the previous step. See [Fusion file system][platform-fusion-docs] for configuration details.
 
 :::note
 Wave containers and Fusion v2 are recommended features for added capability and improved performance, but neither are required to execute workflows in your compute environment.


### PR DESCRIPTION
Small typo fix in Google Batch CE docs to mention Fusion V2 allows access to GCS-hosted data, instead of S3-hosted data. 