### PR TITLE
Document limitations of config profiles detection for dropdown

### DIFF
--- a/platform_versioned_docs/version-24.2/launch/launchpad.mdx
+++ b/platform_versioned_docs/version-24.2/launch/launchpad.mdx
@@ -47,6 +47,37 @@ For saved pipelines, **General config** and **Run parameters** fields are prefil
   The credentials associated with the compute environment must have access to the work directory.
   :::
 
+#### Config profiles
+
+The dropdown of available config profiles is populated by inspecting the Nextflow configuration in the pipeline repository. A limited form of static analysis is used to detect profiles in the main configuration and included configurations that match any of the following patterns:
+
+- Includes with a static string:
+  ```groovy
+  includeConfig 'conf/profiles.config'
+  includeConfig 'http://...'
+  ```
+
+- Includes with dynamic string that depends only on parameters that are defined in the config:
+  ```groovy
+  includeConfig params.custom_config
+  includeConfig "${params.custom_config_base}/nfcore_custom.config"
+  ```
+
+- Includes with a ternary expression:
+  ```groovy
+  includeConfig params.custom_config_base ? "${params.custom_config_base}/nfcore_custom.config" : "/dev/null"
+  ```
+  In this case, only the "true" branch (i.e. `"${params.custom_config_base}/nfcore_custom.config"`) is inspected.
+
+- Includes within a try-catch statement:
+  ```groovy
+  try {
+      includeConfig "${params.custom_config_base}/nfcore_custom.config"
+  } catch (Exception e) {
+      // ...
+  }
+  ```
+
 ### Run parameters 
 
 There are three ways to enter **Run parameters** prior to launch:

--- a/platform_versioned_docs/version-24.2/launch/launchpad.mdx
+++ b/platform_versioned_docs/version-24.2/launch/launchpad.mdx
@@ -57,7 +57,7 @@ The dropdown of available config profiles is populated by inspecting the Nextflo
   includeConfig 'http://...'
   ```
 
-- Includes with dynamic string that depends only on parameters that are defined in the config:
+- Includes with dynamic string that depends on parameters defined in the config:
   ```groovy
   includeConfig params.custom_config
   includeConfig "${params.custom_config_base}/nfcore_custom.config"
@@ -67,7 +67,10 @@ The dropdown of available config profiles is populated by inspecting the Nextflo
   ```groovy
   includeConfig params.custom_config_base ? "${params.custom_config_base}/nfcore_custom.config" : "/dev/null"
   ```
-  In this case, only the "true" branch (i.e. `"${params.custom_config_base}/nfcore_custom.config"`) is inspected.
+  
+  :::note
+  Only the "true" branch is inspected.
+  :::
 
 - Includes within a try-catch statement:
   ```groovy


### PR DESCRIPTION
Source: https://github.com/seqeralabs/platform/pull/7870

The config profiles dropdown in the launch form is populated by inspecting the pipeline config files. This process supports only a few common syntax patterns in the nextflow config, so we would like to document them so that users know which patterns will work.

The linked PR is a patch for the upcoming enterprise release, but these docs are less urgent. Happy to edit / move this content as you see fit. We just want to document this behavior publicly.