### PR TITLE
BT-125 Add robots.txt file for Atlassian AI scrapping

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,5 @@
+User-agent: atlassian-bot
+Allow: /
+
+User-agent: *
+Allow: /


### PR DESCRIPTION
Added `robots.txt` file to docs site to enable Atlassian AI scraping.

[Docosaurus documentation](https://docusaurus.io/docs/seo#robots-file) mentioned that should be added to the `static` folder.

This resolves [BT-125]

[BT-125]: https://seqera.atlassian.net/browse/BT-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ