### PR TITLE
Adding Link to Batch Setup

### DIFF
--- a/platform_versioned_docs/version-24.1/compute-envs/aws-batch.mdx
+++ b/platform_versioned_docs/version-24.1/compute-envs/aws-batch.mdx
@@ -235,7 +235,7 @@ Specify the **Allocation strategy** and indicate any preferred **Instance types*
 
 ## Manual
 
-This section is for users with a pre-configured AWS environment. You will need a Batch queue, a Batch compute environment, an IAM user, and an S3 bucket already set up.
+This section is for users with a pre-configured AWS environment. You will need a [Batch queue, a Batch compute environment, an IAM user, and an S3 bucket](../enterprise/advanced-topics/manual-aws-batch-setup.mdx) already set up.
 
 To enable Seqera in your existing AWS configuration, you need an IAM user with the following permissions:
 


### PR DESCRIPTION
This change adds a link to the manual batch setup from the Manual compute environment setup
I had some trouble finding this while doing the manual setup and thought it would be good to link from one to the other. 

