### PR TITLE
Add basic Kubernetes installation documentation

### DIFF
--- a/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-deploy-no-heading.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-deploy-no-heading.mdx
@@ -1,0 +1,71 @@
+<!-- This partial includes no heading so it can be reused -->
+<!-- This partial uses HTML ol to force a configurable step number -->
+
+<ol start={props.step || '2'}>
+<li>
+Deploy the cron service:
+
+:::caution
+This manifest includes an init container that creates the required database schema the first time it instantiates. This process can take a few minutes to complete and must finish before you instantiate the Seqera backend. Ensure this container is in the `READY` state before proceeding to the next step.
+:::
+
+1. Apply the `tower-cron.yml` manifest:
+
+    ```
+    kubectl apply -f tower-cron.yml
+    ```
+
+    <details>
+    <summary>View command output</summary>
+    ```
+    deployment.apps/cron configured
+    ```
+    </details>
+
+1. Confirm that cron service deployed successfully:
+
+    ```
+    kubectl rollout status deployment/cron
+    ```
+
+    <details>
+    <summary>View command output</summary>
+      deployment "cron" successfully rolled out
+    </details>
+</li>
+<li>
+Deploy the backend and frontend services:
+
+1. Apply the `tower-svc.yml` manifest:
+
+    ```
+    kubectl apply -f tower-svc.yml
+    ```
+
+    <details>
+    <summary>View command output</summary>
+    ```
+    deployment.apps/backend configured
+    deployment.apps/frontend configured
+    service/backend configured
+    service/frontend configured
+    ```
+    </details>
+
+1. Confirm that cron service deployed successfully:
+
+    ```
+    kubectl get deployments
+    ```
+
+    <details>
+    <summary>View command output</summary>
+    ```
+    NAME       READY   UP-TO-DATE   AVAILABLE   AGE
+    backend    1/1     1            1           2d6h
+    cron       1/1     1            1           2d6h
+    frontend   1/1     1            1           2d6h
+    ```
+    </details>
+</li>
+</ol>

--- a/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-deploy.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-deploy.mdx
@@ -1,4 +1,3 @@
-<!-- This partial includes no heading so it can be reused -->
 <!-- This partial uses HTML ol to force a configurable step number -->
 
 <ol start={props.step || '2'}>

--- a/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-ns.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-ns.mdx
@@ -1,5 +1,3 @@
-## Create a namespace
-
 Create a namespace to isolate Kubernetes resources used by Seqera Platform from the other resources on your cluster.
 
 :::tip

--- a/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-ns.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-ns.mdx
@@ -1,0 +1,26 @@
+## Create a namespace
+
+Create a namespace to isolate Kubernetes resources used by Seqera Platform from the other resources on your cluster.
+
+:::tip
+This installation guide assumes the use of `seqera-platform` as the installation namespace. Consider using a different one that better fits your cluster naming convention.
+:::
+
+1. Create a namespace for the Seqera resources:
+
+    ```
+    kubectl create namespace seqera-platform
+    ```
+
+    <details>
+    <summary>View command output</summary>
+    ```
+    namespace/seqera-platform created
+    ```
+    </details>
+
+1. Switch to the namespace:
+
+    ```
+    kubectl config set-context --current --namespace=seqera-platform
+    ```

--- a/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-registry.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-registry.mdx
@@ -66,3 +66,5 @@ Seqera Enterprise is distributed as a collection of Docker containers available 
         ```
         </details>
 
+<!-- links -->
+[kubectl-secret]: https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/

--- a/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-registry.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-registry.mdx
@@ -1,0 +1,70 @@
+## Configure container registry credentials
+
+Seqera Enterprise is distributed as a collection of Docker containers available through the Seqera container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. After you've received your credentials, grant your cluster access to the registry:
+
+1. Retrieve the `name` and `secret` values from the JSON file that you received from Seqera support.
+
+1. Create a [secret][kubectl-secret] for the image pull secret:
+
+    ```
+    kubectl create secret docker-registry cr.seqera.io \
+      --docker-server=cr.seqera.io \
+      --docker-username='<name>' \
+      --docker-password='<secret>'
+    ```
+
+    The credential `name` contains a dollar `$` character. Wrap the name in single quotes to prevent the Linux shell from interpreting this value as an environment variable.
+
+    <details>
+    <summary>View command output</summary>
+    ```
+    secret/cr.seqera.io created
+    ```
+    </details>
+
+1. Confirm that the secret exists:
+
+    ```
+    kubectl get secrets cr.seqera.io
+    ```
+
+    <details>
+    <summary>View command output</summary>
+    ```
+    NAME           TYPE                             DATA   AGE
+    cr.seqera.io   kubernetes.io/dockerconfigjson   1      26s
+    ```
+    </details>
+
+1. Confirm that you can pull containers from `cr.seqera.io`:
+
+   1. Pull a container from the private repository:
+
+        ```
+        kubectl run pull-test --command --restart=Never --image-pull-policy=Always \
+          --image cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.4 \
+          --overrides='{ "spec": { "imagePullSecrets": [ { "name": "cr.seqera.io" } ] } }' \
+          --override-type=strategic -- /bin/true
+        ```
+
+        <details>
+        <summary>View command output</summary>
+        ```
+        pod/pull-test created
+        ```
+        </details>
+
+    1. Confirm that the container was pulled:
+
+        ```
+        kubectl get pods/pull-test -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase
+        ```
+
+        <details>
+        <summary>View command output</summary>
+        ```
+        NAME        STATUS
+        pull-test   Succeeded
+        ```
+        </details>
+

--- a/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-registry.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/_partials/_k8s-install-registry.mdx
@@ -1,5 +1,3 @@
-## Configure container registry credentials
-
 Seqera Enterprise is distributed as a collection of Docker containers available through the Seqera container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. After you've received your credentials, grant your cluster access to the registry:
 
 1. Retrieve the `name` and `secret` values from the JSON file that you received from Seqera support.

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/configmap.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/configmap.yml
@@ -7,7 +7,8 @@ metadata:
 data:
   TOWER_SERVER_URL: "https://<seqera_platform_hostname>"
   TOWER_CONTACT_EMAIL: "<system_email_address>"
-  TOWER_DB_URL: jdbc:mysql://<database_host_name>:3306/tower?permitMysqlScheme=true
+  TOWER_REDIS_URL: "redis://<redis_host_name>:6379"
+  TOWER_DB_URL: "jdbc:mysql://<database_host_name>:3306/tower?permitMysqlScheme=true"
   TOWER_DB_DRIVER: "org.mariadb.jdbc.Driver"
   TOWER_DB_DIALECT: "io.seqera.util.MySQL55DialectCollateBin"
   TOWER_DB_USER: "<db_username>"
@@ -20,7 +21,6 @@ data:
   TOWER_LICENSE: "<license>"
   TOWER_ENABLE_PLATFORMS: "awsbatch-platform,gls-platform,googlebatch-platform,azbatch-platform,uge-platform,slurm-platform"
   FLYWAY_LOCATIONS: "classpath:db-schema/mysql"
-  TOWER_REDIS_URL: "redis://<redis_host_name>:6379"
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/configmap.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/configmap.yml
@@ -5,34 +5,22 @@ metadata:
   labels:
     app: backend-cfg
 data:
-  TOWER_SERVER_URL: "https://<YOUR PUBLIC TOWER HOST NAME>"
-  TOWER_CONTACT_EMAIL: "support@tower.nf"
-  TOWER_JWT_SECRET: "ReplaceThisWithALongSecretString"
-  TOWER_DB_URL: "jdbc:mysql://<YOUR DB HOST NAME AND PORT>/tower"
+  TOWER_SERVER_URL: "https://<seqera_platform_hostname>"
+  TOWER_CONTACT_EMAIL: "<system_email_address>"
+  TOWER_DB_URL: jdbc:mysql://<database_host_name>:3306/tower?permitMysqlScheme=true
   TOWER_DB_DRIVER: "org.mariadb.jdbc.Driver"
-  TOWER_DB_USER: "tower"
-  TOWER_DB_PASSWORD: "<YOUR DB PASSWORD>"
   TOWER_DB_DIALECT: "io.seqera.util.MySQL55DialectCollateBin"
-  TOWER_DB_MIN_POOL_SIZE: "2"
-  TOWER_DB_MAX_POOL_SIZE: "10"
-  TOWER_DB_MAX_LIFETIME: "180000"
-  TOWER_SMTP_HOST: "<YOUR SMTP SERVER HOST NAME>"
-  TOWER_SMTP_USER: "<YOUR SMTP USER NAME>"
-  TOWER_SMTP_PASSWORD: "<YOUR SMTP USER PASSWORD>"
-  TOWER_CRYPTO_SECRETKEY: "<YOUR CRYPTO SECRET>"
-  TOWER_LICENSE: "<YOUR TOWER LICENSE KEY>"
+  TOWER_DB_USER: "<db_username>"
+  TOWER_DB_PASSWORD: "<db_password>"
+  TOWER_SMTP_HOST: "<smtp_host_name>"
+  TOWER_SMTP_USER: "<smtp_username>"
+  TOWER_SMTP_PASSWORD: "<smtp_password>"
+  TOWER_JWT_SECRET: "<jwt_secret>"
+  TOWER_CRYPTO_SECRETKEY: "<crypt_secret>"
+  TOWER_LICENSE: "<license>"
   TOWER_ENABLE_PLATFORMS: "awsbatch-platform,gls-platform,googlebatch-platform,azbatch-platform,uge-platform,slurm-platform"
   FLYWAY_LOCATIONS: "classpath:db-schema/mysql"
-  TOWER_REDIS_URL: "redis://<YOUR REDIS IP>:6379" # For a managed Redis service, specify the IP address or DNS name of the service endpoint. If you use the containerized Redis service, specify "redis" instead of an IP address.
-  # Data Studios configuration variables
-  TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN: '<YOUR_RANDOMLY_GENERATED_STRING>' # This must match the value of CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN in your proxy.yml file.
-  TOWER_DATA_STUDIO_CONNECT_URL: 'https://connect.<YOUR PUBLIC TOWER HOST NAME>' #
-  TOWER_DATA_STUDIO_TEMPLATES_JUPYTER_REPOSITORY: 'cr.seqera.io/public/data-studio-jupyter:0.7.0'
-  TOWER_DATA_STUDIO_TEMPLATES_JUPYTER_ICON: 'jupyter'
-  TOWER_DATA_STUDIO_TEMPLATES_RSTUDIO_REPOSITORY: 'cr.seqera.io/public/data-studio-rstudio:0.7.0'
-  TOWER_DATA_STUDIO_TEMPLATES_RSTUDIO_ICON: 'rstudio'
-  TOWER_DATA_STUDIO_TEMPLATES_VSCODE_REPOSITORY: 'cr.seqera.io/public/data-studio-vscode:0.7.0'
-  TOWER_DATA_STUDIO_TEMPLATES_VSCODE_ICON: 'vscode'
+  TOWER_REDIS_URL: "redis://<redis_host_name>:6379"
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -41,23 +29,4 @@ metadata:
   labels:
     app: backend-cfg
 data:
-  tower.yml: |
-    mail:
-      smtp:
-        auth: true
-        # FIXME `starttls` should be enabled with a production SMTP host
-        starttls:
-          enable: true
-          required: true
-        ssl:
-          protocols: "TLSv1.2"
-
-    auth:
-      mail:
-        duration: 30m
-
-    # Set a custom application name for the Micronaut environment to deploy multiple instances from the same Enterprise account
-    # Required for AWS Parameter Store configuration. For more information, see https://docs.seqera.io/platform/latest/enterprise/configuration/aws_parameter_store 
-    micronaut:
-      application:
-        name: tower-app
+  tower.yml: |-

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/ingress.eks.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/ingress.eks.yml
@@ -20,29 +20,17 @@ spec:
     - host: <YOUR-TOWER-HOST-NAME>
       http:
         paths:
-          - path: /*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: ssl-redirect
-                port:
-                  name: use-annotation
-          - path: /*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: frontend
-                port:
-                  number: 80
-
-# Uncomment the host section below to enable Data Studios. Replace <YOUR-TOWER-HOST-NAME> with the base domain of your Platform installation. See [Data Studios configuration](https://docs.seqera.io/platform/24.1.1/enterprise/data-studios) for more information.
-#    - host: "*.<YOUR-TOWER-HOST-NAME>"
-#      http:
-#        paths:
-#          - backend:
-#              service:
-#                name: connect-proxy
-#                port:
-#                  number: 80
-#            pathType: ImplementationSpecific
-#            path: /*
+        - path: /*
+          pathType: ImplementationSpecific
+          backend:
+            service:
+              name: ssl-redirect
+              port:
+                name: use-annotation
+        - path: /*
+          pathType: ImplementationSpecific
+          backend:
+            service:
+              name: frontend
+              port:
+                number: 80

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/ingress.eks.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/ingress.eks.yml
@@ -5,19 +5,19 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/certificate-arn: <YOUR-CERTIFICATE-ARN>
+    alb.ingress.kubernetes.io/certificate-arn: <YOUR_CERTIFICATE_ARN>
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
-    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301" }}'
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06
     alb.ingress.kubernetes.io/load-balancer-attributes: >
       idle_timeout.timeout_seconds=301,
       routing.http2.enabled=false,
       access_logs.s3.enabled=true,
-      access_logs.s3.bucket=YOUR-LOGS-S3-BUCKET,
-      access_logs.s3.prefix=YOUR-LOGS-PREFIX
+      access_logs.s3.bucket=<YOUR_LOGS_S3_BUCKET>,
+      access_logs.s3.prefix=<YOUR_LOGS_PREFIX>
 spec:
   rules:
-    - host: <YOUR-TOWER-HOST-NAME>
+    - host: <YOUR_SEQERA_HOST_NAME>
       http:
         paths:
         - path: /*

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/configmap.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/configmap.yml
@@ -1,0 +1,57 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tower-backend-cfg
+  labels:
+    app: backend-cfg
+data:
+  TOWER_ENABLE_UNSAFE_MODE: "true"
+  TOWER_ROOT_USERS: "<root_users>"
+  TOWER_SERVER_URL: "http://localhost:8080"
+  TOWER_CONTACT_EMAIL: "user@example.com"
+  TOWER_JWT_SECRET: "<jwt_secret>"
+  TOWER_DB_URL: jdbc:mysql://mysql:3306/tower?permitMysqlScheme=true
+  TOWER_DB_DRIVER: "org.mariadb.jdbc.Driver"
+  TOWER_DB_USER: "tower"
+  TOWER_DB_PASSWORD: "tower"
+  TOWER_DB_DIALECT: "io.seqera.util.MySQL55DialectCollateBin"
+  TOWER_DB_MIN_POOL_SIZE: "2"
+  TOWER_DB_MAX_POOL_SIZE: "10"
+  TOWER_DB_MAX_LIFETIME: "180000"
+  TOWER_SMTP_HOST: "mailcatcher"
+  TOWER_SMTP_USER: ""
+  TOWER_SMTP_PASSWORD: ""
+  TOWER_CRYPTO_SECRETKEY: "<crypt_secret>"
+  TOWER_LICENSE: "<license>"
+  TOWER_ENABLE_PLATFORMS: "local-platform"
+  FLYWAY_LOCATIONS: "classpath:db-schema/mysql"
+  TOWER_REDIS_URL: "redis://redis:6379"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tower-yml
+  labels:
+    app: backend-cfg
+data:
+  tower.yml: |
+    mail:
+      smtp:
+        auth: false
+        # FIXME `starttls` should be enabled with a production SMTP host
+        starttls:
+          enable: false
+          required: false
+        ssl:
+          protocols: "TLSv1.2"
+
+    auth:
+      mail:
+        duration: 30m
+
+    # Set a custom application name for the Micronaut environment to deploy multiple instances from the same Enterprise account
+    # Required for AWS Parameter Store configuration. For more information, see https://docs.seqera.io/platform/latest/enterprise/configuration/aws_parameter_store 
+    micronaut:
+      application:
+        name: tower-app

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/configmap.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/configmap.yml
@@ -11,7 +11,7 @@ data:
   TOWER_SERVER_URL: "http://localhost:8080"
   TOWER_CONTACT_EMAIL: "user@example.com"
   TOWER_REDIS_URL: "redis://redis:6379"
-  TOWER_DB_URL: jdbc:mysql://mysql:3306/tower?permitMysqlScheme=true
+  TOWER_DB_URL: "jdbc:mysql://mysql:3306/tower?permitMysqlScheme=true"
   TOWER_DB_DRIVER: "org.mariadb.jdbc.Driver"
   TOWER_DB_USER: "tower"
   TOWER_DB_PASSWORD: "tower"

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/configmap.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/configmap.yml
@@ -10,23 +10,20 @@ data:
   TOWER_ROOT_USERS: "<root_users>"
   TOWER_SERVER_URL: "http://localhost:8080"
   TOWER_CONTACT_EMAIL: "user@example.com"
-  TOWER_JWT_SECRET: "<jwt_secret>"
+  TOWER_REDIS_URL: "redis://redis:6379"
   TOWER_DB_URL: jdbc:mysql://mysql:3306/tower?permitMysqlScheme=true
   TOWER_DB_DRIVER: "org.mariadb.jdbc.Driver"
   TOWER_DB_USER: "tower"
   TOWER_DB_PASSWORD: "tower"
   TOWER_DB_DIALECT: "io.seqera.util.MySQL55DialectCollateBin"
-  TOWER_DB_MIN_POOL_SIZE: "2"
-  TOWER_DB_MAX_POOL_SIZE: "10"
-  TOWER_DB_MAX_LIFETIME: "180000"
   TOWER_SMTP_HOST: "mailcatcher"
   TOWER_SMTP_USER: ""
   TOWER_SMTP_PASSWORD: ""
+  TOWER_JWT_SECRET: "<jwt_secret>"
   TOWER_CRYPTO_SECRETKEY: "<crypt_secret>"
   TOWER_LICENSE: "<license>"
   TOWER_ENABLE_PLATFORMS: "local-platform"
   FLYWAY_LOCATIONS: "classpath:db-schema/mysql"
-  TOWER_REDIS_URL: "redis://redis:6379"
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -39,19 +36,6 @@ data:
     mail:
       smtp:
         auth: false
-        # FIXME `starttls` should be enabled with a production SMTP host
         starttls:
           enable: false
           required: false
-        ssl:
-          protocols: "TLSv1.2"
-
-    auth:
-      mail:
-        duration: 30m
-
-    # Set a custom application name for the Micronaut environment to deploy multiple instances from the same Enterprise account
-    # Required for AWS Parameter Store configuration. For more information, see https://docs.seqera.io/platform/latest/enterprise/configuration/aws_parameter_store 
-    micronaut:
-      application:
-        name: tower-app

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/mailcatcher.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/mailcatcher.yml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mailcatcher
+  labels:
+    app: mailcatcher
+spec:
+  containers:
+  - name: mailcatcher
+    image: sj26/mailcatcher
+    ports:
+    - containerPort: 1025
+    - containerPort: 1080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mailcatcher
+spec:
+  selector:
+    app: mailcatcher
+  ports:
+  - name: smtp
+    protocol: TCP
+    port: 587
+    targetPort: 1025
+  - name: http
+    protocol: TCP
+    port: 1080
+    targetPort: 1080
+  type: ClusterIP

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/mysql.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/mysql.yml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: hostpath
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+spec:
+  serviceName: mysql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+      - name: mysql
+        image: mysql:8.0
+        ports:
+        - containerPort: 3306
+        env:
+        - name: MYSQL_ALLOW_EMPTY_PASSWORD
+          value: "yes"
+        - name: MYSQL_USER
+          value: "tower"
+        - name: MYSQL_PASSWORD
+          value: "tower"
+        - name: MYSQL_DATABASE
+          value: "tower"
+        volumeMounts:
+        - name: mysql-storage
+          mountPath: /var/lib/mysql
+        readinessProbe:
+          exec:
+            command:
+            - mysqladmin
+            - ping
+            - -h
+            - localhost
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 20
+          failureThreshold: 10
+      volumes:
+      - name: mysql-storage
+        persistentVolumeClaim:
+          claimName: mysql-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  clusterIP: None
+  ports:
+  - port: 3306
+  selector:
+    app: mysql

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/redis.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/redis.yml
@@ -1,0 +1,59 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-data
+  labels:
+    app: redis
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: <storage_class>
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  serviceName: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - image: cr.seqera.io/public/redis:6.0
+        name: redis
+        args:
+        - --appendonly yes
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - mountPath: "/data"
+          name: "vol-data"
+      volumes:
+      - name: vol-data
+        persistentVolumeClaim:
+          claimName: redis-data
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/tower-cron.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/tower-cron.yml
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cron
+  labels:
+    app: cron
+spec:
+  selector:
+    matchLabels:
+      app: cron
+  template:
+    metadata:
+      labels:
+        app: cron
+    spec:
+      imagePullSecrets:
+      - name: cr.seqera.io
+      volumes:
+      - name: config-volume
+        configMap:
+          name: tower-yml
+      initContainers:
+      - name: migrate-db
+        image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.1.3
+        command: ["sh", "-c", "/migrate-db.sh"]
+        envFrom:
+        - configMapRef:
+            name: tower-backend-cfg
+        volumeMounts:
+        - name: config-volume
+          mountPath: /tower.yml
+          subPath: tower.yml
+      containers:
+      - name: backend
+        image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.4
+        envFrom:
+        - configMapRef:
+            name: tower-backend-cfg
+        volumeMounts:
+        - name: config-volume
+          mountPath: /tower.yml
+          subPath: tower.yml
+        env:
+        - name: MICRONAUT_ENVIRONMENTS
+          value: "prod,redis,cron"
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 10

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/tower-svc.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/k8s_min/tower-svc.yml
@@ -1,0 +1,116 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  labels:
+    app: backend
+spec:
+  selector:
+    matchLabels:
+      app: backend
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      imagePullSecrets:
+      - name: cr.seqera.io
+      volumes:
+      - name: config-volume
+        configMap:
+          name: tower-yml
+      containers:
+      - name: backend
+        image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.4
+        envFrom:
+        - configMapRef:
+            name: tower-backend-cfg
+        env:
+        - name: MICRONAUT_ENVIRONMENTS
+          value: "prod,redis,ha"
+        ports:
+          - containerPort: 8080
+        volumeMounts:
+        - name: config-volume
+          mountPath: /tower.yml
+          subPath: tower.yml
+        resources:
+          requests:
+            cpu: "1"
+            memory: "1200Mi"
+          limits:
+            memory: "4200Mi"
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      imagePullSecrets:
+      - name: cr.seqera.io
+      containers:
+      - name: frontend
+        image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.4-unprivileged
+        env:
+        - name: NGINX_LISTEN_PORT  # If not defined, defaults to 8000.
+          value: "8000"
+        ports:
+        - containerPort: 8000
+      restartPolicy: Always
+---
+# Services
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  labels:
+    app: backend
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: backend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+#  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8000
+  selector:
+    app: frontend
+---

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-cron.yml
@@ -15,7 +15,7 @@ spec:
         app: cron
     spec:
       imagePullSecrets:
-      - name: "cr.seqera.io"
+      - name: cr.seqera.io
       volumes:
       - name: config-volume
         configMap:

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-cron.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,57 +15,47 @@ spec:
         app: cron
     spec:
       imagePullSecrets:
-        - name: "cr.seqera.io"
+      - name: "cr.seqera.io"
       volumes:
-        - name: config-volume
-          configMap:
-            name: tower-yml
-        # Volume for Data Studios
-        #- name: cert-volume
-        #  secret:
-        #    secretName: platform-oidc-certs
+      - name: config-volume
+        configMap:
+          name: tower-yml
       initContainers:
-        - name: migrate-db
-          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.1.3
-          command: ["sh", "-c", "/migrate-db.sh"]
-          envFrom:
-            - configMapRef:
-                name: tower-backend-cfg
-          volumeMounts:
-            - name: config-volume
-              mountPath: /tower.yml
-              subPath: tower.yml
-            # Volume mount for Data Studios
-            #- name: cert-volume
-            #  mountPath: /data/certs
+      - name: migrate-db
+        image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.1.3
+        command: ["sh", "-c", "/migrate-db.sh"]
+        envFrom:
+        - configMapRef:
+            name: tower-backend-cfg
+        volumeMounts:
+        - name: config-volume
+          mountPath: /tower.yml
+          subPath: tower.yml
       containers:
-        - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.4
-          envFrom:
-            - configMapRef:
-                name: tower-backend-cfg
-          volumeMounts:
-            - name: config-volume
-              mountPath: /tower.yml
-              subPath: tower.yml
-          env:
-            - name: MICRONAUT_ENVIRONMENTS
-              value: "prod,redis,cron"
-            # TLS certificate for Data Studios
-            #- name: TOWER_OIDC_PEM_PATH
-            #  value: '/data/certs/oidc.pem'
-          ports:
-            - containerPort: 8080
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            initialDelaySeconds: 5
-            timeoutSeconds: 3
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            initialDelaySeconds: 5
-            timeoutSeconds: 3
-            failureThreshold: 10
+      - name: backend
+        image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.4
+        envFrom:
+        - configMapRef:
+            name: tower-backend-cfg
+        volumeMounts:
+        - name: config-volume
+          mountPath: /tower.yml
+          subPath: tower.yml
+        env:
+        - name: MICRONAUT_ENVIRONMENTS
+          value: "prod,redis,cron"
+        ports:
+          - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 10

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-svc.yml
@@ -19,7 +19,7 @@ spec:
         app: backend
     spec:
       imagePullSecrets:
-      - name: "cr.seqera.io"
+      - name: cr.seqera.io
       volumes:
       - name: config-volume
         configMap:
@@ -76,7 +76,7 @@ spec:
         app: frontend
     spec:
       imagePullSecrets:
-      - name: "cr.seqera.io"
+      - name: cr.seqera.io
       containers:
       - name: frontend
         image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.4
@@ -107,5 +107,5 @@ spec:
   ports:
   - port: 80
   selector:
-    app: "frontend"
+    app: frontend
 ---

--- a/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-svc.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,45 +19,45 @@ spec:
         app: backend
     spec:
       imagePullSecrets:
-        - name: "cr.seqera.io"
+      - name: "cr.seqera.io"
       volumes:
-        - name: config-volume
-          configMap:
-            name: tower-yml
+      - name: config-volume
+        configMap:
+          name: tower-yml
       containers:
-        - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.4
-          envFrom:
-            - configMapRef:
-                name: tower-backend-cfg
-          env:
-            - name: MICRONAUT_ENVIRONMENTS
-              value: "prod,redis,ha"
-          ports:
-            - containerPort: 8080
-          volumeMounts:
-            - name: config-volume
-              mountPath: /tower.yml
-              subPath: tower.yml
-          resources:
-            requests:
-              cpu: "1"
-              memory: "1200Mi"
-            limits:
-              memory: "4200Mi"
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            initialDelaySeconds: 5
-            timeoutSeconds: 3
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            initialDelaySeconds: 5
-            timeoutSeconds: 3
-            failureThreshold: 10
+      - name: backend
+        image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.4
+        envFrom:
+        - configMapRef:
+            name: tower-backend-cfg
+        env:
+        - name: MICRONAUT_ENVIRONMENTS
+          value: "prod,redis,ha"
+        ports:
+          - containerPort: 8080
+        volumeMounts:
+        - name: config-volume
+          mountPath: /tower.yml
+          subPath: tower.yml
+        resources:
+          requests:
+            cpu: "1"
+            memory: "1200Mi"
+          limits:
+            memory: "4200Mi"
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 10
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -75,15 +76,14 @@ spec:
         app: frontend
     spec:
       imagePullSecrets:
-        - name: "cr.seqera.io"
+      - name: "cr.seqera.io"
       containers:
-        - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.4
-          ports:
-            - containerPort: 80
+      - name: frontend
+        image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.4
+        ports:
+        - containerPort: 80
       restartPolicy: Always
 ---
-# Services
 apiVersion: v1
 kind: Service
 metadata:
@@ -92,22 +92,9 @@ metadata:
     app: backend
 spec:
   ports:
-    - name: http
-      port: 8080
-      targetPort: 8080
-  selector:
-    app: backend
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: backend-api
-spec:
-  ports:
-    - port: 8080
-      targetPort: 8080
-      protocol: TCP
-  type: NodePort
+  - name: http
+    port: 8080
+    targetPort: 8080
   selector:
     app: backend
 ---
@@ -118,7 +105,7 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-    - port: 80
+  - port: 80
   selector:
     app: "frontend"
 ---

--- a/platform_versioned_docs/version-24.1/enterprise/index.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/index.mdx
@@ -60,6 +60,15 @@ Kubernetes is emerging as the technology of choice for deploying applications th
 ![](./_images/seqera_reference_architecture_aws.png)
 _Reference architecture diagram of Seqera Platform Enterprise on AWS using Elastic Kubernetes Service (EKS)_
 
+### High availability
+
+To configure Seqera Enterprise for high availability, note that:
+
+- The `backend` service can be run in multiple replicas
+- The `frontend` service is replicable, however in most scenarios it is not necessary
+- The `cron` service may only have a single instance
+- The `groundswell` service may only have a single instance
+
 ## Application container images
 
 Seqera Enterprise is distributed as a collection of Docker containers available through the Seqera container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. When you've received your credentials, retrieve the application container images with these steps:

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
@@ -138,7 +138,7 @@ After your database is created:
 
 <ConfigureRegistry />
 
-## 3. Configure Seqera Platform
+### 3. Configure Seqera Platform
 
 Configure the following environment variables. For more information about Seqera configuration options, see [Configuration overview](./configuration/overview.mdx).
 

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
@@ -52,7 +52,7 @@ The following prerequisites are required to complete this installation guide:
 
 Additionally, the ingress assumes the presence of SSL certificates, DNS resolution, and ALB logging. If you've chosen not to use some or all of these features, you'll need to modify the manifest accordingly before applying it to the cluster.
 
-## AWS setup
+## Amazon Web Services (AWS) setup
 
 Set up commonly-used AWS services for Seqera deployment.
 
@@ -87,7 +87,7 @@ Seqera supports managed Redis services such as [Amazon ElastiCache][aws-elastica
 
 External databases for Seqera Enterprise deployments require:
 
-- A **MySQL8 Community** DB instance
+- A MySQL8 Community DB instance
 - At least 2 vCPUs, 8 GB memory, and 30 GB SSD storage
 - Manual MySQL user and database schema creation. See [Database configuration](./configuration/overview.mdx#seqera-and-redis-databases) for more details.
 
@@ -160,15 +160,15 @@ The `configmap.yml` manifest includes both the `tower.env` and `tower.yml` files
 
 1. Edit the `configmap.yml` file and set the following environment variables:
 
-    - `TOWER_CONTACT_EMAIL`:
-    - `TOWER_SERVER_URL`:
+    - `TOWER_CONTACT_EMAIL`: Specify a contact email address for the Seqera administrator.
+    - `TOWER_SERVER_URL`: Specify your fully qualified host name for Platform Enterprise, such as `https://example.com:8000`.
     - `TOWER_REDIS_URL`: Specify the host name for your Amazon ElastiCache Redis instance.
-    - `TOWER_DB_URL`:
-    - `TOWER_DB_USER`:
-    - `TOWER_DB_PASSWORD`:
-    - `TOWER_SMTP_HOST`:
-    - `TOWER_SMTP_USER`:
-    - `TOWER_SMTP_PASSWORD`:
+    - `TOWER_DB_URL`: Specify the Amazon RDS instance URI connection string, such as `jdbc:mysql://<host_name>:3306/tower?permitMysqlScheme=true`. Replace `<host_name>` with the RDS instance's host name.
+    - `TOWER_DB_USER`: Specify the Amazon RDS instance user name.
+    - `TOWER_DB_PASSWORD`: Specify the Amazon RDS instance password.
+    - `TOWER_SMTP_HOST`: Specify the mail server host name.
+    - `TOWER_SMTP_USER`: Specify the mail server user name.
+    - `TOWER_SMTP_PASSWORD`: Specify the mail server password.
     - `TOWER_JWT_SECRET`: Specify a unique secret that is at least 35 alphanumeric characters.
     - `TOWER_CRYPTO_SECRETKEY`: Specify a unique secret.
     - `TOWER_LICENSE`: Specify your Seqera license key, if known. Otherwise, leave this empty.

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
@@ -129,7 +129,12 @@ After your database is created:
 - Update the inbound rules for the underlying EC2 instance to allow MySQL connections.
 - Update your Seqera [configuration](../configuration/overview.mdx#seqera-and-redis-databases) with the database hostname, username, and password.
 
+## 1. Create a namespace
+
 <CreateNamespace />
+
+## 2. Configure container registry credentials
+
 <ConfigureRegistry />
 
 <!-- replace with proper manifests for EKS -->

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
@@ -1,0 +1,161 @@
+---
+title: Install on an Amazon EKS cluster
+description: Deploy Seqera Platform Enterprise on a Kubernetes cluster
+date: "11 Sep 2024"
+tags: [kubernetes, deployment]
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+import CreateNamespace from './_partials/_k8s-install-ns.mdx';
+import ConfigureRegistry from './_partials/_k8s-install-registry.mdx';
+import DeployManifests from './_partials/_k8s-install-deploy-no-heading.mdx';
+
+This installation guide describes how to install Seqera Platform on Enterprise on Amazon Web Services (AWS) Elastic Kubernetes Service (EKS). When you complete the steps in this guide you'll have an installation suitable for product use on EKS.
+
+## Prerequisites
+
+- **SMTP server**: If you don't have an email server, use [Amazon Simple Email Service](https://aws.amazon.com/ses/).
+
+- **MySQL database**: An external database, such as one provided by [Amazon Relational Database Service](https://aws.amazon.com/rds/), is highly recommended for production deployments.
+
+- **SSL certificate**: HTTP must not be used in production environments. An SSL certificate is required for your Seqera instance to handle HTTPS traffic. See [SSL/TLS configuration](../configuration/ssl_tls.mdx#aws-deployments-manage-ssl-certificates-with-amazon-certificate-manager-acm) for more information.
+
+- **Optional: AWS Parameter Store**: Store sensitive Seqera configuration values as SecureString [AWS Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) parameters. See [AWS Parameter Store configuration](../configuration/aws_parameter_store.mdx) for instructions. This is recommended for production environments. 
+
+- **Optional: DNS**: DNS is required to support human-readable domain names and load-balanced traffic. If you don't have access to a pre-existing DNS service, use [Amazon Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/Welcome.html).
+
+### Prerequisites for EKS
+
+If you're installing Seqera Enterprise with Kubernetes, an [Elastic Kubernetes Service (EKS)](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html) cluster is required. See the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html) to provision your own cluster.
+
+- Kubernetes 1.19 or later
+
+- **Subnet requirements**
+
+  - At least 2 subnets across two different Availability Zones
+  - Subnets must be tagged for [AWS Load Balancer Controller auto-discovery](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html)
+  - Public subnets must be configured to [auto-assign IPs on launch](https://aws.amazon.com/blogs/containers/upcoming-changes-to-ip-assignment-for-eks-managed-node-groups/)
+  - Public and private subnets must allow egress traffic to the public internet
+
+- **RBAC requirements**
+
+  - The cluster must be created by a non-root user
+  - `aws-auth` must be updated to [allow access to additional IAM users/roles](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html) (if needed)
+
+- **Addons**
+
+  - Install the [cert-manager](https://cert-manager.io/docs/)
+  - Install the [AWS Load Balancer Controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
+
+- **Ingress**
+
+  - ALB provisioning via the [AWS Load Balancer Controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
+  - ALB integration with the [Amazon Certificate Manager](https://aws.amazon.com/certificate-manager/)
+
+Additionally, the ingress assumes the presence of SSL certificates, DNS resolution, and ALB logging. If you've chosen not to use some or all of these features, you'll need to modify the manifest accordingly before applying it to the cluster.
+
+## AWS setup
+
+Set up commonly-used AWS services for Seqera deployment.
+
+### Fetch Seqera config values from AWS Parameter Store
+
+From version 23.1, you can retrieve Seqera Enterprise configuration values remotely from the AWS Parameter Store. See [AWS Parameter Store configuration](../configuration/aws_parameter_store.mdx) for instructions. 
+
+### Amazon SES
+
+Seqera Enterprise supports AWS Simple Email Service (SES) as an alternative to traditional SMTP servers for sending application emails. 
+
+:::caution
+If you use AWS SES in sandbox mode, both the _sender_ and the _receiver_ email addresses must be verified via AWS SES. Sandbox is not recommended for production use. See the [AWS docs](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) for instructions to move out of the sandbox.
+:::
+
+- See [Obtaining SES SMTP credentials using the SES console](https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html#smtp-credentials-console) for instructions to set up SES to send emails from your preferred address. 
+
+- To prevent emails from SES being flagged as spam, see these AWS instructions for setting up an email authentication method:
+
+   - [DKIM for a domain](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dkim-easy-setup-domain.html) 
+   
+   - [SPF authentication](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-spf.html)
+
+#### Managed Redis services
+
+Seqera supports managed Redis services such as [Amazon ElastiCache][aws-elasticache].
+
+- Use a single-node cluster, as multi-node clusters are not supported
+- Use an instance with at least 6GB capacity ([cache.m4.large][aws-cache-instances] or greater)
+
+### Amazon RDS
+
+External databases for Seqera Enterprise deployments require:
+
+- A **MySQL8 Community** DB instance
+- At least 2 vCPUs, 8 GB memory, and 30 GB SSD storage
+- Manual MySQL user and database schema creation. See [Database configuration](../configuration/overview.mdx#seqera-and-redis-databases) for more details.
+
+:::caution 
+Recommended instance class and storage requirements depend on the number of parallel pipelines you expect to run. 
+:::
+
+<Tabs>
+<TabItem value="AWS console" label="AWS console" default>
+
+See [Creating an Amazon RDS DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateDBInstance.html) to guide you through the external database setup for your production deployment. 
+
+</TabItem>
+<TabItem value="AWS CLI" label="AWS CLI" default>
+
+To create a DB instance with the AWS CLI, call the [create-db-instance](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html) command, replacing `INSTANCE_NAME`, `SECURITY_GROUP`, `DB_USER`, and `DB_PASSWORD` with your unique values:
+
+```console
+aws rds create-db-instance \
+    --engine mysql \ 
+    --db-instance-identifier INSTANCE_NAME \
+    --allocated-storage 30 \
+    --db-instance-class db.m5d.large \
+    --vpc-security-group-ids SECURITY_GROUP \
+    --db-subnet-group SUBNET_GROUP \
+    --master-username DB_USER \
+    --master-user-password DB_PASSWORD \
+```
+
+</TabItem>
+</Tabs>
+
+After your database is created:
+
+- Update the inbound rules for the underlying EC2 instance to allow MySQL connections.
+- Update your Seqera [configuration](../configuration/overview.mdx#seqera-and-redis-databases) with the database hostname, username, and password.
+
+<CreateNamespace />
+<ConfigureRegistry />
+
+<!-- replace with proper manifests for EKS -->
+## Deploy Seqera
+
+Seqera Platform consists of deployments for a cron service, a backend service, and a frontend service.
+
+1. Create the manifest files:
+    - Create a file named `tower-cron.yml` with the following Kubernetes manifest:
+
+      <details>
+      <summary>Show `tower-cron.yml` file</summary>
+      ```js file=./_templates/k8s/k8s_min/tower-cron.yml showLineNumbers
+      ```
+      </details>
+
+    - Create a file named `tower-svc.yml` with the following Kubernetes manifest:
+
+      <details>
+      <summary>Show `tower-svc.yml` file</summary>
+      ```js file=./_templates/k8s/k8s_min/tower-svc.yml showLineNumbers
+      ```
+      </details>
+
+<DeployManifests step={2} />
+
+<!-- links -->
+[aws-elasticache]: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html
+[aws-cache-instances]: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
@@ -12,9 +12,11 @@ import CreateNamespace from './_partials/_k8s-install-ns.mdx';
 import ConfigureRegistry from './_partials/_k8s-install-registry.mdx';
 import DeployManifests from './_partials/_k8s-install-deploy.mdx';
 
-This installation guide describes how to install Seqera Platform on Enterprise on Amazon Web Services (AWS) Elastic Kubernetes Service (EKS). When you complete the steps in this guide you'll have an installation suitable for product use on EKS.
+This installation guide describes how to install Seqera Platform on Enterprise on Amazon Web Services (AWS) [Elastic Kubernetes Service (EKS)](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html). When you complete the steps in this guide you'll have an installation suitable for product use on EKS.
 
 ## Prerequisites
+
+The following prerequisites are required to complete this installation guide:
 
 - **SMTP server**: If you don't have an email server, use [Amazon Simple Email Service](https://aws.amazon.com/ses/).
 
@@ -22,15 +24,9 @@ This installation guide describes how to install Seqera Platform on Enterprise o
 
 - **SSL certificate**: HTTP must not be used in production environments. An SSL certificate is required for your Seqera instance to handle HTTPS traffic. See [SSL/TLS configuration](./configuration/ssl_tls.mdx#aws-deployments-manage-ssl-certificates-with-amazon-certificate-manager-acm) for more information.
 
-- **Optional: AWS Parameter Store**: Store sensitive Seqera configuration values as SecureString [AWS Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) parameters. See [AWS Parameter Store configuration](./configuration/aws_parameter_store.mdx) for instructions. This is recommended for production environments. 
+- **Optional: AWS Parameter Store**: Store sensitive Seqera configuration values as SecureString [AWS Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) parameters. See [AWS Parameter Store configuration](./configuration/aws_parameter_store.mdx) for instructions. This is recommended for production environments.
 
 - **Optional: DNS**: DNS is required to support human-readable domain names and load-balanced traffic. If you don't have access to a pre-existing DNS service, use [Amazon Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/Welcome.html).
-
-### Prerequisites for EKS
-
-If you're installing Seqera Enterprise with Kubernetes, an [Elastic Kubernetes Service (EKS)](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html) cluster is required. See the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html) to provision your own cluster.
-
-- Kubernetes 1.19 or later
 
 - **Subnet requirements**
 
@@ -60,9 +56,9 @@ Additionally, the ingress assumes the presence of SSL certificates, DNS resoluti
 
 Set up commonly-used AWS services for Seqera deployment.
 
-### Fetch Seqera config values from AWS Parameter Store
+### Provision an EKS cluster
 
-From version 23.1, you can retrieve Seqera Enterprise configuration values remotely from the AWS Parameter Store. See [AWS Parameter Store configuration](./configuration/aws_parameter_store.mdx) for instructions. 
+See the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html) to provision your own Kubernetes cluster. Kubernetes version 1.19 or later is required.
 
 ### Amazon SES
 
@@ -128,7 +124,13 @@ After your database is created:
 - Update the inbound rules for the underlying EC2 instance to allow MySQL connections.
 - Update your Seqera [configuration](./configuration/overview.mdx#seqera-and-redis-databases) with the database hostname, username, and password.
 
+### Fetch Seqera config values from AWS Parameter Store
+
+From version 23.1, you can optionally retrieve Seqera Enterprise configuration values remotely from the AWS Parameter Store. See [AWS Parameter Store configuration](./configuration/aws_parameter_store.mdx) for instructions.
+
 ## Installation
+
+Complete the following sections to install Seqera Platform Enterprise on your EKS cluster.
 
 ### 1. Create a namespace
 

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
@@ -62,18 +62,18 @@ See the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/cre
 
 ### Amazon SES
 
-Seqera Enterprise supports AWS Simple Email Service (SES) as an alternative to traditional SMTP servers for sending application emails. 
+Seqera Enterprise supports AWS Simple Email Service (SES) as an alternative to traditional SMTP servers for sending application emails.
 
 :::caution
 If you use AWS SES in sandbox mode, both the _sender_ and the _receiver_ email addresses must be verified via AWS SES. Sandbox is not recommended for production use. See the [AWS docs](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) for instructions to move out of the sandbox.
 :::
 
-- See [Obtaining SES SMTP credentials using the SES console](https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html#smtp-credentials-console) for instructions to set up SES to send emails from your preferred address. 
+- See [Obtaining SES SMTP credentials using the SES console](https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html#smtp-credentials-console) for instructions to set up SES to send emails from your preferred address.
 
 - To prevent emails from SES being flagged as spam, see these AWS instructions for setting up an email authentication method:
 
-   - [DKIM for a domain](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dkim-easy-setup-domain.html) 
-   
+   - [DKIM for a domain](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dkim-easy-setup-domain.html)
+  
    - [SPF authentication](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-spf.html)
 
 ### Managed Redis services
@@ -91,14 +91,14 @@ External databases for Seqera Enterprise deployments require:
 - At least 2 vCPUs, 8 GB memory, and 30 GB SSD storage
 - Manual MySQL user and database schema creation. See [Database configuration](./configuration/overview.mdx#seqera-and-redis-databases) for more details.
 
-:::caution 
-Recommended instance class and storage requirements depend on the number of parallel pipelines you expect to run. 
+:::caution
+Recommended instance class and storage requirements depend on the number of parallel pipelines you expect to run.
 :::
 
 <Tabs>
 <TabItem value="AWS console" label="AWS console" default>
 
-See [Creating an Amazon RDS DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateDBInstance.html) to guide you through the external database setup for your production deployment. 
+See [Creating an Amazon RDS DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateDBInstance.html) to guide you through the external database setup for your production deployment.
 
 </TabItem>
 <TabItem value="AWS CLI" label="AWS CLI" default>
@@ -107,7 +107,7 @@ To create a DB instance with the AWS CLI, call the [create-db-instance](https://
 
 ```console
 aws rds create-db-instance \
-    --engine mysql \ 
+    --engine mysql \
     --db-instance-identifier INSTANCE_NAME \
     --allocated-storage 30 \
     --db-instance-class db.m5d.large \

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
@@ -80,7 +80,7 @@ If you use AWS SES in sandbox mode, both the _sender_ and the _receiver_ email a
    
    - [SPF authentication](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-spf.html)
 
-#### Managed Redis services
+### Managed Redis services
 
 Seqera supports managed Redis services such as [Amazon ElastiCache][aws-elasticache].
 
@@ -118,7 +118,7 @@ aws rds create-db-instance \
     --vpc-security-group-ids SECURITY_GROUP \
     --db-subnet-group SUBNET_GROUP \
     --master-username DB_USER \
-    --master-user-password DB_PASSWORD \
+    --master-user-password DB_PASSWORD
 ```
 </TabItem>
 </Tabs>
@@ -158,11 +158,18 @@ The `configmap.yml` manifest includes both the `tower.env` and `tower.yml` files
 
 1. Edit the `configmap.yml` file and set the following environment variables:
 
-    - `TOWER_ROOT_USERS`: Specify your email address
-    - `TOWER_JWT_SECRET`: Specify a unique secret that is at least 35 alphanumeric characters
+    - `TOWER_CONTACT_EMAIL`:
+    - `TOWER_SERVER_URL`:
+    - `TOWER_REDIS_URL`: Specify the host name for your Amazon ElastiCache Redis instance.
+    - `TOWER_DB_URL`:
+    - `TOWER_DB_USER`:
+    - `TOWER_DB_PASSWORD`:
+    - `TOWER_SMTP_HOST`:
+    - `TOWER_SMTP_USER`:
+    - `TOWER_SMTP_PASSWORD`:
+    - `TOWER_JWT_SECRET`: Specify a unique secret that is at least 35 alphanumeric characters.
     - `TOWER_CRYPTO_SECRETKEY`: Specify a unique secret.
     - `TOWER_LICENSE`: Specify your Seqera license key, if known. Otherwise, leave this empty.
-    - TOWER_REDIS_URL
 
 1. Apply the config map:
 
@@ -178,7 +185,6 @@ The `configmap.yml` manifest includes both the `tower.env` and `tower.yml` files
     ```
     </details>
 
-<!-- replace with proper manifests for EKS -->
 ### 4. Deploy Seqera
 
 Seqera Platform consists of deployments for a cron service, a backend service, and a frontend service.
@@ -202,30 +208,27 @@ Seqera Platform consists of deployments for a cron service, a backend service, a
 
 <DeployManifests step={2} />
 
-### 5. Seqera ingress
+### 5. Configure HTTPS traffic load balancer
 
-An ingress is used to make Seqera Enterprise publicly accessible, load-balance traffic, terminate TLS, and offer name-based virtual hosting. The included ingress manifest will create an external IP address and forward HTTP traffic to the Seqera frontend.
+The Kubernetes ingress resource is used to make Seqera Enterprise publicly accessible, load-balance traffic, terminate TLS, and offer name-based virtual hosting. The included ingress manifest will create an external IP address and forward HTTP traffic to the Seqera frontend.
 
-Download and configure the appropriate manifest for your infrastructure.
+1. Create a file named `ingress.yml` with the following Kubernetes manifest:
 
+    <details>
+    <summary>Show `ingress.yml` file</summary>
+    ```js file=./_templates/k8s/ingress.eks.yml showLineNumbers
+    ```
+    </details>
 
-<details>
-<summary>Show `ingress.eks.yml` file</summary>
-```js file=./_templates/k8s/ingress.eks.yml showLineNumbers
-```
-</details>
-
-To deploy the manifest to your cluster, run the following:
+1. To deploy the manifest to your cluster, run the following:
 
     ```bash
-    kubectl apply -f ingress.*.yml
+    kubectl apply -f ingress.yml
     ```
 
 See [Kubernetes ingress][k8s-ingress] for more information. If you don't need to make Seqera externally accessible, use a service resource to expose a [node port][k8s-node-port] or a [load balancer][k8s-load-balancer] service to make it accessible within your intranet.
 
-See the cloud provider documentation for configuring an ingress service on each cloud provider:
-
-- [Amazon][aws-configure-ingress]
+See the [AWS Load Balancer Controller documentation][aws-configure-ingress] for configuring an ingress service.
 
 ### 6. Check status
 
@@ -259,19 +262,22 @@ Use the [dbconsole.yml](_templates/k8s/dbconsole.yml) manifest to deploy a simpl
 
 ## Next steps
 
-- Configure OpenID Connect (OIDC) for seamless integration with your identify provider
-- Configure ingress for your public cloud provider for load balancing and TLS termination
-- Configure access to your organization's email server
-- Configure Data Studios
-- Configure pipeline resource optimization
-- Configure Wave containers integration
+- Configure [OpenID Connect (OIDC)][authentication] for seamless integration with your identify provider
+- Configure [pipeline resource optimization][groundswell]
+- Configure [Wave containers integration][wave-containers]
+- Configure [Data Studios][data-studios]
 
 
 <!-- links -->
 [aws-elasticache]: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html
 [aws-cache-instances]: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html
-[aws-configure-ingress]: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/
+[aws-configure-ingress]: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.8/
 
 [k8s-ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [k8s-load-balancer]: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
 [k8s-node-port]: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+
+[wave-containers]: ./configuration/wave.mdx
+[groundswell]: ./configuration/pipeline_optimization.mdx
+[data-studios]: ./data-studios.mdx
+[authentication]: ./configuration/authentication.mdx

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 import CreateNamespace from './_partials/_k8s-install-ns.mdx';
 import ConfigureRegistry from './_partials/_k8s-install-registry.mdx';
-import DeployManifests from './_partials/_k8s-install-deploy-no-heading.mdx';
+import DeployManifests from './_partials/_k8s-install-deploy.mdx';
 
 This installation guide describes how to install Seqera Platform on Enterprise on Amazon Web Services (AWS) Elastic Kubernetes Service (EKS). When you complete the steps in this guide you'll have an installation suitable for product use on EKS.
 
@@ -120,7 +120,6 @@ aws rds create-db-instance \
     --master-username DB_USER \
     --master-user-password DB_PASSWORD \
 ```
-
 </TabItem>
 </Tabs>
 
@@ -129,16 +128,58 @@ After your database is created:
 - Update the inbound rules for the underlying EC2 instance to allow MySQL connections.
 - Update your Seqera [configuration](../configuration/overview.mdx#seqera-and-redis-databases) with the database hostname, username, and password.
 
-## 1. Create a namespace
+## Installation
+
+### 1. Create a namespace
 
 <CreateNamespace />
 
-## 2. Configure container registry credentials
+### 2. Configure container registry credentials
 
 <ConfigureRegistry />
 
+## 3. Configure Seqera Platform
+
+Configure the following environment variables. For more information about Seqera configuration options, see [Configuration overview](./configuration/overview.mdx).
+
+:::tip
+The `configmap.yml` manifest includes both the `tower.env` and `tower.yml` files. These files are made available to the other containers through volume mounts.
+:::
+
+1. Create a file named `configmap.yml` with the following Kubernetes manifest:
+
+    <details>
+    <summary>Show `configmap.yml` file</summary>
+    ```js file=./_templates/k8s/configmap.yml showLineNumbers
+    ```
+    </details>
+
+1. Generate two unique secrets with the following command: `openssl rand -base64 32 | tr -d /=+ | cut -c -32`
+
+1. Edit the `configmap.yml` file and set the following environment variables:
+
+    - `TOWER_ROOT_USERS`: Specify your email address
+    - `TOWER_JWT_SECRET`: Specify a unique secret that is at least 35 alphanumeric characters
+    - `TOWER_CRYPTO_SECRETKEY`: Specify a unique secret.
+    - `TOWER_LICENSE`: Specify your Seqera license key, if known. Otherwise, leave this empty.
+    - TOWER_REDIS_URL
+
+1. Apply the config map:
+
+    ```
+    kubectl apply -f configmap.yml
+    ```
+
+    <details>
+    <summary>View command output</summary>
+    ```
+    configmap/tower-backend-cfg created
+    configmap/tower-yml created
+    ```
+    </details>
+
 <!-- replace with proper manifests for EKS -->
-## Deploy Seqera
+### 4. Deploy Seqera
 
 Seqera Platform consists of deployments for a cron service, a backend service, and a frontend service.
 
@@ -161,6 +202,72 @@ Seqera Platform consists of deployments for a cron service, a backend service, a
 
 <DeployManifests step={2} />
 
+### 5. Seqera ingress
+
+An ingress is used to make Seqera Enterprise publicly accessible, load-balance traffic, terminate TLS, and offer name-based virtual hosting. The included ingress manifest will create an external IP address and forward HTTP traffic to the Seqera frontend.
+
+Download and configure the appropriate manifest for your infrastructure:
+
+    - [Amazon EKS](_templates/k8s/ingress.eks.yml)
+
+To deploy the manifest to your cluster, run the following:
+
+    ```bash
+    kubectl apply -f ingress.*.yml
+    ```
+
+See [Kubernetes ingress][k8s-ingress] for more information. If you don't need to make Seqera externally accessible, use a service resource to expose a [node port][k8s-node-port] or a [load balancer][k8s-load-balancer] service to make it accessible within your intranet.
+
+See the cloud provider documentation for configuring an ingress service on each cloud provider:
+
+- [Amazon][aws-configure-ingress]
+
+### 6. Check status
+
+Check that all services are up and running:
+
+```bash
+kubectl get pods
+```
+
+### 7. Test the application
+
+See [Test deployment](./testing.mdx).
+
+### Optional: Configure database console
+
+Use the [dbconsole.yml](_templates/k8s/dbconsole.yml) manifest to deploy a simple web frontend to the Seqera database. Though not required, this can be useful for administrative purposes.
+
+1. Deploy the database console:
+
+    ```bash
+    kubectl apply -f dbconsole.yml
+    ```
+
+1. Enable a port-forward for the database console to your local machine:
+
+    ```bash
+    kubectl port-forward deployment/dbconsole 8080:8080
+    ```
+
+1. Access the database console in a web browser at `http://localhost:8080`.
+
+## Next steps
+
+- Configure OpenID Connect (OIDC) for seamless integration with your identify provider
+- Configure ingress for your public cloud provider for load balancing and TLS termination
+- Configure access to your organization's email server
+- Configure Data Studios
+- Configure pipeline resource optimization
+- Configure Wave containers integration
+
+
 <!-- links -->
 [aws-elasticache]: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html
 [aws-cache-instances]: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html
+[aws-configure-ingress]: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/
+
+[k8s-ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+[k8s-load-balancer]: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+[k8s-node-port]: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
@@ -20,9 +20,9 @@ This installation guide describes how to install Seqera Platform on Enterprise o
 
 - **MySQL database**: An external database, such as one provided by [Amazon Relational Database Service](https://aws.amazon.com/rds/), is highly recommended for production deployments.
 
-- **SSL certificate**: HTTP must not be used in production environments. An SSL certificate is required for your Seqera instance to handle HTTPS traffic. See [SSL/TLS configuration](../configuration/ssl_tls.mdx#aws-deployments-manage-ssl-certificates-with-amazon-certificate-manager-acm) for more information.
+- **SSL certificate**: HTTP must not be used in production environments. An SSL certificate is required for your Seqera instance to handle HTTPS traffic. See [SSL/TLS configuration](./configuration/ssl_tls.mdx#aws-deployments-manage-ssl-certificates-with-amazon-certificate-manager-acm) for more information.
 
-- **Optional: AWS Parameter Store**: Store sensitive Seqera configuration values as SecureString [AWS Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) parameters. See [AWS Parameter Store configuration](../configuration/aws_parameter_store.mdx) for instructions. This is recommended for production environments. 
+- **Optional: AWS Parameter Store**: Store sensitive Seqera configuration values as SecureString [AWS Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) parameters. See [AWS Parameter Store configuration](./configuration/aws_parameter_store.mdx) for instructions. This is recommended for production environments. 
 
 - **Optional: DNS**: DNS is required to support human-readable domain names and load-balanced traffic. If you don't have access to a pre-existing DNS service, use [Amazon Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/Welcome.html).
 
@@ -62,7 +62,7 @@ Set up commonly-used AWS services for Seqera deployment.
 
 ### Fetch Seqera config values from AWS Parameter Store
 
-From version 23.1, you can retrieve Seqera Enterprise configuration values remotely from the AWS Parameter Store. See [AWS Parameter Store configuration](../configuration/aws_parameter_store.mdx) for instructions. 
+From version 23.1, you can retrieve Seqera Enterprise configuration values remotely from the AWS Parameter Store. See [AWS Parameter Store configuration](./configuration/aws_parameter_store.mdx) for instructions. 
 
 ### Amazon SES
 
@@ -93,7 +93,7 @@ External databases for Seqera Enterprise deployments require:
 
 - A **MySQL8 Community** DB instance
 - At least 2 vCPUs, 8 GB memory, and 30 GB SSD storage
-- Manual MySQL user and database schema creation. See [Database configuration](../configuration/overview.mdx#seqera-and-redis-databases) for more details.
+- Manual MySQL user and database schema creation. See [Database configuration](./configuration/overview.mdx#seqera-and-redis-databases) for more details.
 
 :::caution 
 Recommended instance class and storage requirements depend on the number of parallel pipelines you expect to run. 
@@ -126,7 +126,7 @@ aws rds create-db-instance \
 After your database is created:
 
 - Update the inbound rules for the underlying EC2 instance to allow MySQL connections.
-- Update your Seqera [configuration](../configuration/overview.mdx#seqera-and-redis-databases) with the database hostname, username, and password.
+- Update your Seqera [configuration](./configuration/overview.mdx#seqera-and-redis-databases) with the database hostname, username, and password.
 
 ## Installation
 

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-eks-install.mdx
@@ -188,7 +188,7 @@ Seqera Platform consists of deployments for a cron service, a backend service, a
 
       <details>
       <summary>Show `tower-cron.yml` file</summary>
-      ```js file=./_templates/k8s/k8s_min/tower-cron.yml showLineNumbers
+      ```js file=./_templates/k8s/tower-cron.yml showLineNumbers
       ```
       </details>
 
@@ -196,7 +196,7 @@ Seqera Platform consists of deployments for a cron service, a backend service, a
 
       <details>
       <summary>Show `tower-svc.yml` file</summary>
-      ```js file=./_templates/k8s/k8s_min/tower-svc.yml showLineNumbers
+      ```js file=./_templates/k8s/tower-svc.yml showLineNumbers
       ```
       </details>
 
@@ -206,9 +206,14 @@ Seqera Platform consists of deployments for a cron service, a backend service, a
 
 An ingress is used to make Seqera Enterprise publicly accessible, load-balance traffic, terminate TLS, and offer name-based virtual hosting. The included ingress manifest will create an external IP address and forward HTTP traffic to the Seqera frontend.
 
-Download and configure the appropriate manifest for your infrastructure:
+Download and configure the appropriate manifest for your infrastructure.
 
-    - [Amazon EKS](_templates/k8s/ingress.eks.yml)
+
+<details>
+<summary>Show `ingress.eks.yml` file</summary>
+```js file=./_templates/k8s/ingress.eks.yml showLineNumbers
+```
+</details>
 
 To deploy the manifest to your cluster, run the following:
 
@@ -270,4 +275,3 @@ Use the [dbconsole.yml](_templates/k8s/dbconsole.yml) manifest to deploy a simpl
 [k8s-ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [k8s-load-balancer]: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
 [k8s-node-port]: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
-

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
@@ -15,163 +15,397 @@ The following prerequisites are required to deploy Seqera on a Kubernetes cluste
 - The `kubectl` CLI is installed locally
 - Access to the cluster with the `cluster-admin` role
 
-## Create a namespace
+## 1. Create a namespace
 
-```
-kubectl create namespace seqera-platform
-```
+Create a namespace to isolate Kubernetes resources used by Seqera Platform from the other resources on your cluster.
 
-```js file=./_templates/k8s/redis.aks.yml showLineNumbers
-```
+:::tip
+This installation guide assumes the use of `seqera-platform` as the installation namespace. Consider using a different one that better fits your cluster naming convention.
+:::
 
-Output:
+1. Create a namespace for the Seqera resources:
 
-```
-namespace/seqera-platform created
-```
+    ```
+    kubectl create namespace seqera-platform
+    ```
 
-```
-kubectl config set-context --current --namespace=seqera-platform
-```
+    <details>
+    <summary>View command output</summary>
+    ```
+    namespace/seqera-platform created
+    ```
+    </details>
 
-Output:
+1. Switch to the namespace:
 
-```
-Context "default" modified.
-```
+    ```
+    kubectl config set-context --current --namespace=seqera-platform
+    ```
 
-## Configure container registry credentials
+## 2. Configure container registry credentials
 
-```
-kubectl create secret docker-registry cr.seqera.io \
-  --docker-server=cr.seqera.io \
-  --docker-username='<username>' \
-  --docker-password='<password>'
-```
+Seqera Enterprise is distributed as a collection of Docker containers available through the Seqera container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. After you've received your credentials, grant your cluster access to the registry:
 
-```
-secret/cr.seqera.io created
-```
+1. Retrieve the `name` and `secret` values from the JSON file that you received from Seqera support.
 
-```
-kubectl get secrets cr.seqera.io
-```
+1. Create a [secret][kubectl-secret] for the image pull secret:
 
-```
-NAME           TYPE                             DATA   AGE
-cr.seqera.io   kubernetes.io/dockerconfigjson   1      26s
-```
+    ```
+    kubectl create secret docker-registry cr.seqera.io \
+      --docker-server=cr.seqera.io \
+      --docker-username='<name>' \
+      --docker-password='<secret>'
+    ```
 
-```
-kubectl run pull-test --command --restart=Never --image-pull-policy=Always \
-  --image cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.4 \
-  --overrides='{ "spec": { "imagePullSecrets": [ { "name": "cr.seqera.io" } ] } }' \
-  --override-type=strategic -- /bin/true
-```
+    The credential `name` contains a dollar `$` character. Wrap the name in single quotes to prevent the Linux shell from interpreting this value as an environment variable.
 
-```
-pod/pull-test created
-```
+    <details>
+    <summary>View command output</summary>
+    ```
+    secret/cr.seqera.io created
+    ```
+    </details>
 
-```
-kubectl get pods/pull-test -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase
-NAME        STATUS
-```
+1. Confirm that the secret exists:
 
-```
-pull-test   Succeeded
-```
+    ```
+    kubectl get secrets cr.seqera.io
+    ```
 
-## Configure Seqera Platform
+    <details>
+    <summary>View command output</summary>
+    ```
+    NAME           TYPE                             DATA   AGE
+    cr.seqera.io   kubernetes.io/dockerconfigjson   1      26s
+    ```
+    </details>
+
+1. Confirm that you can pull containers from `cr.seqera.io`:
+
+   1. Pull a container from the private repository:
+
+        ```
+        kubectl run pull-test --command --restart=Never --image-pull-policy=Always \
+          --image cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.4 \
+          --overrides='{ "spec": { "imagePullSecrets": [ { "name": "cr.seqera.io" } ] } }' \
+          --override-type=strategic -- /bin/true
+        ```
+
+        <details>
+        <summary>View command output</summary>
+        ```
+        pod/pull-test created
+        ```
+        </details>
+
+    1. Confirm that the container was pulled:
+
+        ```
+        kubectl get pods/pull-test -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase
+        ```
+
+        <details>
+        <summary>View command output</summary>
+        ```
+        NAME        STATUS
+        pull-test   Succeeded
+        ```
+        </details>
+
+## 3. Configure Seqera Platform
 
 Configure the following environment variables. For more information about Seqera configuration options, see [Configuration overview](./configuration/overview.mdx).
 
-TOWER_ROOT_USERS
+:::tip
+The `configmap.yml` manifest includes both the `tower.env` and `tower.yml` files. These files are made available to the other containers through volume mounts.
+:::
 
-```
-TOWER_SERVER_URL: "http://localhost:8080"
-TOWER_CONTACT_EMAIL: "<email>"
-TOWER_JWT_SECRET: ""
-TOWER_DB_URL: jdbc:mysql://mysql:3306/tower?permitMysqlScheme=true
-TOWER_DB_DRIVER: "org.mariadb.jdbc.Driver"
-TOWER_DB_USER: "tower"
-TOWER_DB_PASSWORD: "tower"
-TOWER_DB_DIALECT: "io.seqera.util.MySQL55DialectCollateBin"
-TOWER_SMTP_HOST: "<smtp_host_name>"
-TOWER_SMTP_USER: ""
-TOWER_SMTP_PASSWORD: ""
-TOWER_CRYPTO_SECRETKEY: "<YOUR CRYPTO SECRET>"
-TOWER_LICENSE: "<license_key>"
-TOWER_ENABLE_PLATFORMS: "local-platform"
-FLYWAY_LOCATIONS: "classpath:db-schema/mysql"
-TOWER_REDIS_URL: "redis://redis:6379"
-```
+1. Create a file named `configmap.yml` with the following Kubernetes manifest:
 
-```
-kubectl apply -f configmap.yml
-configmap/tower-backend-cfg created
-configmap/tower-yml created
-```
+    <details>
+    <summary>Show `configmap.yml` file</summary>
+    ```js file=./_templates/k8s/k8s_min/configmap.yml {10,12-13,22,25-26} showLineNumbers
+    ```
+    </details>
 
-## Deploy a Redis instance
+1. Generate two unique secrets with the following command: `openssl rand -base64 36`
 
-Need to confirm provider storage class.
+1. Edit the `configmap.yml` file and set the following environment variables:
 
-```
-kubectl apply -f redis.yml
-persistentvolumeclaim/redis-data created
-statefulset.apps/redis created
-service/redis created
-```
+    - `TOWER_ROOT_USERS`: Specify your email address
+    - `TOWER_JWT_SECRET`: Specify a unique secret that is at least 35 alphanumeric characters
+    - `TOWER_CRYPTO_SECRETKEY`: Specify a unique secret.
+    - `TOWER_LICENSE`: Specify your Seqera license key, if known. Otherwise, leave this empty.
 
-## Deploy a MySQL instance
+1. Apply the config map:
 
-```
-kubectl create -f mysql.yml
-persistentvolumeclaim/mysql-pvc created
-statefulset.apps/mysql created
-service/mysql created
-```
+    ```
+    kubectl apply -f configmap.yml
+    ```
 
-## Deploy Seqera cron deployment
+    <details>
+    <summary>View command output</summary>
+    ```
+    configmap/tower-backend-cfg created
+    configmap/tower-yml created
+    ```
+    </details>
 
-```
-kubectl apply -f tower-cron.yml
-```
+## 4. Deploy a Redis instance
 
-```
-kubectl rollout status deployment/cron
-deployment "cron" successfully rolled out
-```
+Seqera Enterprise requires a Redis database for caching purposes. Configure Redis manually by deploying a manifest to your cluster.
 
-## Deploy Seqera frontend and backend deployments
+1. Create a file named `redis.yml` with the following Kubernetes manifest:
 
-```bash
-kubectl apply -f tower-svc.yml
-```
+    <details>
+    <summary>Show `redis.yml` file</summary>
+    ```js file=./_templates/k8s/k8s_min/redis.yml {14} showLineNumbers
+    ```
+    </details>
 
-```
-deployment.apps/backend configured
-deployment.apps/frontend configured
-service/backend configured
-service/frontend configured
-```
+1. Set the `spec.storageClassName` field for the persistent volume claim:
 
-## Create a new user account
+   1. Obtain the default storage class name that your Kubernetes cluster provides:
 
-```
-kubectl port-forward services/frontend 8080:80
-Forwarding from 127.0.0.1:8080 -> 8000
-Forwarding from [::1]:8080 -> 8000
-```
+       ```
+       kubectl get storageclass -o=custom-columns=NAME:.metadata.name,PROVISIONER:.provisioner
+       ```
 
-Access the Platform UI. Enter your email address.
+        <details>
+        <summary>View command output</summary>
+        ```
+        NAME       PROVISIONER
+        hostpath   docker.io/hostpath
+        ```
+        </details>
 
-```
-kubectl port-forward services/mailcatcher 1080
-```
+    1. Edit the `redis.yml` file and set `spec.storageClassName` to the name of the default storage class from the output from the previous step.
 
-Open the authentication email with the subject _Complete your sign-in to Seqera_ and select **Complete sign-in**. Seqera creates the initial administrator account and ties it to your email address.
+1. Apply the manifest:
+
+    ```
+    kubectl apply -f redis.yml
+    ```
+
+    <details>
+    <summary>View command output</summary>
+    ```
+    persistentvolumeclaim/redis-data created
+    statefulset.apps/redis created
+    service/redis created
+    ```
+    </details>
+
+1. Confirm that Redis is available:
+
+    ```
+    kubectl get statefulsets/redis
+    ```
+
+    <details>
+    <summary>View command output</summary>
+    ```
+    NAME    READY   AGE
+    redis   1/1     3d5h
+    ```
+    </details>
+
+## 5. Deploy a MySQL instance
+
+1. Create a file named `mysql.yml` with the following Kubernetes manifest:
+
+    <details>
+    <summary>Show `mysql.yml` file</summary>
+    ```js file=./_templates/k8s/k8s_min/mysql.yml {14} showLineNumbers
+    ```
+    </details>
+
+1. Set the `spec.storageClassName` field for the persistent volume claim:
+
+   1. Obtain the default storage class name that your Kubernetes cluster provides:
+
+       ```
+       kubectl get storageclass -o=custom-columns=NAME:.metadata.name,PROVISIONER:.provisioner
+       ```
+
+        <details>
+        <summary>View command output</summary>
+        ```
+        NAME       PROVISIONER
+        hostpath   docker.io/hostpath
+        ```
+        </details>
+
+    1. Edit the `mysql.yml` file and set `spec.storageClassName` to the name of the default storage class from the output from the previous step.
+
+1. Apply the manifest:
+
+    ```
+    kubectl create -f mysql.yml
+    ```
+
+    <details>
+    <summary>View command output</summary>
+    ```
+    persistentvolumeclaim/mysql-pvc created
+    statefulset.apps/mysql created
+    service/mysql created
+    ```
+    </details>
+
+1. Confirm that MySQL is available:
+
+    ```
+    kubectl get statefulsets/redis
+    ```
+
+    <details>
+    <summary>View command output</summary>
+    ```
+    NAME    READY   AGE
+    mysql   1/1     2d12h
+    ```
+    </details>
+
+
+## 6. Deploy Seqera
+
+Seqera Platform consists of deployments for a cron service, a backend service, and a frontend service.
+
+1. Create the manifest files:
+    - Create a file named `tower-cron.yml` with the following Kubernetes manifest:
+
+      <details>
+      <summary>Show `tower-cron.yml` file</summary>
+      ```js file=./_templates/k8s/k8s_min/tower-cron.yml showLineNumbers
+      ```
+      </details>
+
+    - Create a file named `tower-svc.yml` with the following Kubernetes manifest:
+
+      <details>
+      <summary>Show `tower-svc.yml` file</summary>
+      ```js file=./_templates/k8s/k8s_min/tower-svc.yml showLineNumbers
+      ```
+      </details>
+
+1. Deploy the cron service:
+
+      :::caution
+      This manifest includes an init container that creates the required database schema the first time it instantiates. This process can take a few minutes to complete and must finish before you instantiate the Seqera backend. Ensure this container is in the `READY` state before proceeding to the next step.
+      :::
+
+    1. Apply the `tower-cron.yml` manifest:
+
+        ```
+        kubectl apply -f tower-cron.yml
+        ```
+
+        <details>
+        <summary>View command output</summary>
+        ```
+        deployment.apps/cron configured
+        ```
+        </details>
+
+    1. Confirm that cron service deployed successfully:
+
+        ```
+        kubectl rollout status deployment/cron
+        ```
+
+        <details>
+        <summary>View command output</summary>
+          deployment "cron" successfully rolled out
+        </details>
+
+1. Deploy the backend and frontend services:
+
+    1. Apply the `tower-svc.yml` manifest:
+
+        ```
+        kubectl apply -f tower-svc.yml
+        ```
+
+        <details>
+        <summary>View command output</summary>
+        ```
+        deployment.apps/backend configured
+        deployment.apps/frontend configured
+        service/backend configured
+        service/frontend configured
+        ```
+        </details>
+
+    1. Confirm that cron service deployed successfully:
+
+        ```
+        kubectl get deployments
+        ```
+
+        <details>
+        <summary>View command output</summary>
+        ```
+        NAME       READY   UP-TO-DATE   AVAILABLE   AGE
+        backend    1/1     1            1           2d6h
+        cron       1/1     1            1           2d6h
+        frontend   1/1     1            1           2d6h
+        ```
+        </details>
+
+## 7. Create a new user account
+
+Use the same email address that you specified for the `TOWER_ROOT_USERS` environment variable.
+
+1. Open a port forward to the frontend to access the Seqera UI:
+
+    ```
+    kubectl port-forward services/frontend 8080:80 &
+    ```
+
+    <details>
+    <summary>View command output</summary>
+    Forwarding from 127.0.0.1:8080 -> 8000
+    Forwarding from [::1]:8080 -> 8000
+    </details>
+
+1. In a web browser, visit `http://localhost:8080/`. In the **Sign in to Seqera platform** form, enter the email address that you set the `TOWER_ROOT_USERS` environment variable to.
+
+1. Create a file named `mailcatcher.yml` with the following manifest:
+
+    <details>
+    <summary>Show `mailcatcher.yml` file</summary>
+    ```js file=./_templates/k8s/k8s_min/mailcatcher.yml showLineNumbers
+    ```
+    </details>
+
+1. Deploy the MatchCatcher application, so that you can access the email that Seqera sends with your authentication token:
+
+    ```
+    kubectl apply -f mailcatcher.yml
+    ```
+
+1. Open a port forward to the MailCatcher application, to access its web UI:
+
+    ```
+    kubectl port-forward services/mailcatcher 1080 &
+    ```
+
+    <details>
+    <summary>View command output</summary>
+    ```
+    Forwarding from 127.0.0.1:1080 -> 1080
+    Forwarding from [::1]:1080 -> 1080
+    ```
+    </details>
+
+1. In a web browser, visit `http://localhost:1080/`.
+
+1. Open the authentication email with the subject _Complete your sign-in to Seqera_ and select **Complete sign-in**. Seqera redirects your browser to the **Launchpad** page.
+
+1. Optional: To stop the background port forward processes, you can run `jobs` in your shell, and then run `kill -15 <pid>` to stop each process. If you stop the port forward to the frontend, you can no longer access the Seqera UI. We recommend using a cloud provider's load balancers in conjunction with the Kubernetes ingress functionality for persistent access to your installation.
+
+Your installation of Seqera Platform is complete.
 
 ## Next steps
 
@@ -179,75 +413,6 @@ Open the authentication email with the subject _Complete your sign-in to Seqera_
 - Configure ingress for your public cloud provider for load balancing and TLS termination
 - Configure access to your organization's email server
 
-## Parking
 
-```
-kubectl create namespace seqera-platform
-namespace/seqera-platform created
-
-kubectl config set-context --current --namespace=seqera-platform
-Context "docker-desktop" modified.
-
-kubectl create secret docker-registry cr.seqera.io \
-                         --docker-server=cr.seqera.io \
-                         --docker-username='jason.boxman@seqera.io' \
-                         --docker-password='<password>'
-secret/cr.seqera.io created
- 
-kubectl get secrets cr.seqera.io
-NAME           TYPE                             DATA   AGE
-cr.seqera.io   kubernetes.io/dockerconfigjson   1      26s
-
-kubectl apply -f configmap.yml
-configmap/tower-backend-cfg created
-configmap/tower-yml created
-
-kubectl create -f mysql.yml
-persistentvolumeclaim/mysql-pvc created
-statefulset.apps/mysql created
-service/mysql-headless created
-
-# Try this because next step is required
-kubectl rollout status deployment/cron
-deployment "cron" successfully rolled out
-
-kubectl port-forward services/frontend 8080:80
-Forwarding from 127.0.0.1:8080 -> 8000
-Forwarding from [::1]:8080 -> 8000
-
-kubectl port-forward services/mailcatcher 1080
-```
-
-```
-kubectl get all
-NAME                           READY   STATUS    RESTARTS   AGE
-pod/backend-69d554df9d-ptsjn   1/1     Running   0          22h
-pod/cron-564c846f7c-79pl6      1/1     Running   0          8h
-pod/frontend-c768bbf7f-dxj7g   1/1     Running   0          36h
-pod/mailcatcher                1/1     Running   0          8h
-pod/mysql-0                    1/1     Running   0          37h
-pod/redis-0                    1/1     Running   0          23m
-
-NAME                  TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)            AGE
-service/backend       ClusterIP      10.96.179.57     <none>        8080/TCP           37h
-service/frontend      ClusterIP      10.103.127.27    <none>        80/TCP       37h
-service/mailcatcher   ClusterIP      10.96.207.80     <none>        587/TCP,1080/TCP   8h
-service/mysql         ClusterIP      None             <none>        3306/TCP           37h
-service/redis         ClusterIP      10.111.114.163   <none>        6379/TCP           2d5h
-service/smtp          ClusterIP      10.104.195.72    <none>        587/TCP            24h
-
-NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
-deployment.apps/backend    1/1     1            1           37h
-deployment.apps/cron       1/1     1            1           37h
-deployment.apps/frontend   1/1     1            1           36h
-
-NAME                                  DESIRED   CURRENT   READY   AGE
-replicaset.apps/backend-69d554df9d    1         1         1       37h
-replicaset.apps/cron-564c846f7c       1         1         1       37h
-replicaset.apps/frontend-6d88cdb487   0         0         0       36h
-replicaset.apps/frontend-c768bbf7f    1         1         1       36h
-
-NAME                     READY   AGE
-statefulset.apps/mysql   1/1     37h
-statefulset.apps/redis   1/1     2d5h
-```
+<!-- links -->
+[kubectl-secret]: https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
@@ -63,9 +63,8 @@ cr.seqera.io   kubernetes.io/dockerconfigjson   1      26s
 ```
 
 ```
-kubectl run pull-test --restart=Never --image-pull-policy=Always \
-  --image cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.4
-  --command \
+kubectl run pull-test --command --restart=Never --image-pull-policy=Always \
+  --image cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.4 \
   --overrides='{ "spec": { "imagePullSecrets": [ { "name": "cr.seqera.io" } ] } }' \
   --override-type=strategic -- /bin/true
 ```
@@ -85,8 +84,11 @@ pull-test   Succeeded
 
 ## Configure Seqera Platform
 
+Configure the following environment variables. For more information about Seqera configuration options, see [Configuration overview](./configuration/overview.mdx).
+
 TOWER_ROOT_USERS
 
+```
 TOWER_SERVER_URL: "http://localhost:8080"
 TOWER_CONTACT_EMAIL: "<email>"
 TOWER_JWT_SECRET: ""
@@ -103,6 +105,7 @@ TOWER_LICENSE: "<license_key>"
 TOWER_ENABLE_PLATFORMS: "local-platform"
 FLYWAY_LOCATIONS: "classpath:db-schema/mysql"
 TOWER_REDIS_URL: "redis://redis:6379"
+```
 
 ```
 kubectl apply -f configmap.yml
@@ -111,6 +114,8 @@ configmap/tower-yml created
 ```
 
 ## Deploy a Redis instance
+
+Need to confirm provider storage class.
 
 ```
 kubectl apply -f redis.yml

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
@@ -1,9 +1,13 @@
 ---
-title: Install Seqera Platform on Kubernetes
-description: Deploy Seqera Platform Enterprise with Kubernetes
+title: Install on a Kubernetes cluster
+description: Deploy Seqera Platform Enterprise on a Kubernetes cluster
 date: "11 Sep 2024"
 tags: [kubernetes, deployment]
 ---
+
+import CreateNamespace from './_partials/_k8s-install-ns.mdx';
+import ConfigureRegistry from './_partials/_k8s-install-registry.mdx';
+import DeployManifests from './_partials/_k8s-install-deploy-no-heading.mdx';
 
 This installation guide describes how to install Seqera Platform on a Kubernetes cluster.
 
@@ -15,104 +19,10 @@ The following prerequisites are required to deploy Seqera on a Kubernetes cluste
 - The `kubectl` CLI is installed locally
 - Access to the cluster with the `cluster-admin` role
 
-## 1. Create a namespace
+<CreateNamespace />
+<ConfigureRegistry />
 
-Create a namespace to isolate Kubernetes resources used by Seqera Platform from the other resources on your cluster.
-
-:::tip
-This installation guide assumes the use of `seqera-platform` as the installation namespace. Consider using a different one that better fits your cluster naming convention.
-:::
-
-1. Create a namespace for the Seqera resources:
-
-    ```
-    kubectl create namespace seqera-platform
-    ```
-
-    <details>
-    <summary>View command output</summary>
-    ```
-    namespace/seqera-platform created
-    ```
-    </details>
-
-1. Switch to the namespace:
-
-    ```
-    kubectl config set-context --current --namespace=seqera-platform
-    ```
-
-## 2. Configure container registry credentials
-
-Seqera Enterprise is distributed as a collection of Docker containers available through the Seqera container registry [`cr.seqera.io`](https://cr.seqera.io). Contact [support](https://support.seqera.io) to get your container access credentials. After you've received your credentials, grant your cluster access to the registry:
-
-1. Retrieve the `name` and `secret` values from the JSON file that you received from Seqera support.
-
-1. Create a [secret][kubectl-secret] for the image pull secret:
-
-    ```
-    kubectl create secret docker-registry cr.seqera.io \
-      --docker-server=cr.seqera.io \
-      --docker-username='<name>' \
-      --docker-password='<secret>'
-    ```
-
-    The credential `name` contains a dollar `$` character. Wrap the name in single quotes to prevent the Linux shell from interpreting this value as an environment variable.
-
-    <details>
-    <summary>View command output</summary>
-    ```
-    secret/cr.seqera.io created
-    ```
-    </details>
-
-1. Confirm that the secret exists:
-
-    ```
-    kubectl get secrets cr.seqera.io
-    ```
-
-    <details>
-    <summary>View command output</summary>
-    ```
-    NAME           TYPE                             DATA   AGE
-    cr.seqera.io   kubernetes.io/dockerconfigjson   1      26s
-    ```
-    </details>
-
-1. Confirm that you can pull containers from `cr.seqera.io`:
-
-   1. Pull a container from the private repository:
-
-        ```
-        kubectl run pull-test --command --restart=Never --image-pull-policy=Always \
-          --image cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.4 \
-          --overrides='{ "spec": { "imagePullSecrets": [ { "name": "cr.seqera.io" } ] } }' \
-          --override-type=strategic -- /bin/true
-        ```
-
-        <details>
-        <summary>View command output</summary>
-        ```
-        pod/pull-test created
-        ```
-        </details>
-
-    1. Confirm that the container was pulled:
-
-        ```
-        kubectl get pods/pull-test -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase
-        ```
-
-        <details>
-        <summary>View command output</summary>
-        ```
-        NAME        STATUS
-        pull-test   Succeeded
-        ```
-        </details>
-
-## 3. Configure Seqera Platform
+## Configure Seqera Platform
 
 Configure the following environment variables. For more information about Seqera configuration options, see [Configuration overview](./configuration/overview.mdx).
 
@@ -124,11 +34,11 @@ The `configmap.yml` manifest includes both the `tower.env` and `tower.yml` files
 
     <details>
     <summary>Show `configmap.yml` file</summary>
-    ```js file=./_templates/k8s/k8s_min/configmap.yml {10,12-13,22,25-26} showLineNumbers
+    ```js file=./_templates/k8s/k8s_min/configmap.yml {10,13,25-26} showLineNumbers
     ```
     </details>
 
-1. Generate two unique secrets with the following command: `openssl rand -base64 36`
+1. Generate two unique secrets with the following command: `openssl rand -base64 32 | tr -d /=+ | cut -c -32`
 
 1. Edit the `configmap.yml` file and set the following environment variables:
 
@@ -151,7 +61,7 @@ The `configmap.yml` manifest includes both the `tower.env` and `tower.yml` files
     ```
     </details>
 
-## 4. Deploy a Redis instance
+## Deploy a Redis instance
 
 Seqera Enterprise requires a Redis database for caching purposes. Configure Redis manually by deploying a manifest to your cluster.
 
@@ -210,7 +120,7 @@ Seqera Enterprise requires a Redis database for caching purposes. Configure Redi
     ```
     </details>
 
-## 5. Deploy a MySQL instance
+## Deploy a MySQL instance
 
 1. Create a file named `mysql.yml` with the following Kubernetes manifest:
 
@@ -267,8 +177,7 @@ Seqera Enterprise requires a Redis database for caching purposes. Configure Redi
     ```
     </details>
 
-
-## 6. Deploy Seqera
+## Deploy Seqera
 
 Seqera Platform consists of deployments for a cron service, a backend service, and a frontend service.
 
@@ -289,69 +198,7 @@ Seqera Platform consists of deployments for a cron service, a backend service, a
       ```
       </details>
 
-1. Deploy the cron service:
-
-      :::caution
-      This manifest includes an init container that creates the required database schema the first time it instantiates. This process can take a few minutes to complete and must finish before you instantiate the Seqera backend. Ensure this container is in the `READY` state before proceeding to the next step.
-      :::
-
-    1. Apply the `tower-cron.yml` manifest:
-
-        ```
-        kubectl apply -f tower-cron.yml
-        ```
-
-        <details>
-        <summary>View command output</summary>
-        ```
-        deployment.apps/cron configured
-        ```
-        </details>
-
-    1. Confirm that cron service deployed successfully:
-
-        ```
-        kubectl rollout status deployment/cron
-        ```
-
-        <details>
-        <summary>View command output</summary>
-          deployment "cron" successfully rolled out
-        </details>
-
-1. Deploy the backend and frontend services:
-
-    1. Apply the `tower-svc.yml` manifest:
-
-        ```
-        kubectl apply -f tower-svc.yml
-        ```
-
-        <details>
-        <summary>View command output</summary>
-        ```
-        deployment.apps/backend configured
-        deployment.apps/frontend configured
-        service/backend configured
-        service/frontend configured
-        ```
-        </details>
-
-    1. Confirm that cron service deployed successfully:
-
-        ```
-        kubectl get deployments
-        ```
-
-        <details>
-        <summary>View command output</summary>
-        ```
-        NAME       READY   UP-TO-DATE   AVAILABLE   AGE
-        backend    1/1     1            1           2d6h
-        cron       1/1     1            1           2d6h
-        frontend   1/1     1            1           2d6h
-        ```
-        </details>
+<DeployManifests step={2} />
 
 ## 7. Create a new user account
 

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
@@ -19,10 +19,15 @@ The following prerequisites are required to deploy Seqera on a Kubernetes cluste
 - The `kubectl` CLI is installed locally
 - Access to the cluster with the `cluster-admin` role
 
+## 1. Create a namespace
+
 <CreateNamespace />
+
+## 2. Configure container registry credentials
+
 <ConfigureRegistry />
 
-## Configure Seqera Platform
+## 3. Configure Seqera Platform
 
 Configure the following environment variables. For more information about Seqera configuration options, see [Configuration overview](./configuration/overview.mdx).
 
@@ -61,7 +66,7 @@ The `configmap.yml` manifest includes both the `tower.env` and `tower.yml` files
     ```
     </details>
 
-## Deploy a Redis instance
+## 4. Deploy a Redis instance
 
 Seqera Enterprise requires a Redis database for caching purposes. Configure Redis manually by deploying a manifest to your cluster.
 
@@ -120,7 +125,7 @@ Seqera Enterprise requires a Redis database for caching purposes. Configure Redi
     ```
     </details>
 
-## Deploy a MySQL instance
+## 5. Deploy a MySQL instance
 
 1. Create a file named `mysql.yml` with the following Kubernetes manifest:
 
@@ -177,7 +182,7 @@ Seqera Enterprise requires a Redis database for caching purposes. Configure Redi
     ```
     </details>
 
-## Deploy Seqera
+## 6. Deploy Seqera
 
 Seqera Platform consists of deployments for a cron service, a backend service, and a frontend service.
 

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
@@ -1,0 +1,7 @@
+---
+title: Install Seqera Platform on Kubernetes
+description: Deploy Seqera Platform Enterprise with Kubernetes
+date: "11 Sep 2024"
+tags: [kubernetes, deployment]
+---
+

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
@@ -62,8 +62,47 @@ NAME           TYPE                             DATA   AGE
 cr.seqera.io   kubernetes.io/dockerconfigjson   1      26s
 ```
 
+```
+kubectl run pull-test --restart=Never --image-pull-policy=Always \
+  --image cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.4
+  --command \
+  --overrides='{ "spec": { "imagePullSecrets": [ { "name": "cr.seqera.io" } ] } }' \
+  --override-type=strategic -- /bin/true
+```
+
+```
+pod/pull-test created
+```
+
+```
+kubectl get pods/pull-test -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase
+NAME        STATUS
+```
+
+```
+pull-test   Succeeded
+```
+
 ## Configure Seqera Platform
 
+TOWER_ROOT_USERS
+
+TOWER_SERVER_URL: "http://localhost:8080"
+TOWER_CONTACT_EMAIL: "<email>"
+TOWER_JWT_SECRET: ""
+TOWER_DB_URL: jdbc:mysql://mysql:3306/tower?permitMysqlScheme=true
+TOWER_DB_DRIVER: "org.mariadb.jdbc.Driver"
+TOWER_DB_USER: "tower"
+TOWER_DB_PASSWORD: "tower"
+TOWER_DB_DIALECT: "io.seqera.util.MySQL55DialectCollateBin"
+TOWER_SMTP_HOST: "<smtp_host_name>"
+TOWER_SMTP_USER: ""
+TOWER_SMTP_PASSWORD: ""
+TOWER_CRYPTO_SECRETKEY: "<YOUR CRYPTO SECRET>"
+TOWER_LICENSE: "<license_key>"
+TOWER_ENABLE_PLATFORMS: "local-platform"
+FLYWAY_LOCATIONS: "classpath:db-schema/mysql"
+TOWER_REDIS_URL: "redis://redis:6379"
 
 ```
 kubectl apply -f configmap.yml
@@ -75,9 +114,9 @@ configmap/tower-yml created
 
 ```
 kubectl apply -f redis.yml
-persistentvolumeclaim/redis-data unchanged
-statefulset.apps/redis unchanged
-service/redis unchanged
+persistentvolumeclaim/redis-data created
+statefulset.apps/redis created
+service/redis created
 ```
 
 ## Deploy a MySQL instance

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
@@ -5,3 +5,205 @@ date: "11 Sep 2024"
 tags: [kubernetes, deployment]
 ---
 
+This installation guide describes how to install Seqera Platform on a Kubernetes cluster.
+
+## Prerequisites
+
+The following prerequisites are required to deploy Seqera on a Kubernetes cluster.
+
+- A Kubernetes cluster version 1.30.2 or newer
+- The `kubectl` CLI is installed locally
+- Access to the cluster with the `cluster-admin` role
+
+## Create a namespace
+
+```
+kubectl create namespace seqera-platform
+```
+
+```js file=./_templates/k8s/redis.aks.yml showLineNumbers
+```
+
+Output:
+
+```
+namespace/seqera-platform created
+```
+
+```
+kubectl config set-context --current --namespace=seqera-platform
+```
+
+Output:
+
+```
+Context "default" modified.
+```
+
+## Configure container registry credentials
+
+```
+kubectl create secret docker-registry cr.seqera.io \
+  --docker-server=cr.seqera.io \
+  --docker-username='<username>' \
+  --docker-password='<password>'
+```
+
+```
+secret/cr.seqera.io created
+```
+
+```
+kubectl get secrets cr.seqera.io
+```
+
+```
+NAME           TYPE                             DATA   AGE
+cr.seqera.io   kubernetes.io/dockerconfigjson   1      26s
+```
+
+## Configure Seqera Platform
+
+
+```
+kubectl apply -f configmap.yml
+configmap/tower-backend-cfg created
+configmap/tower-yml created
+```
+
+## Deploy a Redis instance
+
+```
+kubectl apply -f redis.yml
+persistentvolumeclaim/redis-data unchanged
+statefulset.apps/redis unchanged
+service/redis unchanged
+```
+
+## Deploy a MySQL instance
+
+```
+kubectl create -f mysql.yml
+persistentvolumeclaim/mysql-pvc created
+statefulset.apps/mysql created
+service/mysql created
+```
+
+## Deploy Seqera cron deployment
+
+```
+kubectl apply -f tower-cron.yml
+```
+
+```
+kubectl rollout status deployment/cron
+deployment "cron" successfully rolled out
+```
+
+## Deploy Seqera frontend and backend deployments
+
+```bash
+kubectl apply -f tower-svc.yml
+```
+
+```
+deployment.apps/backend configured
+deployment.apps/frontend configured
+service/backend configured
+service/frontend configured
+```
+
+## Create a new user account
+
+```
+kubectl port-forward services/frontend 8080:80
+Forwarding from 127.0.0.1:8080 -> 8000
+Forwarding from [::1]:8080 -> 8000
+```
+
+Access the Platform UI. Enter your email address.
+
+```
+kubectl port-forward services/mailcatcher 1080
+```
+
+Open the authentication email with the subject _Complete your sign-in to Seqera_ and select **Complete sign-in**. Seqera creates the initial administrator account and ties it to your email address.
+
+## Next steps
+
+- Configure OpenID Connect (OIDC) for seamless integration with your identify provider
+- Configure ingress for your public cloud provider for load balancing and TLS termination
+- Configure access to your organization's email server
+
+## Parking
+
+```
+kubectl create namespace seqera-platform
+namespace/seqera-platform created
+
+kubectl config set-context --current --namespace=seqera-platform
+Context "docker-desktop" modified.
+
+kubectl create secret docker-registry cr.seqera.io \
+                         --docker-server=cr.seqera.io \
+                         --docker-username='jason.boxman@seqera.io' \
+                         --docker-password='<password>'
+secret/cr.seqera.io created
+ 
+kubectl get secrets cr.seqera.io
+NAME           TYPE                             DATA   AGE
+cr.seqera.io   kubernetes.io/dockerconfigjson   1      26s
+
+kubectl apply -f configmap.yml
+configmap/tower-backend-cfg created
+configmap/tower-yml created
+
+kubectl create -f mysql.yml
+persistentvolumeclaim/mysql-pvc created
+statefulset.apps/mysql created
+service/mysql-headless created
+
+# Try this because next step is required
+kubectl rollout status deployment/cron
+deployment "cron" successfully rolled out
+
+kubectl port-forward services/frontend 8080:80
+Forwarding from 127.0.0.1:8080 -> 8000
+Forwarding from [::1]:8080 -> 8000
+
+kubectl port-forward services/mailcatcher 1080
+```
+
+```
+kubectl get all
+NAME                           READY   STATUS    RESTARTS   AGE
+pod/backend-69d554df9d-ptsjn   1/1     Running   0          22h
+pod/cron-564c846f7c-79pl6      1/1     Running   0          8h
+pod/frontend-c768bbf7f-dxj7g   1/1     Running   0          36h
+pod/mailcatcher                1/1     Running   0          8h
+pod/mysql-0                    1/1     Running   0          37h
+pod/redis-0                    1/1     Running   0          23m
+
+NAME                  TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)            AGE
+service/backend       ClusterIP      10.96.179.57     <none>        8080/TCP           37h
+service/frontend      ClusterIP      10.103.127.27    <none>        80/TCP       37h
+service/mailcatcher   ClusterIP      10.96.207.80     <none>        587/TCP,1080/TCP   8h
+service/mysql         ClusterIP      None             <none>        3306/TCP           37h
+service/redis         ClusterIP      10.111.114.163   <none>        6379/TCP           2d5h
+service/smtp          ClusterIP      10.104.195.72    <none>        587/TCP            24h
+
+NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/backend    1/1     1            1           37h
+deployment.apps/cron       1/1     1            1           37h
+deployment.apps/frontend   1/1     1            1           36h
+
+NAME                                  DESIRED   CURRENT   READY   AGE
+replicaset.apps/backend-69d554df9d    1         1         1       37h
+replicaset.apps/cron-564c846f7c       1         1         1       37h
+replicaset.apps/frontend-6d88cdb487   0         0         0       36h
+replicaset.apps/frontend-c768bbf7f    1         1         1       36h
+
+NAME                     READY   AGE
+statefulset.apps/mysql   1/1     37h
+statefulset.apps/redis   1/1     2d5h
+```

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
@@ -16,7 +16,7 @@ This installation guide describes how to install Seqera Platform on a Kubernetes
 The following prerequisites are required to deploy Seqera on a Kubernetes cluster.
 
 - A Kubernetes cluster version 1.30.2 or newer
-- The `kubectl` CLI is installed locally
+- A local installation of `kubectl` CLI 
 - Access to the cluster with the `cluster-admin` role
 
 ## 1. Create a namespace

--- a/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/kubernetes-minimal-install.mdx
@@ -7,7 +7,7 @@ tags: [kubernetes, deployment]
 
 import CreateNamespace from './_partials/_k8s-install-ns.mdx';
 import ConfigureRegistry from './_partials/_k8s-install-registry.mdx';
-import DeployManifests from './_partials/_k8s-install-deploy-no-heading.mdx';
+import DeployManifests from './_partials/_k8s-install-deploy.mdx';
 
 This installation guide describes how to install Seqera Platform on a Kubernetes cluster.
 
@@ -267,4 +267,3 @@ Your installation of Seqera Platform is complete.
 
 
 <!-- links -->
-[kubectl-secret]: https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/

--- a/platform_versioned_sidebars/version-24.1-sidebars.json
+++ b/platform_versioned_sidebars/version-24.1-sidebars.json
@@ -167,6 +167,8 @@
           "items": [
             "enterprise/docker-compose",
             "enterprise/kubernetes",
+            "enterprise/kubernetes-minimal-install",
+            "enterprise/kubernetes-eks-install",
             "enterprise/testing",
             "enterprise/upgrade"          
           ]


### PR DESCRIPTION
- https://seqera.atlassian.net/browse/EDU-301

Preview URL: https://deploy-preview-220--seqera-docs.netlify.app/platform/24.1/enterprise/kubernetes-minimal-install

The goal of this project is the improvement of the existing installation documentation. In particular, provide installation documentation for Kubernetes that is vastly simplified, providing the user with a turnkey working Kubernetes installation on any Kubernetes cluster, without any cloud provider specific requirements or configuration initially. This also works locally on Docker Desktop K8s.

This gives the user an immediately functional installation. Then we can build on this with Seqera recommended reference installations that cover best practice for ingress configuration, Redis and MySQL SaaS service integration, external SMTP server integration, custom TLS certificates for NF launcher, and so on.

For clarity, configuration files are functional minimums, without any extraneous fields. Any commands run include output and examples where ever possible, along with validation and confirmation steps.
