### PR TITLE
Fix wrong file name for env file to edit

### DIFF
--- a/platform_versioned_docs/version-24.1/enterprise/data-studios.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/data-studios.mdx
@@ -77,7 +77,7 @@ This guide assumes that all services will be run in the same container as the re
         - `CONNECT_PROXY_URL`: A URL for the connect proxy subdomain. We recommend you set a first-level subdomain of your `PLATFORM_URL` for your connect proxy. For example, `https://connect.example.com`.
         - `CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN`: The same value set in the `oidc_registration_token` environment variable.
 
-1. Open `data-studios.env` in an editor and set the following variables:
+1. Open `tower.env` in an editor and set the following variables:
 
     - `TOWER_DATA_EXPLORER_ENABLED`: Set `true` to enable Data Explorer. You must enable Data Explorer to mount data inside a data studio instance.
     - `TOWER_DATA_STUDIO_CONNECT_URL`: The URL of the Data Studios connect proxy, such as `https://connect.example.com/`.


### PR DESCRIPTION
Need to double check, but as near as I can tell, the file name is wrong. This corrects it to the proper file to edit. This is for the Docker Compose installation variant for a new install.

Preview: https://deploy-preview-197--seqera-docs.netlify.app/platform/24.1/enterprise/data-studios#procedure