### PR TITLE
MultiQC sidebar: Add AI page

### DIFF
--- a/multiqc_docs/sidebar.js
+++ b/multiqc_docs/sidebar.js
@@ -29,6 +29,7 @@ export default {
         ]
       },
       "custom_content/index",
+      "ai/index",
       {
         "type": "category",
         "label": "Usage",


### PR DESCRIPTION
Adds in link in sidebar for new docs page.

To be merged once https://github.com/MultiQC/MultiQC/pull/2915 is merged.

To test:

```bash
# Check out this PR in your local copy of the docs repo
git checkout multiqc-sidebar-ai

# Check out the 'ai' branch of the MultiQC repo
cd multiqc_docs/multiqc_repo
git checkout ai
git pull

# Run the local docs server
cd ../../
npm run dev
```