### PR TITLE
Fix minimum nextflow version number for using Azure Managed Identities

### DIFF
--- a/platform_versioned_docs/version-24.2/compute-envs/azure-batch.mdx
+++ b/platform_versioned_docs/version-24.2/compute-envs/azure-batch.mdx
@@ -182,7 +182,7 @@ To create an Entra service principal:
 ##### Managed identity
 
 :::info
-To use managed identities, Seqera requires Nextflow version 24.06.0-edge or later.
+To use managed identities, Seqera requires Nextflow version 24.10.0 or later.
 :::
 
 Nextflow can authenticate to Azure services using a managed identity. This method offers enhanced security compared to access keys, but must run on Azure infrastructure. 


### PR DESCRIPTION
The number still referred to the edge release, unlike <24.1 documentation, so I've updated it.