### PR TITLE
Disable faster experimental builds to fix previews

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,7 +33,7 @@ export default async function createConfigAsync() {
     },
 
     future: {
-      experimental_faster: true,
+      experimental_faster: false,
     },
 
     presets: [


### PR DESCRIPTION
This breaks local live preview feature.