### PR TITLE
Use code font for URLs to avoid parser error

### DIFF
--- a/platform_versioned_docs/version-22.4/faqs.mdx
+++ b/platform_versioned_docs/version-22.4/faqs.mdx
@@ -811,7 +811,7 @@ To resolve this error, please try using the MUSL-based binary first. If this fai
 This error indicates that your Tower host accepts connections using http (insecure), rather than https. If your host cannot be configured to accept https connections, run your tw cli command with the `--insecure` flag.
 
 ```
- ERROR: You are trying to connect to an insecure server: http://hostname:port/api
+ ERROR: You are trying to connect to an insecure server: `http://hostname:port/api`
         if you want to force the connection use '--insecure'. NOT RECOMMENDED!
 ```
 

--- a/platform_versioned_docs/version-23.1/faqs.mdx
+++ b/platform_versioned_docs/version-23.1/faqs.mdx
@@ -831,7 +831,7 @@ To resolve this error, please try using the MUSL-based binary first. If this fai
 This error indicates that your Tower host accepts connections using http (insecure), rather than https. If your host cannot be configured to accept https connections, run your tw cli command with the `--insecure` flag.
 
 ```
- ERROR: You are trying to connect to an insecure server: http://hostname:port/api
+ ERROR: You are trying to connect to an insecure server: `http://hostname:port/api`
         if you want to force the connection use '--insecure'. NOT RECOMMENDED!
 ```
 

--- a/platform_versioned_docs/version-23.2/faqs.mdx
+++ b/platform_versioned_docs/version-23.2/faqs.mdx
@@ -831,7 +831,7 @@ To resolve this error, please try using the MUSL-based binary first. If this fai
 This error indicates that your Tower host accepts connections using http (insecure), rather than https. If your host cannot be configured to accept https connections, run your tw cli command with the `--insecure` flag.
 
 ```
- ERROR: You are trying to connect to an insecure server: http://hostname:port/api
+ ERROR: You are trying to connect to an insecure server: `http://hostname:port/api`
         if you want to force the connection use '--insecure'. NOT RECOMMENDED!
 ```
 

--- a/platform_versioned_docs/version-23.3/faqs.mdx
+++ b/platform_versioned_docs/version-23.3/faqs.mdx
@@ -659,7 +659,7 @@ To resolve segfault errors, first upgrade your tw CLI to the latest available ve
 
 **Insecure HTTP errors**
 
-_ERROR: You are trying to connect to an insecure server: http://hostname:port/api if you want to force the connection use '--insecure'. NOT RECOMMENDED!_
+_ERROR: You are trying to connect to an insecure server: `http://hostname:port/api` if you want to force the connection use '--insecure'. NOT RECOMMENDED!_
 
 This error indicates that your Seqera host accepts connections using insecure HTTP instead of HTTPS. If your host cannot be configured to accept HTTPS connections, add the `--insecure` flag **before** your CLI command:
 

--- a/platform_versioned_docs/version-23.4/faqs.mdx
+++ b/platform_versioned_docs/version-23.4/faqs.mdx
@@ -659,7 +659,7 @@ To resolve segfault errors, first upgrade your tw CLI to the latest available ve
 
 **Insecure HTTP errors**
 
-_ERROR: You are trying to connect to an insecure server: http://hostname:port/api if you want to force the connection use '--insecure'. NOT RECOMMENDED!_
+_ERROR: You are trying to connect to an insecure server: `http://hostname:port/api` if you want to force the connection use '--insecure'. NOT RECOMMENDED!_
 
 This error indicates that your Seqera host accepts connections using insecure HTTP instead of HTTPS. If your host cannot be configured to accept HTTPS connections, add the `--insecure` flag **before** your CLI command:
 

--- a/platform_versioned_docs/version-24.1/faqs.mdx
+++ b/platform_versioned_docs/version-24.1/faqs.mdx
@@ -659,7 +659,7 @@ To resolve segfault errors, first upgrade your tw CLI to the latest available ve
 
 **Insecure HTTP errors**
 
-_ERROR: You are trying to connect to an insecure server: http://hostname:port/api if you want to force the connection use '--insecure'. NOT RECOMMENDED!_
+_ERROR: You are trying to connect to an insecure server: `http://hostname:port/api` if you want to force the connection use '--insecure'. NOT RECOMMENDED!_
 
 This error indicates that your Seqera host accepts connections using insecure HTTP instead of HTTPS. If your host cannot be configured to accept HTTPS connections, add the `--insecure` flag **before** your CLI command:
 


### PR DESCRIPTION
This is a minor fix so that these do not fail builds.