### PR TITLE
dp-909: fix codeblock, nav

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -151,7 +151,3 @@ nav.menu .menu__list-item--collapsed .menu__link--sublist:after,
     color: #98a3ff;
   }
 }
-
-.theme-code-block code {
-  max-width: 100px;
-}

--- a/src/theme/BlogLayout/index.js
+++ b/src/theme/BlogLayout/index.js
@@ -14,8 +14,8 @@ export default function BlogLayout(props) {
         <BlogSidebar sidebar={sidebar} />
         <main className={styles.blogMain}>
           <div className="container padding-top--lg padding-bottom--lg">
-            <div className="row">
-              <div className="col">
+            <div className={clsx(styles.blogBody, "row")}>
+              <div className={clsx(styles.blogContent, "col")}>
                 {children}
               </div>
               {toc && (

--- a/src/theme/BlogLayout/styles.module.css
+++ b/src/theme/BlogLayout/styles.module.css
@@ -1,19 +1,32 @@
 @media (min-width: 997px) {
-    .blogWrapper {
-        display: flex;
-        width: 100%;
-    }
+  .blogWrapper {
+    display: flex;
+    width: 100%;
+  }
 }
 
 .blogMain {
-    flex-grow: 1;
+  flex-grow: 1;
+  flex-wrap: nowrap;
+  max-width: 100%;
+  @media (min-width: 997px) {
+    max-width: calc(100% - var(--doc-sidebar-width));
+  }
 }
 
 .toc {
-    display: none;
+  display: none;
+  @media (min-width: 997px) {
+    display: flex;
+  }
 }
-@media (min-width: 1312px) {
-    .toc {
-        display: block;
-    }
+
+@media (min-width: 997px) {
+  .blogBody {
+    display: flex;
+    flex-wrap: nowrap;
+  }
+  .blogContent {
+    max-width: 75% !important;
+  }
 }


### PR DESCRIPTION
Quick fix: from a prior [commit](https://github.com/seqeralabs/docs/pull/362), adding max width on code is hiding the table on this [page](https://docs.seqera.io/multiqc/getting_started/installation)

```
.theme-code-block code {
    max-width: 100px;
}
```

I added a max width on the blog layout instead and made some small adjustments to correct the code block from disappearing and also keep the nav appearing on the right.