### PR TITLE
Fixing codeblock component

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -163,7 +163,6 @@ nav.menu .menu__list-item--collapsed .menu__link--sublist:after,
 }
 /* Custom styling for code blocks content */
 .theme-code-block pre {
-  white-space: pre-wrap; 
-  word-wrap: break-word; 
+  white-space: pre; 
   overflow-x: auto; 
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -153,3 +153,17 @@ nav.menu .menu__list-item--collapsed .menu__link--sublist:after,
     color: #98a3ff;
   }
 }
+
+/* Custom styling for code blocks */
+.theme-code-block {
+  overflow-x: auto; 
+  max-width: 100%; 
+  width: 100%; 
+  box-sizing: border-box;
+}
+/* Custom styling for code blocks content */
+.theme-code-block pre {
+  white-space: pre-wrap; 
+  word-wrap: break-word; 
+  overflow-x: auto; 
+}


### PR DESCRIPTION
Hi @ewels and @justinegeffen,

I found out that the issue was with the code block component. It wasn't getting the correct width, so it made the component expand too much. This caused the wrapper container to stretch, pushing the navigation to the bottom due to the flex-wrap prop.