### PR TITLE
Seqerakit - bash syntax highlighting

### DIFF
--- a/platform_versioned_docs/version-22.4/faqs.mdx
+++ b/platform_versioned_docs/version-22.4/faqs.mdx
@@ -195,7 +195,7 @@ When uploading Datasets via the Tower UI or CLI, some steps are automatically do
 
 Example:
 
-```console
+```bash
 # Step 1: Create the Dataset object
 $ curl -X POST "https://api.cloud.seqera.io/workspaces/$WORKSPACE_ID/datasets/" -H "Content-Type: application/json" -H "Authorization: Bearer $TOWER_ACCESS_TOKEN" --data '{"name":"placeholder", "description":"A placeholder for the data we will submit in the next call"}'
 
@@ -206,7 +206,7 @@ $ curl -X POST "https://api.cloud.seqera.io/workspaces/$WORKSPACE_ID/datasets/$D
 :::tip
 You can also use the [tower-cli](https://github.com/seqeralabs/tower-cli) to upload the dataset to a particular workspace.
 
-    ```console
+    ```bash
     tw datasets add --name "cli_uploaded_samplesheet" ./samplesheet_full.csv
     ```
 

--- a/platform_versioned_docs/version-23.1/faqs.mdx
+++ b/platform_versioned_docs/version-23.1/faqs.mdx
@@ -202,7 +202,7 @@ When uploading Datasets via the Tower UI or CLI, some steps are automatically do
 
 Example:
 
-```console
+```bash
 # Step 1: Create the Dataset object
 $ curl -X POST "https://api.cloud.seqera.io/workspaces/$WORKSPACE_ID/datasets/" -H "Content-Type: application/json" -H "Authorization: Bearer $TOWER_ACCESS_TOKEN" --data '{"name":"placeholder", "description":"A placeholder for the data we will submit in the next call"}'
 
@@ -213,7 +213,7 @@ $ curl -X POST "https://api.cloud.seqera.io/workspaces/$WORKSPACE_ID/datasets/$D
 :::tip
 You can also use the [tower-cli](https://github.com/seqeralabs/tower-cli) to upload the dataset to a particular workspace.
 
-    ```console
+    ```bash
     tw datasets add --name "cli_uploaded_samplesheet" ./samplesheet_full.csv
     ```
 

--- a/platform_versioned_docs/version-23.2/faqs.mdx
+++ b/platform_versioned_docs/version-23.2/faqs.mdx
@@ -202,7 +202,7 @@ When uploading Datasets via the Tower UI or CLI, some steps are automatically do
 
 Example:
 
-```console
+```bash
 # Step 1: Create the Dataset object
 $ curl -X POST "https://api.cloud.seqera.io/workspaces/$WORKSPACE_ID/datasets/" -H "Content-Type: application/json" -H "Authorization: Bearer $TOWER_ACCESS_TOKEN" --data '{"name":"placeholder", "description":"A placeholder for the data we will submit in the next call"}'
 
@@ -213,7 +213,7 @@ $ curl -X POST "https://api.cloud.seqera.io/workspaces/$WORKSPACE_ID/datasets/$D
 :::tip
 You can also use the [tower-cli](https://github.com/seqeralabs/tower-cli) to upload the dataset to a particular workspace.
 
-    ```console
+    ```bash
     tw datasets add --name "cli_uploaded_samplesheet" ./samplesheet_full.csv
     ```
 

--- a/platform_versioned_docs/version-23.3/cli/commands.mdx
+++ b/platform_versioned_docs/version-23.3/cli/commands.mdx
@@ -48,7 +48,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   Platform requires credentials to access your cloud compute environments. See the [compute environment page][compute-envs] for your cloud provider for more information.
 
-    ```console
+    ```bash
     tw credentials add aws --name=my_aws_creds --access-key=<aws access key> --secret-key=<aws secret key>
 
       New AWS credentials 'my_aws_creds (1sxCxvxfx8xnxdxGxQxqxH)' added at user workspace
@@ -58,7 +58,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   Platform requires access credentials to interact with pipeline Git repositories. See [Git integration][git-integration] for more information.
 
-    ```console
+    ```bash
     tw credentials add github -n=my_GH_creds -u=<GitHub username> -p=<GitHub access token>
 
       New GITHUB credentials 'my_GH_creds (xxxxx3prfGlpxxxvR2xxxxo7ow)' added at user workspace
@@ -74,7 +74,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   ### List credentials
 
-  ```console
+  ```bash
   tw credentials list
 
     Credentials at user workspace:
@@ -89,7 +89,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   ### Delete credentials
 
-  ```console
+  ```bash
   tw credentials delete --name=my_aws_creds
 
     Credentials '1sxCxvxfx8xnxdxGxQxqxH' deleted at user workspace
@@ -111,7 +111,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   You must add the credentials for your provider before creating your compute environment.
 
-  ```console
+  ```bash
   tw compute-envs add aws-batch forge --name=my_aws_ce \
   --credentials=<my_aws_creds_1> --region=eu-west-1 --max-cpus=256 \
   --work-dir=s3://<bucket name> --wait=AVAILABLE
@@ -132,7 +132,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   ### Delete a compute environment
 
-  ```console
+  ```bash
   tw compute-envs delete --name=my_aws_ce
 
     Compute environment '1sxCxvxfx8xnxdxGxQxqxH' deleted at user workspace
@@ -142,7 +142,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Select a **primary** compute environment to be used by default in a workspace. You can override the workspace primary compute environment by explicitly specifying an alternative compute environment when you create or launch a pipeline.
 
-  ```console
+  ```bash
   tw compute-envs primary set --name=my_aws_ce
 
     Primary compute environment for workspace 'user' was set to 'my_aws_ce (1sxCxvxfx8xnxdxGxQxqxH)'  
@@ -152,7 +152,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Export the configuration details of a compute environment in JSON format for scripting and reproducibility purposes.
 
-  ```console
+  ```bash
   tw compute-envs export --name=my_aws_ce my_aws_ce_v1.json
 
     Compute environment exported into 'my_aws_ce_v1.json' 
@@ -160,7 +160,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Similarly, a compute environment can be imported to a workspace from a previously exported JSON file.
 
-  ```console
+  ```bash
   tw compute-envs import --name=my_aws_ce_v1 ./my_aws_ce_v1.json
 
     New AWS-BATCH compute environment 'my_aws_ce_v1' added at user workspace
@@ -179,7 +179,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Add a preconfigured dataset file to a workspace (include the `--header` flag if the first row of your samplesheet file is a header):
 
-  ```console
+  ```bash
   tw datasets add --name=samplesheet1 --header samplesheet_test.csv
 
   Dataset 'samplesheet1' added at user workspace with id '60gGrD4I2Gk0TUpEGOj5Td'
@@ -193,7 +193,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To delete a workspace dataset, specify either the dataset name (`-n` flag) or ID (`-i` flag):
 
-  ```console 
+  ```bash 
   tw datasets delete -i 6tYMjGqCUJy6dEXNK9y8kh
 
   Dataset '6tYMjGqCUJy6dEXNK9y8kh' deleted at 97652229034604 workspace
@@ -203,7 +203,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   View a stored dataset's contents: 
 
-  ```console 
+  ```bash 
   tw datasets download -n samplesheet1
 
   sample,fastq_1,fastq_2,strandedness
@@ -220,7 +220,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets list -h` to view the optional fields for listing and filtering datasets.
 
-  ```console 
+  ```bash 
   tw datasets list -f data
 
   Datasets at 97652229034604 workspace:
@@ -234,7 +234,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets view -h` to view the required and optional fields for viewing a stored dataset's details.
 
-  ```console
+  ```bash
   tw datasets view -n samplesheet1
 
   Dataset at 97652229034604 workspace:
@@ -252,7 +252,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets update -h` to view the required and optional fields for updating a dataset.
 
-  ```console 
+  ```bash 
   tw datasets update -n dataset1 --new-name=dataset2 -f samplesheet_test.csv
 
   Dataset 'dataset1' updated at 97652229034604 workspace with id '6vBGj6aWWpBuLpGKjJDpZy'
@@ -262,7 +262,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets url -h` to view the required and optional fields for obtaining dataset URLs.
 
-  ```console 
+  ```bash 
   tw datasets url -n dataset2
 
   Dataset URL
@@ -286,7 +286,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Add a pre-configured pipeline to the Launchpad:
 
-  ```console
+  ```bash
   tw pipelines add --name=my_rnaseq_nf_pipeline \
   --params-file=my_rnaseq_nf_pipeline_params.yaml \
   --config=<path/to/nextflow/conf/file> \
@@ -307,7 +307,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Export the configuration details of a pipeline in JSON format for scripting and reproducibility purposes.
 
-  ```console
+  ```bash
   tw pipelines export --name=my_rnaseq_nf_pipeline my_rnaseq_nf_pipeline_v1.json
 
     Pipeline exported into 'my_rnaseq_nf_pipeline_v1.json' 
@@ -315,7 +315,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Similarly, a pipeline can be imported to a workspace from a previously exported JSON file.
 
-  ```console
+  ```bash
   tw pipelines import --name=my_rnaseq_nf_pipeline_v1 ./my_rnaseq_nf_pipeline_v1.json
 
     New pipeline 'my_rnaseq_nf_pipeline_v1' added at user workspace
@@ -325,7 +325,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   The default launch parameters can be changed with the `update` command:
 
-  ```console
+  ```bash
   tw pipelines update --name=my_rnaseq_nf_pipeline \
   --params-file=my_rnaseq_nf_pipeline_params_2.yaml
   ```
@@ -343,7 +343,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   tw CLI users are bound to the same user permissions that apply in the Platform UI. Launch users can launch pre-configured pipelines in the workspaces they have access to, but they cannot add or run new pipelines.
   :::
 
-  ```console
+  ```bash
   tw launch my_rnaseq_nf_pipeline \
   --config=<path/to/nextflow/conf/file> \
 
@@ -368,7 +368,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To specify custom parameters during pipeline launch, specify a custom `--params-file`:
 
-  ```console
+  ```bash
   tw launch my_rnaseq_nf_pipeline --params-file=my_rnaseq_nf_pipeline_params_2.yaml
 
     Workflow 2XDXxX0vCX8xhx submitted at user workspace.
@@ -382,7 +382,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   The CLI can directly launch pipelines that have not been added to the Launchpad in a Platform workspace by using the full pipeline repository URL:
 
-  ```console
+  ```bash
   tw launch https://github.com/nf-core/rnaseq \
   --params-file=./custom_rnaseq_params.yaml \
   --config=<path/to/nextflow/conf/file> \
@@ -422,7 +422,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw runs view -h` to view all the required and optional fields for viewing a pipeline's runs.
 
-  ```console
+  ```bash
   tw runs view -i 2vFUbBx63cfsBY -w seqeralabs/showcase
 
     Run at [seqeralabs / showcase] workspace:
@@ -450,7 +450,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw runs list -h` to view all the required and optional fields for listing runs in a workspace.
 
-  ```console
+  ```bash
   tw runs list
 
     Pipeline runs at [seqeralabs / testing] workspace:
@@ -486,7 +486,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   The `after` and `before` flags require an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp with UTC timezone (`YYYY-MM-DDThh:mm:ss.sssZ`).
   :::
 
-  ```console
+  ```bash
   tw runs list --filter hello_slurm_20240530
 
     Pipeline runs at [seqeralabs / showcase] workspace:
@@ -498,7 +498,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Multiple filter criteria can be defined:
 
-  ```console
+  ```bash
   tw runs list --filter="after:2024-05-29T00:00:00.000Z before:2024-05-30T00:00:00.000Z username:user1"
 
     Pipeline runs at [seqeralabs / testing] workspace:
@@ -517,7 +517,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   A leading and trailing `*` wildcard character is supported:
 
-  ```console
+  ```bash
   tw runs list --filter="*man/rnaseq-*"    
 
     Pipeline runs at [seqeralabs / testing] workspace:
@@ -547,7 +547,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   In the example below, we add the labels `test` and `rnaseq-demo` to the run with ID `5z4AMshti4g0GK`:
 
-  ```console
+  ```bash
   tw runs labels -i 5z4AMshti4g0GK test,rnaseq-demo 
 
   'set' labels on 'run' with id '5z4AMshti4g0GK' at 34830707738561 workspace
@@ -561,7 +561,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw runs dump -h` to view all the required and optional fields for dumping all logs and details of a run in a workspace. The supported formats are `.tar.xz` and `.tar.gz`. In the example below, we dump all the logs and details for the run with ID `5z4AMshti4g0GK` to the output file `file.tar.gz`.
 
-  ```console
+  ```bash
   tw runs dump -i 5z4AMshti4g0GK -o file.tar.gz
   - Tower info
   - Workflow details
@@ -587,7 +587,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   [Labels](../labels/overview.mdx) require only a name. 
   ::: 
 
-  ```console
+  ```bash
   tw labels add -n Label1 -w DocTestOrg2/Testing -v Value1
 
   Label 'Label1=Value1' added at 'DocTestOrg2/Testing' workspace with id '268741348267491'
@@ -597,7 +597,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw labels list -h` to view the optional fields for filtering labels. 
 
-  ```console
+  ```bash
   tw labels list
 
   Labels at 97652229034604 workspace:
@@ -620,7 +620,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw labels delete -h` to view the required and optional fields for deleting labels. 
 
-    ```console
+    ```bash
     tw labels delete -i 203879852150462
 
     Label '203879852150462' deleted at '97652229034604' workspace
@@ -649,7 +649,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   - `v1-cloud-<id>`: Cloud data links auto-discovered using credentials attached to the workspace.
   - `v1-user-<id>`: Custom data links created by users.
 
-  ```console
+  ```bash
   tw data-links list -w seqeralabs/showcase
 
   Data links at [seqeralabs / showcase] workspace:
@@ -676,7 +676,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   
   Users with the workspace `MAINTAIN` role and above can add custom data links. The data link `name`, `uri`, and `provider` (`aws`, `azure`, or `google`) fields are required. If adding a custom data link for a private bucket, the credentials identifier field is also required. Adding a custom data link for a public bucket doesn't require credentials.
 
-  ```console
+  ```bash
   tw data-links add -w seqeralabs/showcase -n FOO -u az://seqeralabs.azure-benchmarking \
   -p azure -c seqera_azure_credentials
 
@@ -691,7 +691,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw data-links update -h` to view all the required and optional fields for updating a custom data link in a workspace. Users with the `MAINTAIN` role and above for a workspace can update custom data links.
 
-  ```console
+  ```bash
   tw data-links update -w seqeralabs/showcase -i v1-user-152116183ee325463901430bb9efb8c9 -n BAR
 
   Data link updated:
@@ -707,7 +707,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   
   Users with the `MAINTAIN` role and above for a workspace can delete custom data links.
 
-  ```console 
+  ```bash 
   tw data-links delete -w seqeralabs/showcase -i v1-user-152116183ee325463901430bb9efb8c9
 
   Data link 'v1-user-152116183ee325463901430bb9efb8c9' deleted at '138659136604200' workspace.
@@ -719,7 +719,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   
   Define the data link ID using the required `-i` or `--id` argument, which can be found by first using the list operation for a workspace. In the example below, a name is defined to only retrieve data links with names that start with the given word:
 
-  ```console 
+  ```bash 
   tw data-links list -w seqeralabs/showcase -n 1000genomes
 
   Data links at [seqeralabs / showcase] workspace:
@@ -780,7 +780,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw organizations add -h` to view the required and optional fields for adding your workspace.
 
-  ```console 
+  ```bash 
   tw organizations add -n TestOrg2 -f 2nd\ Test\ Organization\ LLC -l RSA
 
   Organization 'TestOrg2' with ID '204336622618177' was added
@@ -798,7 +798,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw members list -h` view all the optional fields for listing organization members.
 
-  ```console
+  ```bash
   tw members list -o TestOrg2
 
   Members for TestOrg2 organization:
@@ -815,7 +815,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw members add -h` view all the required and optional fields for adding organization members.
 
-  ```console
+  ```bash
   tw members add -u user1@domain.com -o DocTestOrg2
 
   Member 'user1' with ID '134534064600266' was added in organization 'TestOrg2'
@@ -825,7 +825,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
     Run `tw members delete -h` view all the required and optional fields for deleting organization members.
 
-    ```console
+    ```bash
     tw members delete -u user1 -o TestOrg2
 
     Member 'user1' deleted from organization 'TestOrg2'
@@ -835,7 +835,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw members update -h` view all the required and optional fields for updating organization members.
 
-  ```console 
+  ```bash 
   tw members update -u user1 -r OWNER -o TestOrg2
 
   Member 'user1' updated to role 'owner' in organization 'TestOrg2'
@@ -865,7 +865,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   In the example below, we create a shared workspace to be used for sharing pipelines with other private workspaces. See [Shared workspaces][shared-workspaces] for more information.
 
-  ```console
+  ```bash
   tw workspaces add --name=shared-workspace --full-name=shared-workspace-for-all  --org=my-tower-org --visibility=SHARED
 
     A 'SHARED' workspace 'shared-workspace' added for 'my-tower-org' organization
@@ -879,7 +879,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   List all the workspaces in which you are a participant:
 
-  ```console
+  ```bash
   tw workspaces list                      
 
     Workspaces for default user:
@@ -903,7 +903,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   ### List participants
 
-  ```console
+  ```bash
   tw participants list
 
     Participants for 'my-tower-org/shared-workspace' workspace:
@@ -921,7 +921,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   See [Participant roles][participant-roles] for more information.
 
-  ```console
+  ```bash
   tw participants add --name=collaborator@mydomain.com --type=MEMBER                           
 
     User 'collaborator' was added as participant to 'shared-workspace' workspace with role 'launch'
@@ -931,7 +931,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To update the role of a _Collaborator_ to `ADMIN` or `MAINTAIN`, use the `update` subcommand:
 
-  ```console
+  ```bash
   tw  participants update --name=collaborator@mydomain.com --type=COLLABORATOR --role=MAINTAIN
 
     Participant 'collaborator@mydomain.com' has now role 'maintain' for workspace 'shared-workspace'
@@ -953,7 +953,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw teams list -h` to view the required and optional fields for listing teams. 
 
-  ```console
+  ```bash
   tw teams list -o TestOrg2
 
   Teams for TestOrg2 organization:
@@ -967,7 +967,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw teams add -h` to view the required and optional fields for creating a team. 
 
-  ```console 
+  ```bash 
   tw teams add -n team1 -o TestOrg2 -d testing
 
   A 'team1' team added for 'TestOrg2' organization
@@ -975,7 +975,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   ### Delete a team 
 
-  ```console 
+  ```bash 
   tw teams delete -i 169283393825479 -o TestOrg2
 
   Team '169283393825479' deleted for TestOrg2 organization
@@ -987,7 +987,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To add a new team member, include an existing username or new user email:
 
-  ```console 
+  ```bash 
   tw teams members -t Testing -o TestOrg2 add -m user1@domain.com
 
   Member 'user1' added to team 'Testing' with id '243206491381406'
@@ -995,7 +995,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To delete a team member, include the member's username:
 
-  ```console 
+  ```bash 
   tw teams members -t Testing -o TestOrg2 delete -m user1
 
   Team member 'user1' deleted at 'Testing' team
@@ -1011,7 +1011,7 @@ Run `tw collaborators -h` view all the required and optional fields for managing
 
   ### List collaborators
 
-  ```console
+  ```bash
   tw collaborators list -o seqeralabs
 
   Collaborators for 88848180287xxx organization:

--- a/platform_versioned_docs/version-23.3/cli/installation.mdx
+++ b/platform_versioned_docs/version-23.3/cli/installation.mdx
@@ -59,7 +59,7 @@ Find your `TOWER_WORKSPACE_ID` from the **Workspaces** tab on your organization 
 
 Confirm the installation, configuration, and connection:
 
-```console
+```bash
 tw info
 
     Details
@@ -141,7 +141,7 @@ tw CLI is a platform binary executable created by a native compilation from Java
 
     This will install a locally compiled version of `tw` in the nativeCompile directory:
 
-    ```console
+    ```bash
     Produced artifacts:
      <tower-cli-repository-root>/build/native/nativeCompile/tw (executable)
     ========================================================================================================================

--- a/platform_versioned_docs/version-23.3/enterprise/prerequisites/aws.mdx
+++ b/platform_versioned_docs/version-23.3/enterprise/prerequisites/aws.mdx
@@ -115,7 +115,7 @@ See [Creating an Amazon RDS DB instance](https://docs.aws.amazon.com/AmazonRDS/l
 
 To create a DB instance with the AWS CLI, call the [create-db-instance](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html) command, replacing `INSTANCE_NAME`, `SECURITY_GROUP`, `DB_USER`, and `DB_PASSWORD` with your unique values:
 
-```console
+```bash
 aws rds create-db-instance \
     --engine mysql \ 
     --db-instance-identifier INSTANCE_NAME \

--- a/platform_versioned_docs/version-23.3/enterprise/prerequisites/azure.mdx
+++ b/platform_versioned_docs/version-23.3/enterprise/prerequisites/azure.mdx
@@ -59,7 +59,7 @@ Create a resource group:
 
   Run the `az group create` command:
 
-  ```console
+  ```bash
   az group create --name $MY_RESOURCE_GROUP_NAME --location $REGION
   ```
 
@@ -93,7 +93,7 @@ Create a storage account:
 
   Run the `az storage account create` command:
 
-  ```console
+  ```bash
   az storage account create -n towerstorage -g towerrg -l eastus --sku Standard_GRS
   ```
 
@@ -141,7 +141,7 @@ Create an Azure MySQL DB instance:
 
   1. Run `az mysql flexible-server create` to create your server:
 
-      ```console
+      ```bash
       az mysql flexible-server create --location eastus --resource-group towerrg --name towerdbserver --admin-user username --admin-password password --sku-name Standard_B2ms --tier Burstable --public-access 0.0.0.0 --storage-size 30 --version 8.0 --high-availability ZoneRedundant --zone 1 --standby-zone 3 --storage-auto-grow Enabled --iops 500
       ```
 
@@ -149,7 +149,7 @@ Create an Azure MySQL DB instance:
 
   1. Run `az mysql flexible-server db create` to create a database on your server:
 
-      ```console 
+      ```bash 
       az mysql flexible-server db create --resource-group towerrg
                                       --server-name towerdbserver
                                       --database-name towerdb
@@ -242,7 +242,7 @@ Create an Azure Linux VM:
 
   Run `az vm create`:
 
-  ```console 
+  ```bash 
   az vm create \
     --resource-group towerrg \
     --name towervm \

--- a/platform_versioned_docs/version-23.3/enterprise/prerequisites/gcp.mdx
+++ b/platform_versioned_docs/version-23.3/enterprise/prerequisites/gcp.mdx
@@ -72,7 +72,7 @@ The recommended machine type and storage requirements depend on the number of pa
 See [Create a MySQL instance][gcloudsql-create] for gcloud CLI instructions.
 
 1. Create your MySQL instance with the following command:
-    ```console 
+    ```bash 
     gcloud sql instances create INSTANCE_NAME \
     --database-version=MYSQL_8_0 \
     --cpu=2 \
@@ -82,14 +82,14 @@ See [Create a MySQL instance][gcloudsql-create] for gcloud CLI instructions.
     ```
 1. Note the private IP address as it must be supplied to the `TOWER_DB_URL` environment variable during Seqera configuration. 
 1. Set the password for the root MySQL user:
-    ```console
+    ```bash
     gcloud sql users set-password root \
     --host=% \
     --instance INSTANCE_NAME \
     --password PASSWORD
     ```
 1. Create a database named `tower` on the instance: 
-    ```console 
+    ```bash 
     gcloud sql databases create tower \
     --instance=INSTANCE_NAME \
     ```

--- a/platform_versioned_docs/version-23.3/faqs.mdx
+++ b/platform_versioned_docs/version-23.3/faqs.mdx
@@ -149,7 +149,7 @@ When uploading datasets via the Seqera UI or CLI, some steps are automatically d
 
 Example:
 
-```console
+```bash
 # Step 1: Create the dataset object.
 $ curl -X POST "https://api.cloud.seqera.io/workspaces/$WORKSPACE_ID/datasets/" -H "Content-Type: application/json" -H "Authorization: Bearer $TOWER_ACCESS_TOKEN" --data '{"name":"placeholder", "description":"A placeholder for the data we will submit in the next call"}'
 
@@ -160,7 +160,7 @@ $ curl -X POST "https://api.cloud.seqera.io/workspaces/$WORKSPACE_ID/datasets/$D
 :::tip
 You can also use the [tower-cli](https://github.com/seqeralabs/tower-cli) to upload the dataset to a particular workspace:
 
-    ```console
+    ```bash
     tw datasets add --name "cli_uploaded_samplesheet" ./samplesheet_full.csv
     ```
 

--- a/platform_versioned_docs/version-23.3/seqerakit/installation.mdx
+++ b/platform_versioned_docs/version-23.3/seqerakit/installation.mdx
@@ -26,13 +26,13 @@ Seqerakit has three dependencies:
 
 If you already have [Platform CLI](../cli/installation.mdx) and Python installed on your system, install Seqerakit directly from [PyPI](https://pypi.org/project/seqerakit/):
 
-```console
+```bash
 pip install seqerakit
 ```
 
 Overwrite an existing installation to use the latest version:
 
-```console
+```bash
 pip install --upgrade --force-reinstall seqerakit
 ```
 
@@ -40,7 +40,7 @@ pip install --upgrade --force-reinstall seqerakit
 
 To install `seqerakit` and its dependencies via Conda, first configure the correct channels:
 
-```console
+```bash
 conda config --add channels bioconda
 conda config --add channels conda-forge
 conda config --set channel_priority strict
@@ -48,7 +48,7 @@ conda config --set channel_priority strict
 
 Then create a conda environment with `seqerakit` installed:
 
-```console
+```bash
 conda env create -n seqerakit seqerakit
 conda activate seqerakit
 ```

--- a/platform_versioned_docs/version-23.4/cli/commands.mdx
+++ b/platform_versioned_docs/version-23.4/cli/commands.mdx
@@ -48,7 +48,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   Platform requires credentials to access your cloud compute environments. See the [compute environment page][compute-envs] for your cloud provider for more information.
 
-    ```console
+    ```bash
     tw credentials add aws --name=my_aws_creds --access-key=<aws access key> --secret-key=<aws secret key>
 
       New AWS credentials 'my_aws_creds (1sxCxvxfx8xnxdxGxQxqxH)' added at user workspace
@@ -58,7 +58,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   Platform requires access credentials to interact with pipeline Git repositories. See [Git integration][git-integration] for more information.
 
-    ```console
+    ```bash
     tw credentials add github -n=my_GH_creds -u=<GitHub username> -p=<GitHub access token>
 
       New GITHUB credentials 'my_GH_creds (xxxxx3prfGlpxxxvR2xxxxo7ow)' added at user workspace
@@ -74,7 +74,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   ### List credentials
 
-  ```console
+  ```bash
   tw credentials list
 
     Credentials at user workspace:
@@ -89,7 +89,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   ### Delete credentials
 
-  ```console
+  ```bash
   tw credentials delete --name=my_aws_creds
 
     Credentials '1sxCxvxfx8xnxdxGxQxqxH' deleted at user workspace
@@ -111,7 +111,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   You must add the credentials for your provider before creating your compute environment.
 
-  ```console
+  ```bash
   tw compute-envs add aws-batch forge --name=my_aws_ce \
   --credentials=<my_aws_creds_1> --region=eu-west-1 --max-cpus=256 \
   --work-dir=s3://<bucket name> --wait=AVAILABLE
@@ -132,7 +132,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   ### Delete a compute environment
 
-  ```console
+  ```bash
   tw compute-envs delete --name=my_aws_ce
 
     Compute environment '1sxCxvxfx8xnxdxGxQxqxH' deleted at user workspace
@@ -142,7 +142,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Select a **primary** compute environment to be used by default in a workspace. You can override the workspace primary compute environment by explicitly specifying an alternative compute environment when you create or launch a pipeline.
 
-  ```console
+  ```bash
   tw compute-envs primary set --name=my_aws_ce
 
     Primary compute environment for workspace 'user' was set to 'my_aws_ce (1sxCxvxfx8xnxdxGxQxqxH)'  
@@ -152,7 +152,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Export the configuration details of a compute environment in JSON format for scripting and reproducibility purposes.
 
-  ```console
+  ```bash
   tw compute-envs export --name=my_aws_ce my_aws_ce_v1.json
 
     Compute environment exported into 'my_aws_ce_v1.json' 
@@ -160,7 +160,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Similarly, a compute environment can be imported to a workspace from a previously exported JSON file.
 
-  ```console
+  ```bash
   tw compute-envs import --name=my_aws_ce_v1 ./my_aws_ce_v1.json
 
     New AWS-BATCH compute environment 'my_aws_ce_v1' added at user workspace
@@ -179,7 +179,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Add a preconfigured dataset file to a workspace (include the `--header` flag if the first row of your samplesheet file is a header):
 
-  ```console
+  ```bash
   tw datasets add --name=samplesheet1 --header samplesheet_test.csv
 
   Dataset 'samplesheet1' added at user workspace with id '60gGrD4I2Gk0TUpEGOj5Td'
@@ -193,7 +193,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To delete a workspace dataset, specify either the dataset name (`-n` flag) or ID (`-i` flag):
 
-  ```console 
+  ```bash 
   tw datasets delete -i 6tYMjGqCUJy6dEXNK9y8kh
 
   Dataset '6tYMjGqCUJy6dEXNK9y8kh' deleted at 97652229034604 workspace
@@ -203,7 +203,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   View a stored dataset's contents: 
 
-  ```console 
+  ```bash 
   tw datasets download -n samplesheet1
 
   sample,fastq_1,fastq_2,strandedness
@@ -220,7 +220,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets list -h` to view the optional fields for listing and filtering datasets.
 
-  ```console 
+  ```bash 
   tw datasets list -f data
 
   Datasets at 97652229034604 workspace:
@@ -234,7 +234,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets view -h` to view the required and optional fields for viewing a stored dataset's details.
 
-  ```console
+  ```bash
   tw datasets view -n samplesheet1
 
   Dataset at 97652229034604 workspace:
@@ -252,7 +252,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets update -h` to view the required and optional fields for updating a dataset.
 
-  ```console 
+  ```bash 
   tw datasets update -n dataset1 --new-name=dataset2 -f samplesheet_test.csv
 
   Dataset 'dataset1' updated at 97652229034604 workspace with id '6vBGj6aWWpBuLpGKjJDpZy'
@@ -262,7 +262,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets url -h` to view the required and optional fields for obtaining dataset URLs.
 
-  ```console 
+  ```bash 
   tw datasets url -n dataset2
 
   Dataset URL
@@ -286,7 +286,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Add a pre-configured pipeline to the Launchpad:
 
-  ```console
+  ```bash
   tw pipelines add --name=my_rnaseq_nf_pipeline \
   --params-file=my_rnaseq_nf_pipeline_params.yaml \
   --config=<path/to/nextflow/conf/file> \
@@ -307,7 +307,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Export the configuration details of a pipeline in JSON format for scripting and reproducibility purposes.
 
-  ```console
+  ```bash
   tw pipelines export --name=my_rnaseq_nf_pipeline my_rnaseq_nf_pipeline_v1.json
 
     Pipeline exported into 'my_rnaseq_nf_pipeline_v1.json' 
@@ -315,7 +315,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Similarly, a pipeline can be imported to a workspace from a previously exported JSON file.
 
-  ```console
+  ```bash
   tw pipelines import --name=my_rnaseq_nf_pipeline_v1 ./my_rnaseq_nf_pipeline_v1.json
 
     New pipeline 'my_rnaseq_nf_pipeline_v1' added at user workspace
@@ -325,7 +325,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   The default launch parameters can be changed with the `update` command:
 
-  ```console
+  ```bash
   tw pipelines update --name=my_rnaseq_nf_pipeline \
   --params-file=my_rnaseq_nf_pipeline_params_2.yaml
   ```
@@ -343,7 +343,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   tw CLI users are bound to the same user permissions that apply in the Platform UI. Launch users can launch pre-configured pipelines in the workspaces they have access to, but they cannot add or run new pipelines.
   :::
 
-  ```console
+  ```bash
   tw launch my_rnaseq_nf_pipeline \
   --config=<path/to/nextflow/conf/file> \
 
@@ -368,7 +368,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To specify custom parameters during pipeline launch, specify a custom `--params-file`:
 
-  ```console
+  ```bash
   tw launch my_rnaseq_nf_pipeline --params-file=my_rnaseq_nf_pipeline_params_2.yaml
 
     Workflow 2XDXxX0vCX8xhx submitted at user workspace.
@@ -382,7 +382,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   The CLI can directly launch pipelines that have not been added to the Launchpad in a Platform workspace by using the full pipeline repository URL:
 
-  ```console
+  ```bash
   tw launch https://github.com/nf-core/rnaseq \
   --params-file=./custom_rnaseq_params.yaml \
   --config=<path/to/nextflow/conf/file> \
@@ -422,7 +422,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw runs view -h` to view all the required and optional fields for viewing a pipeline's runs.
 
-  ```console
+  ```bash
   tw runs view -i 2vFUbBx63cfsBY -w seqeralabs/showcase
 
     Run at [seqeralabs / showcase] workspace:
@@ -450,7 +450,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw runs list -h` to view all the required and optional fields for listing runs in a workspace.
 
-  ```console
+  ```bash
   tw runs list
 
     Pipeline runs at [seqeralabs / testing] workspace:
@@ -486,7 +486,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   The `after` and `before` flags require an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp with UTC timezone (`YYYY-MM-DDThh:mm:ss.sssZ`).
   :::
 
-  ```console
+  ```bash
   tw runs list --filter hello_slurm_20240530
 
     Pipeline runs at [seqeralabs / showcase] workspace:
@@ -498,7 +498,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Multiple filter criteria can be defined:
 
-  ```console
+  ```bash
   tw runs list --filter="after:2024-05-29T00:00:00.000Z before:2024-05-30T00:00:00.000Z username:user1"
 
     Pipeline runs at [seqeralabs / testing] workspace:
@@ -517,7 +517,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   A leading and trailing `*` wildcard character is supported:
 
-  ```console
+  ```bash
   tw runs list --filter="*man/rnaseq-*"    
 
     Pipeline runs at [seqeralabs / testing] workspace:
@@ -547,7 +547,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   In the example below, we add the labels `test` and `rnaseq-demo` to the run with ID `5z4AMshti4g0GK`:
 
-  ```console
+  ```bash
   tw runs labels -i 5z4AMshti4g0GK test,rnaseq-demo 
 
   'set' labels on 'run' with id '5z4AMshti4g0GK' at 34830707738561 workspace
@@ -561,7 +561,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw runs dump -h` to view all the required and optional fields for dumping all logs and details of a run in a workspace. The supported formats are `.tar.xz` and `.tar.gz`. In the example below, we dump all the logs and details for the run with ID `5z4AMshti4g0GK` to the output file `file.tar.gz`.
 
-  ```console
+  ```bash
   tw runs dump -i 5z4AMshti4g0GK -o file.tar.gz
   - Tower info
   - Workflow details
@@ -587,7 +587,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   [Labels](../labels/overview.mdx) require only a name. 
   ::: 
 
-  ```console
+  ```bash
   tw labels add -n Label1 -w DocTestOrg2/Testing -v Value1
 
   Label 'Label1=Value1' added at 'DocTestOrg2/Testing' workspace with id '268741348267491'
@@ -597,7 +597,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw labels list -h` to view the optional fields for filtering labels. 
 
-  ```console
+  ```bash
   tw labels list
 
   Labels at 97652229034604 workspace:
@@ -620,7 +620,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw labels delete -h` to view the required and optional fields for deleting labels. 
 
-    ```console
+    ```bash
     tw labels delete -i 203879852150462
 
     Label '203879852150462' deleted at '97652229034604' workspace
@@ -649,7 +649,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   - `v1-cloud-<id>`: Cloud data links auto-discovered using credentials attached to the workspace.
   - `v1-user-<id>`: Custom data links created by users.
 
-  ```console
+  ```bash
   tw data-links list -w seqeralabs/showcase
 
   Data links at [seqeralabs / showcase] workspace:
@@ -676,7 +676,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   
   Users with the workspace `MAINTAIN` role and above can add custom data links. The data link `name`, `uri`, and `provider` (`aws`, `azure`, or `google`) fields are required. If adding a custom data link for a private bucket, the credentials identifier field is also required. Adding a custom data link for a public bucket doesn't require credentials.
 
-  ```console
+  ```bash
   tw data-links add -w seqeralabs/showcase -n FOO -u az://seqeralabs.azure-benchmarking \
   -p azure -c seqera_azure_credentials
 
@@ -691,7 +691,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw data-links update -h` to view all the required and optional fields for updating a custom data link in a workspace. Users with the `MAINTAIN` role and above for a workspace can update custom data links.
 
-  ```console
+  ```bash
   tw data-links update -w seqeralabs/showcase -i v1-user-152116183ee325463901430bb9efb8c9 -n BAR
 
   Data link updated:
@@ -707,7 +707,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   
   Users with the `MAINTAIN` role and above for a workspace can delete custom data links.
 
-  ```console 
+  ```bash 
   tw data-links delete -w seqeralabs/showcase -i v1-user-152116183ee325463901430bb9efb8c9
 
   Data link 'v1-user-152116183ee325463901430bb9efb8c9' deleted at '138659136604200' workspace.
@@ -719,7 +719,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   
   Define the data link ID using the required `-i` or `--id` argument, which can be found by first using the list operation for a workspace. In the example below, a name is defined to only retrieve data links with names that start with the given word:
 
-  ```console 
+  ```bash 
   tw data-links list -w seqeralabs/showcase -n 1000genomes
 
   Data links at [seqeralabs / showcase] workspace:
@@ -780,7 +780,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw organizations add -h` to view the required and optional fields for adding your workspace.
 
-  ```console 
+  ```bash 
   tw organizations add -n TestOrg2 -f 2nd\ Test\ Organization\ LLC -l RSA
 
   Organization 'TestOrg2' with ID '204336622618177' was added
@@ -798,7 +798,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw members list -h` view all the optional fields for listing organization members.
 
-  ```console
+  ```bash
   tw members list -o TestOrg2
 
   Members for TestOrg2 organization:
@@ -815,7 +815,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw members add -h` view all the required and optional fields for adding organization members.
 
-  ```console
+  ```bash
   tw members add -u user1@domain.com -o DocTestOrg2
 
   Member 'user1' with ID '134534064600266' was added in organization 'TestOrg2'
@@ -825,7 +825,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
     Run `tw members delete -h` view all the required and optional fields for deleting organization members.
 
-    ```console
+    ```bash
     tw members delete -u user1 -o TestOrg2
 
     Member 'user1' deleted from organization 'TestOrg2'
@@ -835,7 +835,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw members update -h` view all the required and optional fields for updating organization members.
 
-  ```console 
+  ```bash 
   tw members update -u user1 -r OWNER -o TestOrg2
 
   Member 'user1' updated to role 'owner' in organization 'TestOrg2'
@@ -865,7 +865,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   In the example below, we create a shared workspace to be used for sharing pipelines with other private workspaces. See [Shared workspaces][shared-workspaces] for more information.
 
-  ```console
+  ```bash
   tw workspaces add --name=shared-workspace --full-name=shared-workspace-for-all  --org=my-tower-org --visibility=SHARED
 
     A 'SHARED' workspace 'shared-workspace' added for 'my-tower-org' organization
@@ -879,7 +879,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   List all the workspaces in which you are a participant:
 
-  ```console
+  ```bash
   tw workspaces list                      
 
     Workspaces for default user:
@@ -903,7 +903,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   ### List participants
 
-  ```console
+  ```bash
   tw participants list
 
     Participants for 'my-tower-org/shared-workspace' workspace:
@@ -921,7 +921,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   See [Participant roles][participant-roles] for more information.
 
-  ```console
+  ```bash
   tw participants add --name=collaborator@mydomain.com --type=MEMBER                           
 
     User 'collaborator' was added as participant to 'shared-workspace' workspace with role 'launch'
@@ -931,7 +931,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To update the role of a _Collaborator_ to `ADMIN` or `MAINTAIN`, use the `update` subcommand:
 
-  ```console
+  ```bash
   tw  participants update --name=collaborator@mydomain.com --type=COLLABORATOR --role=MAINTAIN
 
     Participant 'collaborator@mydomain.com' has now role 'maintain' for workspace 'shared-workspace'
@@ -953,7 +953,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw teams list -h` to view the required and optional fields for listing teams. 
 
-  ```console
+  ```bash
   tw teams list -o TestOrg2
 
   Teams for TestOrg2 organization:
@@ -967,7 +967,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw teams add -h` to view the required and optional fields for creating a team. 
 
-  ```console 
+  ```bash 
   tw teams add -n team1 -o TestOrg2 -d testing
 
   A 'team1' team added for 'TestOrg2' organization
@@ -975,7 +975,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   ### Delete a team 
 
-  ```console 
+  ```bash 
   tw teams delete -i 169283393825479 -o TestOrg2
 
   Team '169283393825479' deleted for TestOrg2 organization
@@ -987,7 +987,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To add a new team member, include an existing username or new user email:
 
-  ```console 
+  ```bash 
   tw teams members -t Testing -o TestOrg2 add -m user1@domain.com
 
   Member 'user1' added to team 'Testing' with id '243206491381406'
@@ -995,7 +995,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To delete a team member, include the member's username:
 
-  ```console 
+  ```bash 
   tw teams members -t Testing -o TestOrg2 delete -m user1
 
   Team member 'user1' deleted at 'Testing' team
@@ -1011,7 +1011,7 @@ Run `tw collaborators -h` view all the required and optional fields for managing
 
   ### List collaborators
 
-  ```console
+  ```bash
   tw collaborators list -o seqeralabs
 
   Collaborators for 88848180287xxx organization:

--- a/platform_versioned_docs/version-23.4/cli/installation.mdx
+++ b/platform_versioned_docs/version-23.4/cli/installation.mdx
@@ -59,7 +59,7 @@ Find your `TOWER_WORKSPACE_ID` from the **Workspaces** tab on your organization 
 
 Confirm the installation, configuration, and connection:
 
-```console
+```bash
 tw info
 
     Details
@@ -141,7 +141,7 @@ tw CLI is a platform binary executable created by a native compilation from Java
 
     This will install a locally compiled version of `tw` in the nativeCompile directory:
 
-    ```console
+    ```bash
     Produced artifacts:
      <tower-cli-repository-root>/build/native/nativeCompile/tw (executable)
     ========================================================================================================================

--- a/platform_versioned_docs/version-23.4/enterprise/prerequisites/aws.mdx
+++ b/platform_versioned_docs/version-23.4/enterprise/prerequisites/aws.mdx
@@ -115,7 +115,7 @@ See [Creating an Amazon RDS DB instance](https://docs.aws.amazon.com/AmazonRDS/l
 
 To create a DB instance with the AWS CLI, call the [create-db-instance](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html) command, replacing `INSTANCE_NAME`, `SECURITY_GROUP`, `DB_USER`, and `DB_PASSWORD` with your unique values:
 
-```console
+```bash
 aws rds create-db-instance \
     --engine mysql \ 
     --db-instance-identifier INSTANCE_NAME \

--- a/platform_versioned_docs/version-23.4/enterprise/prerequisites/azure.mdx
+++ b/platform_versioned_docs/version-23.4/enterprise/prerequisites/azure.mdx
@@ -59,7 +59,7 @@ Create a resource group:
 
   Run the `az group create` command:
 
-  ```console
+  ```bash
   az group create --name $MY_RESOURCE_GROUP_NAME --location $REGION
   ```
 
@@ -93,7 +93,7 @@ Create a storage account:
 
   Run the `az storage account create` command:
 
-  ```console
+  ```bash
   az storage account create -n towerstorage -g towerrg -l eastus --sku Standard_GRS
   ```
 
@@ -141,7 +141,7 @@ Create an Azure MySQL DB instance:
 
   1. Run `az mysql flexible-server create` to create your server:
 
-      ```console
+      ```bash
       az mysql flexible-server create --location eastus --resource-group towerrg --name towerdbserver --admin-user username --admin-password password --sku-name Standard_B2ms --tier Burstable --public-access 0.0.0.0 --storage-size 30 --version 8.0 --high-availability ZoneRedundant --zone 1 --standby-zone 3 --storage-auto-grow Enabled --iops 500
       ```
 
@@ -149,7 +149,7 @@ Create an Azure MySQL DB instance:
 
   1. Run `az mysql flexible-server db create` to create a database on your server:
 
-      ```console 
+      ```bash 
       az mysql flexible-server db create --resource-group towerrg
                                       --server-name towerdbserver
                                       --database-name towerdb
@@ -242,7 +242,7 @@ Create an Azure Linux VM:
 
   Run `az vm create`:
 
-  ```console 
+  ```bash 
   az vm create \
     --resource-group towerrg \
     --name towervm \

--- a/platform_versioned_docs/version-23.4/enterprise/prerequisites/gcp.mdx
+++ b/platform_versioned_docs/version-23.4/enterprise/prerequisites/gcp.mdx
@@ -72,7 +72,7 @@ The recommended machine type and storage requirements depend on the number of pa
 See [Create a MySQL instance][gcloudsql-create] for gcloud CLI instructions.
 
 1. Create your MySQL instance with the following command:
-    ```console 
+    ```bash 
     gcloud sql instances create INSTANCE_NAME \
     --database-version=MYSQL_8_0 \
     --cpu=2 \
@@ -82,14 +82,14 @@ See [Create a MySQL instance][gcloudsql-create] for gcloud CLI instructions.
     ```
 1. Note the private IP address as it must be supplied to the `TOWER_DB_URL` environment variable during Seqera configuration. 
 1. Set the password for the root MySQL user:
-    ```console
+    ```bash
     gcloud sql users set-password root \
     --host=% \
     --instance INSTANCE_NAME \
     --password PASSWORD
     ```
 1. Create a database named `tower` on the instance: 
-    ```console 
+    ```bash 
     gcloud sql databases create tower \
     --instance=INSTANCE_NAME \
     ```

--- a/platform_versioned_docs/version-23.4/faqs.mdx
+++ b/platform_versioned_docs/version-23.4/faqs.mdx
@@ -149,7 +149,7 @@ When uploading datasets via the Seqera UI or CLI, some steps are automatically d
 
 Example:
 
-```console
+```bash
 # Step 1: Create the dataset object.
 $ curl -X POST "https://api.cloud.seqera.io/workspaces/$WORKSPACE_ID/datasets/" -H "Content-Type: application/json" -H "Authorization: Bearer $TOWER_ACCESS_TOKEN" --data '{"name":"placeholder", "description":"A placeholder for the data we will submit in the next call"}'
 
@@ -160,7 +160,7 @@ $ curl -X POST "https://api.cloud.seqera.io/workspaces/$WORKSPACE_ID/datasets/$D
 :::tip
 You can also use the [tower-cli](https://github.com/seqeralabs/tower-cli) to upload the dataset to a particular workspace:
 
-    ```console
+    ```bash
     tw datasets add --name "cli_uploaded_samplesheet" ./samplesheet_full.csv
     ```
 

--- a/platform_versioned_docs/version-23.4/getting-started/quickstart-demo/automation.mdx
+++ b/platform_versioned_docs/version-23.4/getting-started/quickstart-demo/automation.mdx
@@ -59,7 +59,7 @@ See [CLI](../../cli/overview.mdx) for installation and usage details.
 :::info
 **Example pipeline launch CLI command**
 
-```console
+```bash
 tw launch hello --workspace community/showcase
 ```
 :::
@@ -90,7 +90,7 @@ See the [seqerakit GitHub repository](https://github.com/seqeralabs/seqera-kit/)
       
   Then run seqerakit:
 
-    ```console
+    ```bash
     $ seqerakit hello.yaml
     ```
 

--- a/platform_versioned_docs/version-23.4/seqerakit/installation.mdx
+++ b/platform_versioned_docs/version-23.4/seqerakit/installation.mdx
@@ -26,13 +26,13 @@ Seqerakit has three dependencies:
 
 If you already have [Platform CLI](../cli/installation.mdx) and Python installed on your system, install Seqerakit directly from [PyPI](https://pypi.org/project/seqerakit/):
 
-```console
+```bash
 pip install seqerakit
 ```
 
 Overwrite an existing installation to use the latest version:
 
-```console
+```bash
 pip install --upgrade --force-reinstall seqerakit
 ```
 
@@ -40,7 +40,7 @@ pip install --upgrade --force-reinstall seqerakit
 
 To install `seqerakit` and its dependencies via Conda, first configure the correct channels:
 
-```console
+```bash
 conda config --add channels bioconda
 conda config --add channels conda-forge
 conda config --set channel_priority strict
@@ -48,7 +48,7 @@ conda config --set channel_priority strict
 
 Then create a conda environment with `seqerakit` installed:
 
-```console
+```bash
 conda env create -n seqerakit seqerakit
 conda activate seqerakit
 ```

--- a/platform_versioned_docs/version-24.1/cli/commands.mdx
+++ b/platform_versioned_docs/version-24.1/cli/commands.mdx
@@ -48,7 +48,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   Platform requires credentials to access your cloud compute environments. See the [compute environment page][compute-envs] for your cloud provider for more information.
 
-    ```console
+    ```bash
     tw credentials add aws --name=my_aws_creds --access-key=<aws access key> --secret-key=<aws secret key>
 
       New AWS credentials 'my_aws_creds (1sxCxvxfx8xnxdxGxQxqxH)' added at user workspace
@@ -58,7 +58,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   Platform requires access credentials to interact with pipeline Git repositories. See [Git integration][git-integration] for more information.
 
-    ```console
+    ```bash
     tw credentials add github -n=my_GH_creds -u=<GitHub username> -p=<GitHub access token>
 
       New GITHUB credentials 'my_GH_creds (xxxxx3prfGlpxxxvR2xxxxo7ow)' added at user workspace
@@ -74,7 +74,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   ### List credentials
 
-  ```console
+  ```bash
   tw credentials list
 
     Credentials at user workspace:
@@ -89,7 +89,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   ### Delete credentials
 
-  ```console
+  ```bash
   tw credentials delete --name=my_aws_creds
 
     Credentials '1sxCxvxfx8xnxdxGxQxqxH' deleted at user workspace
@@ -111,7 +111,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   You must add the credentials for your provider before creating your compute environment.
 
-  ```console
+  ```bash
   tw compute-envs add aws-batch forge --name=my_aws_ce \
   --credentials=<my_aws_creds_1> --region=eu-west-1 --max-cpus=256 \
   --work-dir=s3://<bucket name> --wait=AVAILABLE
@@ -132,7 +132,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   ### Delete a compute environment
 
-  ```console
+  ```bash
   tw compute-envs delete --name=my_aws_ce
 
     Compute environment '1sxCxvxfx8xnxdxGxQxqxH' deleted at user workspace
@@ -142,7 +142,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Select a **primary** compute environment to be used by default in a workspace. You can override the workspace primary compute environment by explicitly specifying an alternative compute environment when you create or launch a pipeline.
 
-  ```console
+  ```bash
   tw compute-envs primary set --name=my_aws_ce
 
     Primary compute environment for workspace 'user' was set to 'my_aws_ce (1sxCxvxfx8xnxdxGxQxqxH)'  
@@ -152,7 +152,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Export the configuration details of a compute environment in JSON format for scripting and reproducibility purposes.
 
-  ```console
+  ```bash
   tw compute-envs export --name=my_aws_ce my_aws_ce_v1.json
 
     Compute environment exported into 'my_aws_ce_v1.json' 
@@ -160,7 +160,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Similarly, a compute environment can be imported to a workspace from a previously exported JSON file.
 
-  ```console
+  ```bash
   tw compute-envs import --name=my_aws_ce_v1 ./my_aws_ce_v1.json
 
     New AWS-BATCH compute environment 'my_aws_ce_v1' added at user workspace
@@ -179,7 +179,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Add a preconfigured dataset file to a workspace (include the `--header` flag if the first row of your samplesheet file is a header):
 
-  ```console
+  ```bash
   tw datasets add --name=samplesheet1 --header samplesheet_test.csv
 
   Dataset 'samplesheet1' added at user workspace with id '60gGrD4I2Gk0TUpEGOj5Td'
@@ -193,7 +193,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To delete a workspace dataset, specify either the dataset name (`-n` flag) or ID (`-i` flag):
 
-  ```console 
+  ```bash 
   tw datasets delete -i 6tYMjGqCUJy6dEXNK9y8kh
 
   Dataset '6tYMjGqCUJy6dEXNK9y8kh' deleted at 97652229034604 workspace
@@ -203,7 +203,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   View a stored dataset's contents: 
 
-  ```console 
+  ```bash 
   tw datasets download -n samplesheet1
 
   sample,fastq_1,fastq_2,strandedness
@@ -220,7 +220,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets list -h` to view the optional fields for listing and filtering datasets.
 
-  ```console 
+  ```bash 
   tw datasets list -f data
 
   Datasets at 97652229034604 workspace:
@@ -234,7 +234,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets view -h` to view the required and optional fields for viewing a stored dataset's details.
 
-  ```console
+  ```bash
   tw datasets view -n samplesheet1
 
   Dataset at 97652229034604 workspace:
@@ -252,7 +252,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets update -h` to view the required and optional fields for updating a dataset.
 
-  ```console 
+  ```bash 
   tw datasets update -n dataset1 --new-name=dataset2 -f samplesheet_test.csv
 
   Dataset 'dataset1' updated at 97652229034604 workspace with id '6vBGj6aWWpBuLpGKjJDpZy'
@@ -262,7 +262,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets url -h` to view the required and optional fields for obtaining dataset URLs.
 
-  ```console 
+  ```bash 
   tw datasets url -n dataset2
 
   Dataset URL
@@ -286,7 +286,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Add a pre-configured pipeline to the Launchpad:
 
-  ```console
+  ```bash
   tw pipelines add --name=my_rnaseq_nf_pipeline \
   --params-file=my_rnaseq_nf_pipeline_params.yaml \
   --config=<path/to/nextflow/conf/file> \
@@ -307,7 +307,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Export the configuration details of a pipeline in JSON format for scripting and reproducibility purposes.
 
-  ```console
+  ```bash
   tw pipelines export --name=my_rnaseq_nf_pipeline my_rnaseq_nf_pipeline_v1.json
 
     Pipeline exported into 'my_rnaseq_nf_pipeline_v1.json' 
@@ -315,7 +315,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Similarly, a pipeline can be imported to a workspace from a previously exported JSON file.
 
-  ```console
+  ```bash
   tw pipelines import --name=my_rnaseq_nf_pipeline_v1 ./my_rnaseq_nf_pipeline_v1.json
 
     New pipeline 'my_rnaseq_nf_pipeline_v1' added at user workspace
@@ -325,7 +325,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   The default launch parameters can be changed with the `update` command:
 
-  ```console
+  ```bash
   tw pipelines update --name=my_rnaseq_nf_pipeline \
   --params-file=my_rnaseq_nf_pipeline_params_2.yaml
   ```
@@ -343,7 +343,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   tw CLI users are bound to the same user permissions that apply in the Platform UI. Launch users can launch pre-configured pipelines in the workspaces they have access to, but they cannot add or run new pipelines.
   :::
 
-  ```console
+  ```bash
   tw launch my_rnaseq_nf_pipeline \
   --config=<path/to/nextflow/conf/file> \
 
@@ -368,7 +368,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To specify custom parameters during pipeline launch, specify a custom `--params-file`:
 
-  ```console
+  ```bash
   tw launch my_rnaseq_nf_pipeline --params-file=my_rnaseq_nf_pipeline_params_2.yaml
 
     Workflow 2XDXxX0vCX8xhx submitted at user workspace.
@@ -382,7 +382,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   The CLI can directly launch pipelines that have not been added to the Launchpad in a Platform workspace by using the full pipeline repository URL:
 
-  ```console
+  ```bash
   tw launch https://github.com/nf-core/rnaseq \
   --params-file=./custom_rnaseq_params.yaml \
   --config=<path/to/nextflow/conf/file> \
@@ -422,7 +422,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw runs view -h` to view all the required and optional fields for viewing a pipeline's runs.
 
-  ```console
+  ```bash
   tw runs view -i 2vFUbBx63cfsBY -w seqeralabs/showcase
 
     Run at [seqeralabs / showcase] workspace:
@@ -450,7 +450,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw runs list -h` to view all the required and optional fields for listing runs in a workspace.
 
-  ```console
+  ```bash
   tw runs list
 
     Pipeline runs at [seqeralabs / testing] workspace:
@@ -486,7 +486,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   The `after` and `before` flags require an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp with UTC timezone (`YYYY-MM-DDThh:mm:ss.sssZ`).
   :::
 
-  ```console
+  ```bash
   tw runs list --filter hello_slurm_20240530
 
     Pipeline runs at [seqeralabs / showcase] workspace:
@@ -498,7 +498,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Multiple filter criteria can be defined:
 
-  ```console
+  ```bash
   tw runs list --filter="after:2024-05-29T00:00:00.000Z before:2024-05-30T00:00:00.000Z username:user1"
 
     Pipeline runs at [seqeralabs / testing] workspace:
@@ -517,7 +517,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   A leading and trailing `*` wildcard character is supported:
 
-  ```console
+  ```bash
   tw runs list --filter="*man/rnaseq-*"    
 
     Pipeline runs at [seqeralabs / testing] workspace:
@@ -547,7 +547,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   In the example below, we add the labels `test` and `rnaseq-demo` to the run with ID `5z4AMshti4g0GK`:
 
-  ```console
+  ```bash
   tw runs labels -i 5z4AMshti4g0GK test,rnaseq-demo 
 
   'set' labels on 'run' with id '5z4AMshti4g0GK' at 34830707738561 workspace
@@ -561,7 +561,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw runs dump -h` to view all the required and optional fields for dumping all logs and details of a run in a workspace. The supported formats are `.tar.xz` and `.tar.gz`. In the example below, we dump all the logs and details for the run with ID `5z4AMshti4g0GK` to the output file `file.tar.gz`.
 
-  ```console
+  ```bash
   tw runs dump -i 5z4AMshti4g0GK -o file.tar.gz
   - Tower info
   - Workflow details
@@ -587,7 +587,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   [Labels](../labels/overview.mdx) require only a name. 
   ::: 
 
-  ```console
+  ```bash
   tw labels add -n Label1 -w DocTestOrg2/Testing -v Value1
 
   Label 'Label1=Value1' added at 'DocTestOrg2/Testing' workspace with id '268741348267491'
@@ -597,7 +597,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw labels list -h` to view the optional fields for filtering labels. 
 
-  ```console
+  ```bash
   tw labels list
 
   Labels at 97652229034604 workspace:
@@ -620,7 +620,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw labels delete -h` to view the required and optional fields for deleting labels. 
 
-    ```console
+    ```bash
     tw labels delete -i 203879852150462
 
     Label '203879852150462' deleted at '97652229034604' workspace
@@ -649,7 +649,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   - `v1-cloud-<id>`: Cloud data links auto-discovered using credentials attached to the workspace.
   - `v1-user-<id>`: Custom data links created by users.
 
-  ```console
+  ```bash
   tw data-links list -w seqeralabs/showcase
 
   Data links at [seqeralabs / showcase] workspace:
@@ -676,7 +676,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   
   Users with the workspace `MAINTAIN` role and above can add custom data links. The data link `name`, `uri`, and `provider` (`aws`, `azure`, or `google`) fields are required. If adding a custom data link for a private bucket, the credentials identifier field is also required. Adding a custom data link for a public bucket doesn't require credentials.
 
-  ```console
+  ```bash
   tw data-links add -w seqeralabs/showcase -n FOO -u az://seqeralabs.azure-benchmarking \
   -p azure -c seqera_azure_credentials
 
@@ -691,7 +691,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw data-links update -h` to view all the required and optional fields for updating a custom data link in a workspace. Users with the `MAINTAIN` role and above for a workspace can update custom data links.
 
-  ```console
+  ```bash
   tw data-links update -w seqeralabs/showcase -i v1-user-152116183ee325463901430bb9efb8c9 -n BAR
 
   Data link updated:
@@ -707,7 +707,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   
   Users with the `MAINTAIN` role and above for a workspace can delete custom data links.
 
-  ```console 
+  ```bash 
   tw data-links delete -w seqeralabs/showcase -i v1-user-152116183ee325463901430bb9efb8c9
 
   Data link 'v1-user-152116183ee325463901430bb9efb8c9' deleted at '138659136604200' workspace.
@@ -719,7 +719,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   
   Define the data link ID using the required `-i` or `--id` argument, which can be found by first using the list operation for a workspace. In the example below, a name is defined to only retrieve data links with names that start with the given word:
 
-  ```console 
+  ```bash 
   tw data-links list -w seqeralabs/showcase -n 1000genomes
 
   Data links at [seqeralabs / showcase] workspace:
@@ -780,7 +780,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw organizations add -h` to view the required and optional fields for adding your workspace.
 
-  ```console 
+  ```bash 
   tw organizations add -n TestOrg2 -f 2nd\ Test\ Organization\ LLC -l RSA
 
   Organization 'TestOrg2' with ID '204336622618177' was added
@@ -798,7 +798,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw members list -h` view all the optional fields for listing organization members.
 
-  ```console
+  ```bash
   tw members list -o TestOrg2
 
   Members for TestOrg2 organization:
@@ -815,7 +815,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw members add -h` view all the required and optional fields for adding organization members.
 
-  ```console
+  ```bash
   tw members add -u user1@domain.com -o DocTestOrg2
 
   Member 'user1' with ID '134534064600266' was added in organization 'TestOrg2'
@@ -825,7 +825,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
     Run `tw members delete -h` view all the required and optional fields for deleting organization members.
 
-    ```console
+    ```bash
     tw members delete -u user1 -o TestOrg2
 
     Member 'user1' deleted from organization 'TestOrg2'
@@ -835,7 +835,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw members update -h` view all the required and optional fields for updating organization members.
 
-  ```console 
+  ```bash 
   tw members update -u user1 -r OWNER -o TestOrg2
 
   Member 'user1' updated to role 'owner' in organization 'TestOrg2'
@@ -865,7 +865,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   In the example below, we create a shared workspace to be used for sharing pipelines with other private workspaces. See [Shared workspaces][shared-workspaces] for more information.
 
-  ```console
+  ```bash
   tw workspaces add --name=shared-workspace --full-name=shared-workspace-for-all  --org=my-tower-org --visibility=SHARED
 
     A 'SHARED' workspace 'shared-workspace' added for 'my-tower-org' organization
@@ -879,7 +879,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   List all the workspaces in which you are a participant:
 
-  ```console
+  ```bash
   tw workspaces list                      
 
     Workspaces for default user:
@@ -903,7 +903,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   ### List participants
 
-  ```console
+  ```bash
   tw participants list
 
     Participants for 'my-tower-org/shared-workspace' workspace:
@@ -921,7 +921,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   See [Participant roles][participant-roles] for more information.
 
-  ```console
+  ```bash
   tw participants add --name=collaborator@mydomain.com --type=MEMBER                           
 
     User 'collaborator' was added as participant to 'shared-workspace' workspace with role 'launch'
@@ -931,7 +931,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To update the role of a _Collaborator_ to `ADMIN` or `MAINTAIN`, use the `update` subcommand:
 
-  ```console
+  ```bash
   tw  participants update --name=collaborator@mydomain.com --type=COLLABORATOR --role=MAINTAIN
 
     Participant 'collaborator@mydomain.com' has now role 'maintain' for workspace 'shared-workspace'
@@ -953,7 +953,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw teams list -h` to view the required and optional fields for listing teams. 
 
-  ```console
+  ```bash
   tw teams list -o TestOrg2
 
   Teams for TestOrg2 organization:
@@ -967,7 +967,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw teams add -h` to view the required and optional fields for creating a team. 
 
-  ```console 
+  ```bash 
   tw teams add -n team1 -o TestOrg2 -d testing
 
   A 'team1' team added for 'TestOrg2' organization
@@ -975,7 +975,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   ### Delete a team 
 
-  ```console 
+  ```bash 
   tw teams delete -i 169283393825479 -o TestOrg2
 
   Team '169283393825479' deleted for TestOrg2 organization
@@ -987,7 +987,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To add a new team member, include an existing username or new user email:
 
-  ```console 
+  ```bash 
   tw teams members -t Testing -o TestOrg2 add -m user1@domain.com
 
   Member 'user1' added to team 'Testing' with id '243206491381406'
@@ -995,7 +995,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To delete a team member, include the member's username:
 
-  ```console 
+  ```bash 
   tw teams members -t Testing -o TestOrg2 delete -m user1
 
   Team member 'user1' deleted at 'Testing' team
@@ -1011,7 +1011,7 @@ Run `tw collaborators -h` view all the required and optional fields for managing
 
   ### List collaborators
 
-  ```console
+  ```bash
   tw collaborators list -o seqeralabs
 
   Collaborators for 88848180287xxx organization:

--- a/platform_versioned_docs/version-24.1/cli/installation.mdx
+++ b/platform_versioned_docs/version-24.1/cli/installation.mdx
@@ -59,7 +59,7 @@ Find your `TOWER_WORKSPACE_ID` from the **Workspaces** tab on your organization 
 
 Confirm the installation, configuration, and connection:
 
-```console
+```bash
 tw info
 
     Details
@@ -141,7 +141,7 @@ tw CLI is a platform binary executable created by a native compilation from Java
 
     This will install a locally compiled version of `tw` in the nativeCompile directory:
 
-    ```console
+    ```bash
     Produced artifacts:
      <tower-cli-repository-root>/build/native/nativeCompile/tw (executable)
     ========================================================================================================================

--- a/platform_versioned_docs/version-24.1/enterprise/prerequisites/aws.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/prerequisites/aws.mdx
@@ -115,7 +115,7 @@ See [Creating an Amazon RDS DB instance](https://docs.aws.amazon.com/AmazonRDS/l
 
 To create a DB instance with the AWS CLI, call the [create-db-instance](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html) command, replacing `INSTANCE_NAME`, `SECURITY_GROUP`, `DB_USER`, and `DB_PASSWORD` with your unique values:
 
-```console
+```bash
 aws rds create-db-instance \
     --engine mysql \ 
     --db-instance-identifier INSTANCE_NAME \

--- a/platform_versioned_docs/version-24.1/enterprise/prerequisites/azure.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/prerequisites/azure.mdx
@@ -59,7 +59,7 @@ Create a resource group:
 
   Run the `az group create` command:
 
-  ```console
+  ```bash
   az group create --name $MY_RESOURCE_GROUP_NAME --location $REGION
   ```
 
@@ -93,7 +93,7 @@ Create a storage account:
 
   Run the `az storage account create` command:
 
-  ```console
+  ```bash
   az storage account create -n towerstorage -g towerrg -l eastus --sku Standard_GRS
   ```
 
@@ -141,7 +141,7 @@ Create an Azure MySQL DB instance:
 
   1. Run `az mysql flexible-server create` to create your server:
 
-      ```console
+      ```bash
       az mysql flexible-server create --location eastus --resource-group towerrg --name towerdbserver --admin-user username --admin-password password --sku-name Standard_B2ms --tier Burstable --public-access 0.0.0.0 --storage-size 30 --version 8.0 --high-availability ZoneRedundant --zone 1 --standby-zone 3 --storage-auto-grow Enabled --iops 500
       ```
 
@@ -149,7 +149,7 @@ Create an Azure MySQL DB instance:
 
   1. Run `az mysql flexible-server db create` to create a database on your server:
 
-      ```console 
+      ```bash 
       az mysql flexible-server db create --resource-group towerrg
                                       --server-name towerdbserver
                                       --database-name towerdb
@@ -242,7 +242,7 @@ Create an Azure Linux VM:
 
   Run `az vm create`:
 
-  ```console 
+  ```bash 
   az vm create \
     --resource-group towerrg \
     --name towervm \

--- a/platform_versioned_docs/version-24.1/enterprise/prerequisites/gcp.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/prerequisites/gcp.mdx
@@ -72,7 +72,7 @@ The recommended machine type and storage requirements depend on the number of pa
 See [Create a MySQL instance][gcloudsql-create] for gcloud CLI instructions.
 
 1. Create your MySQL instance with the following command:
-    ```console 
+    ```bash 
     gcloud sql instances create INSTANCE_NAME \
     --database-version=MYSQL_8_0 \
     --cpu=2 \
@@ -82,14 +82,14 @@ See [Create a MySQL instance][gcloudsql-create] for gcloud CLI instructions.
     ```
 1. Note the private IP address as it must be supplied to the `TOWER_DB_URL` environment variable during Seqera configuration. 
 1. Set the password for the root MySQL user:
-    ```console
+    ```bash
     gcloud sql users set-password root \
     --host=% \
     --instance INSTANCE_NAME \
     --password PASSWORD
     ```
 1. Create a database named `tower` on the instance: 
-    ```console 
+    ```bash 
     gcloud sql databases create tower \
     --instance=INSTANCE_NAME \
     ```

--- a/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_latest.mdx
+++ b/platform_versioned_docs/version-24.1/enterprise/release_notes/enterprise_latest.mdx
@@ -80,7 +80,7 @@ Enterprise deployments that have customized this value previously will need to a
 1. This version requires a database schema update. Make a backup of your Platform database prior to upgrade.
 1. If you are upgrading from a version older than 23.4.1, update your installation to version [23.4.4](./23.4.mdx) first, before updating to 24.1 with the steps below.
 1. For recommended Platform memory settings, add the following environment variable to your Platform configuration values (`tower.env`, `configmap.yml`, etc. ):
-    ```console 
+    ```bash 
     JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
     ```
 1. See [Upgrade installation](../upgrade.mdx) for database backup and installation upgrade guidance.

--- a/platform_versioned_docs/version-24.1/getting-started/quickstart-demo/automation.mdx
+++ b/platform_versioned_docs/version-24.1/getting-started/quickstart-demo/automation.mdx
@@ -59,7 +59,7 @@ See [CLI](../../cli/overview.mdx) for installation and usage details.
 :::info
 **Example pipeline launch CLI command**
 
-```console
+```bash
 tw launch hello --workspace community/showcase
 ```
 :::
@@ -90,7 +90,7 @@ See the [seqerakit GitHub repository](https://github.com/seqeralabs/seqera-kit/)
 
   Then run seqerakit:
 
-    ```console
+    ```bash
     $ seqerakit hello.yaml
     ```
 

--- a/platform_versioned_docs/version-24.1/seqerakit/installation.mdx
+++ b/platform_versioned_docs/version-24.1/seqerakit/installation.mdx
@@ -26,13 +26,13 @@ Seqerakit has three dependencies:
 
 If you already have [Platform CLI](../cli/installation.mdx) and Python installed on your system, install Seqerakit directly from [PyPI](https://pypi.org/project/seqerakit/):
 
-```console
+```bash
 pip install seqerakit
 ```
 
 Overwrite an existing installation to use the latest version:
 
-```console
+```bash
 pip install --upgrade --force-reinstall seqerakit
 ```
 
@@ -40,7 +40,7 @@ pip install --upgrade --force-reinstall seqerakit
 
 To install `seqerakit` and its dependencies via Conda, first configure the correct channels:
 
-```console
+```bash
 conda config --add channels bioconda
 conda config --add channels conda-forge
 conda config --set channel_priority strict
@@ -48,7 +48,7 @@ conda config --set channel_priority strict
 
 Then create a conda environment with `seqerakit` installed:
 
-```console
+```bash
 conda env create -n seqerakit seqerakit
 conda activate seqerakit
 ```

--- a/platform_versioned_docs/version-24.2/cli/commands.mdx
+++ b/platform_versioned_docs/version-24.2/cli/commands.mdx
@@ -48,7 +48,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   Platform requires credentials to access your cloud compute environments. See the [compute environment page][compute-envs] for your cloud provider for more information.
 
-    ```console
+    ```bash
     tw credentials add aws --name=my_aws_creds --access-key=<aws access key> --secret-key=<aws secret key>
 
       New AWS credentials 'my_aws_creds (1sxCxvxfx8xnxdxGxQxqxH)' added at user workspace
@@ -58,7 +58,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   Platform requires access credentials to interact with pipeline Git repositories. See [Git integration][git-integration] for more information.
 
-    ```console
+    ```bash
     tw credentials add github -n=my_GH_creds -u=<GitHub username> -p=<GitHub access token>
 
       New GITHUB credentials 'my_GH_creds (xxxxx3prfGlpxxxvR2xxxxo7ow)' added at user workspace
@@ -74,7 +74,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   ### List credentials
 
-  ```console
+  ```bash
   tw credentials list
 
     Credentials at user workspace:
@@ -89,7 +89,7 @@ Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use
 
   ### Delete credentials
 
-  ```console
+  ```bash
   tw credentials delete --name=my_aws_creds
 
     Credentials '1sxCxvxfx8xnxdxGxQxqxH' deleted at user workspace
@@ -111,7 +111,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   You must add the credentials for your provider before creating your compute environment.
 
-  ```console
+  ```bash
   tw compute-envs add aws-batch forge --name=my_aws_ce \
   --credentials=<my_aws_creds_1> --region=eu-west-1 --max-cpus=256 \
   --work-dir=s3://<bucket name> --wait=AVAILABLE
@@ -132,7 +132,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   ### Delete a compute environment
 
-  ```console
+  ```bash
   tw compute-envs delete --name=my_aws_ce
 
     Compute environment '1sxCxvxfx8xnxdxGxQxqxH' deleted at user workspace
@@ -142,7 +142,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Select a **primary** compute environment to be used by default in a workspace. You can override the workspace primary compute environment by explicitly specifying an alternative compute environment when you create or launch a pipeline.
 
-  ```console
+  ```bash
   tw compute-envs primary set --name=my_aws_ce
 
     Primary compute environment for workspace 'user' was set to 'my_aws_ce (1sxCxvxfx8xnxdxGxQxqxH)'  
@@ -152,7 +152,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Export the configuration details of a compute environment in JSON format for scripting and reproducibility purposes.
 
-  ```console
+  ```bash
   tw compute-envs export --name=my_aws_ce my_aws_ce_v1.json
 
     Compute environment exported into 'my_aws_ce_v1.json' 
@@ -160,7 +160,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Similarly, a compute environment can be imported to a workspace from a previously exported JSON file.
 
-  ```console
+  ```bash
   tw compute-envs import --name=my_aws_ce_v1 ./my_aws_ce_v1.json
 
     New AWS-BATCH compute environment 'my_aws_ce_v1' added at user workspace
@@ -179,7 +179,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Add a preconfigured dataset file to a workspace (include the `--header` flag if the first row of your samplesheet file is a header):
 
-  ```console
+  ```bash
   tw datasets add --name=samplesheet1 --header samplesheet_test.csv
 
   Dataset 'samplesheet1' added at user workspace with id '60gGrD4I2Gk0TUpEGOj5Td'
@@ -193,7 +193,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To delete a workspace dataset, specify either the dataset name (`-n` flag) or ID (`-i` flag):
 
-  ```console 
+  ```bash 
   tw datasets delete -i 6tYMjGqCUJy6dEXNK9y8kh
 
   Dataset '6tYMjGqCUJy6dEXNK9y8kh' deleted at 97652229034604 workspace
@@ -203,7 +203,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   View a stored dataset's contents: 
 
-  ```console 
+  ```bash 
   tw datasets download -n samplesheet1
 
   sample,fastq_1,fastq_2,strandedness
@@ -220,7 +220,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets list -h` to view the optional fields for listing and filtering datasets.
 
-  ```console 
+  ```bash 
   tw datasets list -f data
 
   Datasets at 97652229034604 workspace:
@@ -234,7 +234,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets view -h` to view the required and optional fields for viewing a stored dataset's details.
 
-  ```console
+  ```bash
   tw datasets view -n samplesheet1
 
   Dataset at 97652229034604 workspace:
@@ -252,7 +252,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets update -h` to view the required and optional fields for updating a dataset.
 
-  ```console 
+  ```bash 
   tw datasets update -n dataset1 --new-name=dataset2 -f samplesheet_test.csv
 
   Dataset 'dataset1' updated at 97652229034604 workspace with id '6vBGj6aWWpBuLpGKjJDpZy'
@@ -262,7 +262,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw datasets url -h` to view the required and optional fields for obtaining dataset URLs.
 
-  ```console 
+  ```bash 
   tw datasets url -n dataset2
 
   Dataset URL
@@ -286,7 +286,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Add a pre-configured pipeline to the Launchpad:
 
-  ```console
+  ```bash
   tw pipelines add --name=my_rnaseq_nf_pipeline \
   --params-file=my_rnaseq_nf_pipeline_params.yaml \
   --config=<path/to/nextflow/conf/file> \
@@ -307,7 +307,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Export the configuration details of a pipeline in JSON format for scripting and reproducibility purposes.
 
-  ```console
+  ```bash
   tw pipelines export --name=my_rnaseq_nf_pipeline my_rnaseq_nf_pipeline_v1.json
 
     Pipeline exported into 'my_rnaseq_nf_pipeline_v1.json' 
@@ -315,7 +315,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Similarly, a pipeline can be imported to a workspace from a previously exported JSON file.
 
-  ```console
+  ```bash
   tw pipelines import --name=my_rnaseq_nf_pipeline_v1 ./my_rnaseq_nf_pipeline_v1.json
 
     New pipeline 'my_rnaseq_nf_pipeline_v1' added at user workspace
@@ -325,7 +325,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   The default launch parameters can be changed with the `update` command:
 
-  ```console
+  ```bash
   tw pipelines update --name=my_rnaseq_nf_pipeline \
   --params-file=my_rnaseq_nf_pipeline_params_2.yaml
   ```
@@ -343,7 +343,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   tw CLI users are bound to the same user permissions that apply in the Platform UI. Launch users can launch pre-configured pipelines in the workspaces they have access to, but they cannot add or run new pipelines.
   :::
 
-  ```console
+  ```bash
   tw launch my_rnaseq_nf_pipeline \
   --config=<path/to/nextflow/conf/file> \
 
@@ -368,7 +368,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To specify custom parameters during pipeline launch, specify a custom `--params-file`:
 
-  ```console
+  ```bash
   tw launch my_rnaseq_nf_pipeline --params-file=my_rnaseq_nf_pipeline_params_2.yaml
 
     Workflow 2XDXxX0vCX8xhx submitted at user workspace.
@@ -382,7 +382,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   The CLI can directly launch pipelines that have not been added to the Launchpad in a Platform workspace by using the full pipeline repository URL:
 
-  ```console
+  ```bash
   tw launch https://github.com/nf-core/rnaseq \
   --params-file=./custom_rnaseq_params.yaml \
   --config=<path/to/nextflow/conf/file> \
@@ -422,7 +422,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw runs view -h` to view all the required and optional fields for viewing a pipeline's runs.
 
-  ```console
+  ```bash
   tw runs view -i 2vFUbBx63cfsBY -w seqeralabs/showcase
 
     Run at [seqeralabs / showcase] workspace:
@@ -450,7 +450,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw runs list -h` to view all the required and optional fields for listing runs in a workspace.
 
-  ```console
+  ```bash
   tw runs list
 
     Pipeline runs at [seqeralabs / testing] workspace:
@@ -486,7 +486,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   The `after` and `before` flags require an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp with UTC timezone (`YYYY-MM-DDThh:mm:ss.sssZ`).
   :::
 
-  ```console
+  ```bash
   tw runs list --filter hello_slurm_20240530
 
     Pipeline runs at [seqeralabs / showcase] workspace:
@@ -498,7 +498,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Multiple filter criteria can be defined:
 
-  ```console
+  ```bash
   tw runs list --filter="after:2024-05-29T00:00:00.000Z before:2024-05-30T00:00:00.000Z username:user1"
 
     Pipeline runs at [seqeralabs / testing] workspace:
@@ -517,7 +517,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   A leading and trailing `*` wildcard character is supported:
 
-  ```console
+  ```bash
   tw runs list --filter="*man/rnaseq-*"    
 
     Pipeline runs at [seqeralabs / testing] workspace:
@@ -547,7 +547,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   In the example below, we add the labels `test` and `rnaseq-demo` to the run with ID `5z4AMshti4g0GK`:
 
-  ```console
+  ```bash
   tw runs labels -i 5z4AMshti4g0GK test,rnaseq-demo 
 
   'set' labels on 'run' with id '5z4AMshti4g0GK' at 34830707738561 workspace
@@ -561,7 +561,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw runs dump -h` to view all the required and optional fields for dumping all logs and details of a run in a workspace. The supported formats are `.tar.xz` and `.tar.gz`. In the example below, we dump all the logs and details for the run with ID `5z4AMshti4g0GK` to the output file `file.tar.gz`.
 
-  ```console
+  ```bash
   tw runs dump -i 5z4AMshti4g0GK -o file.tar.gz
   - Tower info
   - Workflow details
@@ -587,7 +587,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   [Labels](../labels/overview.mdx) require only a name. 
   ::: 
 
-  ```console
+  ```bash
   tw labels add -n Label1 -w DocTestOrg2/Testing -v Value1
 
   Label 'Label1=Value1' added at 'DocTestOrg2/Testing' workspace with id '268741348267491'
@@ -597,7 +597,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw labels list -h` to view the optional fields for filtering labels. 
 
-  ```console
+  ```bash
   tw labels list
 
   Labels at 97652229034604 workspace:
@@ -620,7 +620,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw labels delete -h` to view the required and optional fields for deleting labels. 
 
-    ```console
+    ```bash
     tw labels delete -i 203879852150462
 
     Label '203879852150462' deleted at '97652229034604' workspace
@@ -649,7 +649,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   - `v1-cloud-<id>`: Cloud data links auto-discovered using credentials attached to the workspace.
   - `v1-user-<id>`: Custom data links created by users.
 
-  ```console
+  ```bash
   tw data-links list -w seqeralabs/showcase
 
   Data links at [seqeralabs / showcase] workspace:
@@ -676,7 +676,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   
   Users with the workspace `MAINTAIN` role and above can add custom data links. The data link `name`, `uri`, and `provider` (`aws`, `azure`, or `google`) fields are required. If adding a custom data link for a private bucket, the credentials identifier field is also required. Adding a custom data link for a public bucket doesn't require credentials.
 
-  ```console
+  ```bash
   tw data-links add -w seqeralabs/showcase -n FOO -u az://seqeralabs.azure-benchmarking \
   -p azure -c seqera_azure_credentials
 
@@ -691,7 +691,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw data-links update -h` to view all the required and optional fields for updating a custom data link in a workspace. Users with the `MAINTAIN` role and above for a workspace can update custom data links.
 
-  ```console
+  ```bash
   tw data-links update -w seqeralabs/showcase -i v1-user-152116183ee325463901430bb9efb8c9 -n BAR
 
   Data link updated:
@@ -707,7 +707,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   
   Users with the `MAINTAIN` role and above for a workspace can delete custom data links.
 
-  ```console 
+  ```bash 
   tw data-links delete -w seqeralabs/showcase -i v1-user-152116183ee325463901430bb9efb8c9
 
   Data link 'v1-user-152116183ee325463901430bb9efb8c9' deleted at '138659136604200' workspace.
@@ -719,7 +719,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
   
   Define the data link ID using the required `-i` or `--id` argument, which can be found by first using the list operation for a workspace. In the example below, a name is defined to only retrieve data links with names that start with the given word:
 
-  ```console 
+  ```bash 
   tw data-links list -w seqeralabs/showcase -n 1000genomes
 
   Data links at [seqeralabs / showcase] workspace:
@@ -780,7 +780,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw organizations add -h` to view the required and optional fields for adding your workspace.
 
-  ```console 
+  ```bash 
   tw organizations add -n TestOrg2 -f 2nd\ Test\ Organization\ LLC -l RSA
 
   Organization 'TestOrg2' with ID '204336622618177' was added
@@ -798,7 +798,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw members list -h` view all the optional fields for listing organization members.
 
-  ```console
+  ```bash
   tw members list -o TestOrg2
 
   Members for TestOrg2 organization:
@@ -815,7 +815,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw members add -h` view all the required and optional fields for adding organization members.
 
-  ```console
+  ```bash
   tw members add -u user1@domain.com -o DocTestOrg2
 
   Member 'user1' with ID '134534064600266' was added in organization 'TestOrg2'
@@ -825,7 +825,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
     Run `tw members delete -h` view all the required and optional fields for deleting organization members.
 
-    ```console
+    ```bash
     tw members delete -u user1 -o TestOrg2
 
     Member 'user1' deleted from organization 'TestOrg2'
@@ -835,7 +835,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw members update -h` view all the required and optional fields for updating organization members.
 
-  ```console 
+  ```bash 
   tw members update -u user1 -r OWNER -o TestOrg2
 
   Member 'user1' updated to role 'owner' in organization 'TestOrg2'
@@ -865,7 +865,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   In the example below, we create a shared workspace to be used for sharing pipelines with other private workspaces. See [Shared workspaces][shared-workspaces] for more information.
 
-  ```console
+  ```bash
   tw workspaces add --name=shared-workspace --full-name=shared-workspace-for-all  --org=my-tower-org --visibility=SHARED
 
     A 'SHARED' workspace 'shared-workspace' added for 'my-tower-org' organization
@@ -879,7 +879,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   List all the workspaces in which you are a participant:
 
-  ```console
+  ```bash
   tw workspaces list                      
 
     Workspaces for default user:
@@ -903,7 +903,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   ### List participants
 
-  ```console
+  ```bash
   tw participants list
 
     Participants for 'my-tower-org/shared-workspace' workspace:
@@ -921,7 +921,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   See [Participant roles][participant-roles] for more information.
 
-  ```console
+  ```bash
   tw participants add --name=collaborator@mydomain.com --type=MEMBER                           
 
     User 'collaborator' was added as participant to 'shared-workspace' workspace with role 'launch'
@@ -931,7 +931,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To update the role of a _Collaborator_ to `ADMIN` or `MAINTAIN`, use the `update` subcommand:
 
-  ```console
+  ```bash
   tw  participants update --name=collaborator@mydomain.com --type=COLLABORATOR --role=MAINTAIN
 
     Participant 'collaborator@mydomain.com' has now role 'maintain' for workspace 'shared-workspace'
@@ -953,7 +953,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw teams list -h` to view the required and optional fields for listing teams. 
 
-  ```console
+  ```bash
   tw teams list -o TestOrg2
 
   Teams for TestOrg2 organization:
@@ -967,7 +967,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   Run `tw teams add -h` to view the required and optional fields for creating a team. 
 
-  ```console 
+  ```bash 
   tw teams add -n team1 -o TestOrg2 -d testing
 
   A 'team1' team added for 'TestOrg2' organization
@@ -975,7 +975,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   ### Delete a team 
 
-  ```console 
+  ```bash 
   tw teams delete -i 169283393825479 -o TestOrg2
 
   Team '169283393825479' deleted for TestOrg2 organization
@@ -987,7 +987,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To add a new team member, include an existing username or new user email:
 
-  ```console 
+  ```bash 
   tw teams members -t Testing -o TestOrg2 add -m user1@domain.com
 
   Member 'user1' added to team 'Testing' with id '243206491381406'
@@ -995,7 +995,7 @@ Run `tw compute-envs -h` to view the list of supported compute environment opera
 
   To delete a team member, include the member's username:
 
-  ```console 
+  ```bash 
   tw teams members -t Testing -o TestOrg2 delete -m user1
 
   Team member 'user1' deleted at 'Testing' team
@@ -1011,7 +1011,7 @@ Run `tw collaborators -h` view all the required and optional fields for managing
 
   ### List collaborators
 
-  ```console
+  ```bash
   tw collaborators list -o seqeralabs
 
   Collaborators for 88848180287xxx organization:

--- a/platform_versioned_docs/version-24.2/cli/installation.mdx
+++ b/platform_versioned_docs/version-24.2/cli/installation.mdx
@@ -59,7 +59,7 @@ Find your `TOWER_WORKSPACE_ID` from the **Workspaces** tab on your organization 
 
 Confirm the installation, configuration, and connection:
 
-```console
+```bash
 tw info
 
     Details
@@ -141,7 +141,7 @@ tw CLI is a platform binary executable created by a native compilation from Java
 
     This will install a locally compiled version of `tw` in the nativeCompile directory:
 
-    ```console
+    ```bash
     Produced artifacts:
      <tower-cli-repository-root>/build/native/nativeCompile/tw (executable)
     ========================================================================================================================

--- a/platform_versioned_docs/version-24.2/enterprise/prerequisites/aws.mdx
+++ b/platform_versioned_docs/version-24.2/enterprise/prerequisites/aws.mdx
@@ -115,7 +115,7 @@ See [Creating an Amazon RDS DB instance](https://docs.aws.amazon.com/AmazonRDS/l
 
 To create a DB instance with the AWS CLI, call the [create-db-instance](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html) command, replacing `INSTANCE_NAME`, `SECURITY_GROUP`, `DB_USER`, and `DB_PASSWORD` with your unique values:
 
-```console
+```bash
 aws rds create-db-instance \
     --engine mysql \ 
     --db-instance-identifier INSTANCE_NAME \

--- a/platform_versioned_docs/version-24.2/enterprise/prerequisites/azure.mdx
+++ b/platform_versioned_docs/version-24.2/enterprise/prerequisites/azure.mdx
@@ -59,7 +59,7 @@ Create a resource group:
 
   Run the `az group create` command:
 
-  ```console
+  ```bash
   az group create --name $MY_RESOURCE_GROUP_NAME --location $REGION
   ```
 
@@ -93,7 +93,7 @@ Create a storage account:
 
   Run the `az storage account create` command:
 
-  ```console
+  ```bash
   az storage account create -n towerstorage -g towerrg -l eastus --sku Standard_GRS
   ```
 
@@ -141,7 +141,7 @@ Create an Azure MySQL DB instance:
 
   1. Run `az mysql flexible-server create` to create your server:
 
-      ```console
+      ```bash
       az mysql flexible-server create --location eastus --resource-group towerrg --name towerdbserver --admin-user username --admin-password password --sku-name Standard_B2ms --tier Burstable --public-access 0.0.0.0 --storage-size 30 --version 8.0 --high-availability ZoneRedundant --zone 1 --standby-zone 3 --storage-auto-grow Enabled --iops 500
       ```
 
@@ -149,7 +149,7 @@ Create an Azure MySQL DB instance:
 
   1. Run `az mysql flexible-server db create` to create a database on your server:
 
-      ```console 
+      ```bash 
       az mysql flexible-server db create --resource-group towerrg
                                       --server-name towerdbserver
                                       --database-name towerdb
@@ -242,7 +242,7 @@ Create an Azure Linux VM:
 
   Run `az vm create`:
 
-  ```console 
+  ```bash 
   az vm create \
     --resource-group towerrg \
     --name towervm \

--- a/platform_versioned_docs/version-24.2/enterprise/prerequisites/gcp.mdx
+++ b/platform_versioned_docs/version-24.2/enterprise/prerequisites/gcp.mdx
@@ -72,7 +72,7 @@ The recommended machine type and storage requirements depend on the number of pa
 See [Create a MySQL instance][gcloudsql-create] for gcloud CLI instructions.
 
 1. Create your MySQL instance with the following command:
-    ```console 
+    ```bash 
     gcloud sql instances create INSTANCE_NAME \
     --database-version=MYSQL_8_0 \
     --cpu=2 \
@@ -82,14 +82,14 @@ See [Create a MySQL instance][gcloudsql-create] for gcloud CLI instructions.
     ```
 1. Note the private IP address as it must be supplied to the `TOWER_DB_URL` environment variable during Seqera configuration. 
 1. Set the password for the root MySQL user:
-    ```console
+    ```bash
     gcloud sql users set-password root \
     --host=% \
     --instance INSTANCE_NAME \
     --password PASSWORD
     ```
 1. Create a database named `tower` on the instance: 
-    ```console 
+    ```bash 
     gcloud sql databases create tower \
     --instance=INSTANCE_NAME \
     ```

--- a/platform_versioned_docs/version-24.2/enterprise/release_notes/enterprise_latest.mdx
+++ b/platform_versioned_docs/version-24.2/enterprise/release_notes/enterprise_latest.mdx
@@ -80,7 +80,7 @@ Enterprise deployments that have customized this value previously will need to a
 1. This version requires a database schema update. Make a backup of your Platform database prior to upgrade.
 1. If you are upgrading from a version older than 23.4.1, update your installation to version [23.4.4](./23.4.mdx) first, before updating to 24.1 with the steps below.
 1. For recommended Platform memory settings, add the following environment variable to your Platform configuration values (`tower.env`, `configmap.yml`, etc. ):
-    ```console 
+    ```bash 
     JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
     ```
 1. See [Upgrade installation](../upgrade.mdx) for database backup and installation upgrade guidance.

--- a/platform_versioned_docs/version-24.2/getting-started/quickstart-demo/automation.mdx
+++ b/platform_versioned_docs/version-24.2/getting-started/quickstart-demo/automation.mdx
@@ -59,7 +59,7 @@ See [CLI](../../cli/overview.mdx) for installation and usage details.
 :::info
 **Example pipeline launch CLI command**
 
-```console
+```bash
 tw launch hello --workspace community/showcase
 ```
 :::
@@ -90,7 +90,7 @@ See the [seqerakit GitHub repository](https://github.com/seqeralabs/seqera-kit/)
 
   Then run seqerakit:
 
-    ```console
+    ```bash
     $ seqerakit hello.yaml
     ```
 

--- a/platform_versioned_docs/version-24.2/seqerakit/installation.mdx
+++ b/platform_versioned_docs/version-24.2/seqerakit/installation.mdx
@@ -26,13 +26,13 @@ Seqerakit has three dependencies:
 
 If you already have [Platform CLI](../cli/installation.mdx) and Python installed on your system, install Seqerakit directly from [PyPI](https://pypi.org/project/seqerakit/):
 
-```console
+```bash
 pip install seqerakit
 ```
 
 Overwrite an existing installation to use the latest version:
 
-```console
+```bash
 pip install --upgrade --force-reinstall seqerakit
 ```
 
@@ -40,7 +40,7 @@ pip install --upgrade --force-reinstall seqerakit
 
 To install `seqerakit` and its dependencies via Conda, first configure the correct channels:
 
-```console
+```bash
 conda config --add channels bioconda
 conda config --add channels conda-forge
 conda config --set channel_priority strict
@@ -48,7 +48,7 @@ conda config --set channel_priority strict
 
 Then create a conda environment with `seqerakit` installed:
 
-```console
+```bash
 conda env create -n seqerakit seqerakit
 conda activate seqerakit
 ```
@@ -59,18 +59,18 @@ Install the development branch of `seqerakit` on your local machine to test the 
 
 1. You must have [Python](https://www.python.org/downloads/) and [Git](https://git-scm.com/downloads) installed on your system.
 1. To install directly from pip:
-    ```shell-session
+    ```bash
     pip install git+https://github.com/seqeralabs/seqera-kit.git@dev
     ```
 1. Alternatively, clone the repository locally and install manually:
-    ```shell-session
+    ```bash
     git clone https://github.com/seqeralabs/seqera-kit.git
     cd seqera-kit
     git checkout dev
     pip install .
     ```
 1. Verify your installation:
-    ```shell-session
+    ```bash
     pip show seqerakit
     ```
 
@@ -80,13 +80,13 @@ Create a [Seqera](https://cloud.seqera.io/tokens) access token via **Your Tokens
 
 Seqerakit reads your access token from the `TOWER_ACCESS_TOKEN` environment variable:
 
-```shell-session
+```bash
 export TOWER_ACCESS_TOKEN=<Your Seqera access token>
 ```
 
 For Enterprise installations, specify the custom API endpoint used to connect to Seqera. Export the API endpoint environment variable:
 
-```shell-session
+```bash
 export TOWER_API_ENDPOINT=<Seqera Enterprise API URL>
 ```
 
@@ -96,7 +96,7 @@ By default, this is set to `https://api.cloud.seqera.io` to connect to Seqera Cl
 
 To confirm the installation of `seqerakit`, configuration of the Platform CLI, and connection to Seqera is working as expected, run this command: 
 
-```shell-session
+```bash
 seqerakit --info
 ```
 
@@ -104,13 +104,13 @@ This runs the `tw info` command under the hood.
 
 Use `--version` or `-v` to retrieve the current version of your `seqerakit` installation:
 
-```shell-session
+```bash
 seqerakit --version
 ```
 
 Use the `--help` or `-h` option to list the available commands and their associated options:
 
-```shell-session
+```bash
 seqerakit --help
 ```
 


### PR DESCRIPTION
Docusaurus apparently doesn't understand `console` or `shell-script`.

Setting to `bash` should give syntax highlighting.

@netlify /platform/24.2/seqerakit/installation