### PR TITLE
Add steps for manually creating API secret

### DIFF
--- a/platform_versioned_docs/version-24.1/compute-envs/k8s.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/k8s.mdx
@@ -15,6 +15,8 @@ The following instructions create a Seqera compute environment for a **generic K
 
 To prepare your Kubernetes cluster for the deployment of Nextflow pipelines using Seqera, this guide assumes that you've already created the cluster and that you have administrative privileges.
 
+This guide applies a Kubernetes manifest that creates a service account named `tower-launcher-sa` and the associated role bindings, all contained in the `tower-nf` namespace. Seqera uses the service account to launch Nextflow pipelines. Use this service account name when setting up the compute environment for this Kubernetes cluster in Seqera.
+
 **Prepare your Kubernetes cluster for Seqera Platform**
 
 1. Verify the connection to your Kubernetes cluster:
@@ -23,14 +25,36 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
    kubectl cluster-info
    ```
 
-1. Download the [tower-launcher.yml](../_templates/k8s/tower-launcher.yml) file.
-1. Create the Seqera launcher:
+1. Create a file named `tower-launcher.yml` with the following YAML:
 
-   ```bash
-   kubectl apply -f path/to/tower-launcher.yml
-   ```
+    ```yaml file=../_templates/k8s/tower-launcher.yml showLineNumbers
+    ```
 
-   This command creates a service account called `tower-launcher-sa` and the associated role bindings, all contained in a namespace called `tower-nf`. Seqera uses the service account to launch Nextflow pipelines. Use this service account name when setting up the compute environment for this Kubernetes cluster in Seqera.
+1. Apply the manifest:
+
+    ```bash
+    kubectl apply -f tower-launcher.yml
+    ```
+
+1. Create a persistent API token for the `tower-launcher-sa` service account:
+
+    ```bash
+    kubectl apply -f - <<EOF
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: tower-launcher-token
+      annotations:
+        kubernetes.io/service-account.name: tower-launcher-sa
+    type: kubernetes.io/service-account-token
+    EOF
+    ```
+
+1. Confirm that Kubernetes created the persistent API token secret:
+
+    ```bash
+    kubectl describe secrets/tower-launcher-token
+    ```
 
 1. Create persistent storage. Seqera requires a `ReadWriteMany` persistent volume claim (PVC) mounted to all nodes where workflow pods will be dispatched.
 
@@ -43,7 +67,7 @@ To prepare your Kubernetes cluster for the deployment of Nextflow pipelines usin
 1. Apply the appropriate PVC configuration to your cluster:
 
    ```bash
-   kubectl apply -f <PVC_YAML_FILE>.
+   kubectl apply -f <PVC_YAML_FILE>
    ```
 
 ## Seqera compute environment


### PR DESCRIPTION
- https://seqera.atlassian.net/browse/EDU-255

So for whatever reason, this does not work for me locally with Docker Desktop K8s. I don't know why. This comes right from the upstream documentation, so I assume it is correct: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-long-lived-api-token-for-a-serviceaccount

Someone else would need to validate this on a live cluster, because strangely I cannot.