### PR TITLE
Remove references to `redisson.*`  properties

### DIFF
--- a/platform_versioned_docs/version-23.3/enterprise/configuration/configtables/db_aws.yml
+++ b/platform_versioned_docs/version-23.3/enterprise/configuration/configtables/db_aws.yml
@@ -32,12 +32,12 @@
     Maximum lifespan of database connections, in milliseconds. 
   Value:                'Default: `1800000`'
 - 
-  AWS Parameter Store:  '`{prefix}/redisson/uri`'
+  AWS Parameter Store:  '`{prefix}/TOWER_REDIS_URL`'
   Description: > 
     The URL to access your Seqera Redis instance.
   Value:                'Example: `redis://redis:6379`'
 - 
-  AWS Parameter Store:  '`{prefix}/redisson/password`'
+  AWS Parameter Store:  '`{prefix}/TOWER_REDIS_PASSWORD`'
   Description: > 
     The password of your Seqera Redis instance.
   Value:                

--- a/platform_versioned_docs/version-23.3/enterprise/configuration/configtables/db_yml.yml
+++ b/platform_versioned_docs/version-23.3/enterprise/configuration/configtables/db_yml.yml
@@ -31,13 +31,13 @@
   Description: > 
     Maximum lifespan of database connections, in milliseconds. 
   Value:              'Default: `1800000`'
-- 
-  tower.yml:            '`redisson.uri`'
+-
+  tower.yml:            '`TOWER_REDIS_URL`'
   Description: > 
     The URL to access your Seqera Redis instance.
   Value:              'Example: `redis://redis:6379`'
 - 
-  tower.yml:            '`redisson.password`'
+  tower.yml:            '`TOWER_REDIS_PASSWORD`'
   Description: > 
     The password of your Seqera Redis instance.
-  Value:              
+  Value:  

--- a/platform_versioned_docs/version-23.4/enterprise/configuration/configtables/db_aws.yml
+++ b/platform_versioned_docs/version-23.4/enterprise/configuration/configtables/db_aws.yml
@@ -32,12 +32,12 @@
     Maximum lifespan of database connections, in milliseconds. 
   Value:                'Default: `1800000`'
 - 
-  AWS Parameter Store:  '`{prefix}/redisson/uri`'
+  AWS Parameter Store:  '`{prefix}/TOWER_REDIS_URL`'
   Description: > 
     The URL to access your Seqera Redis instance.
   Value:                'Example: `redis://redis:6379`'
 - 
-  AWS Parameter Store:  '`{prefix}/redisson/password`'
+  AWS Parameter Store:  '`{prefix}/TOWER_REDIS_PASSWORD`'
   Description: > 
     The password of your Seqera Redis instance.
   Value:                

--- a/platform_versioned_docs/version-23.4/enterprise/configuration/configtables/db_yml.yml
+++ b/platform_versioned_docs/version-23.4/enterprise/configuration/configtables/db_yml.yml
@@ -31,13 +31,13 @@
   Description: > 
     Maximum lifespan of database connections, in milliseconds. 
   Value:              'Default: `1800000`'
-- 
-  tower.yml:            '`redisson.uri`'
+-
+  tower.yml:            '`TOWER_REDIS_URL`'
   Description: > 
     The URL to access your Seqera Redis instance.
   Value:              'Example: `redis://redis:6379`'
 - 
-  tower.yml:            '`redisson.password`'
+  tower.yml:            '`TOWER_REDIS_PASSWORD`'
   Description: > 
     The password of your Seqera Redis instance.
-  Value:              
+  Value:  

--- a/platform_versioned_docs/version-24.1/enterprise/configuration/configtables/db_aws.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/configuration/configtables/db_aws.yml
@@ -32,12 +32,12 @@
     Maximum lifespan of database connections, in milliseconds. 
   Value:                'Default: `1800000`'
 - 
-  AWS Parameter Store:  '`{prefix}/redisson/uri`'
+  AWS Parameter Store:  '`{prefix}/TOWER_REDIS_URL`'
   Description: > 
     The URL to access your Seqera Redis instance.
   Value:                'Example: `redis://redis:6379`'
 - 
-  AWS Parameter Store:  '`{prefix}/redisson/password`'
+  AWS Parameter Store:  '`{prefix}/TOWER_REDIS_PASSWORD`'
   Description: > 
     The password of your Seqera Redis instance.
   Value:                

--- a/platform_versioned_docs/version-24.1/enterprise/configuration/configtables/db_yml.yml
+++ b/platform_versioned_docs/version-24.1/enterprise/configuration/configtables/db_yml.yml
@@ -31,13 +31,13 @@
   Description: > 
     Maximum lifespan of database connections, in milliseconds. 
   Value:              'Default: `1800000`'
-- 
-  tower.yml:            '`redisson.uri`'
+-
+  tower.yml:            '`TOWER_REDIS_URL`'
   Description: > 
     The URL to access your Seqera Redis instance.
   Value:              'Example: `redis://redis:6379`'
 - 
-  tower.yml:            '`redisson.password`'
+  tower.yml:            '`TOWER_REDIS_PASSWORD`'
   Description: > 
     The password of your Seqera Redis instance.
-  Value:              
+  Value:  

--- a/platform_versioned_docs/version-24.2/enterprise/configuration/configtables/db_aws.yml
+++ b/platform_versioned_docs/version-24.2/enterprise/configuration/configtables/db_aws.yml
@@ -32,12 +32,12 @@
     Maximum lifespan of database connections, in milliseconds. 
   Value:                'Default: `1800000`'
 - 
-  AWS Parameter Store:  '`{prefix}/redisson/uri`'
+  AWS Parameter Store:  '`{prefix}/TOWER_REDIS_URL`'
   Description: > 
     The URL to access your Seqera Redis instance.
   Value:                'Example: `redis://redis:6379`'
 - 
-  AWS Parameter Store:  '`{prefix}/redisson/password`'
+  AWS Parameter Store:  '`{prefix}/TOWER_REDIS_PASSWORD`'
   Description: > 
     The password of your Seqera Redis instance.
   Value:                

--- a/platform_versioned_docs/version-24.2/enterprise/configuration/configtables/db_yml.yml
+++ b/platform_versioned_docs/version-24.2/enterprise/configuration/configtables/db_yml.yml
@@ -31,13 +31,13 @@
   Description: > 
     Maximum lifespan of database connections, in milliseconds. 
   Value:              'Default: `1800000`'
-- 
-  tower.yml:            '`redisson.uri`'
+-
+  tower.yml:            '`TOWER_REDIS_URL`'
   Description: > 
     The URL to access your Seqera Redis instance.
   Value:              'Example: `redis://redis:6379`'
 - 
-  tower.yml:            '`redisson.password`'
+  tower.yml:            '`TOWER_REDIS_PASSWORD`'
   Description: > 
     The password of your Seqera Redis instance.
-  Value:              
+  Value:  


### PR DESCRIPTION
In the next Enterprise version, `redisson.*` properties will be deprecated.

- Replace `/redisson/*` references for the AWS parameter store with `TOWER_REDIS_*`.
- Replace `redisson.*` references for the `tower.yml` with `TOWER_REDIS_*`. Setting `TOWER_REDIS_*` values directly in the YAML file (for example, `TOWER_REDIS_URL: redis://...`) in `tower.yml` is feasible.

In fact, the tweak could be backported to previous versions, as the `TOWER_REDIS_*` placeholders were always the source of truth. I doubt any Enterprise users were setting `redisson.*` properties directly, because the H8 2nd-level cache config doesn't know about them and the application would fail to start if they are not properly set.