### PR TITLE
Update Enterprise /latest and /24.3 redirects to /24.2

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,10 @@
 /platform/latest/*   /platform/24.3/:splat   301
 
+# Temporarily redirect latest Platform docs Enterprise pages to current Enterprise version (cloud.latest - 1)
+# Remove when Enterprise version is released and Cloud and ENT latest major versions are at parity
+/platform/latest/enterprise/* /platform/24.2/enterprise/:splat 301
+/platform/24.3/enterprise/* /platform/24.2/enterprise/:splat 301
+
 /nextflow           https://www.nextflow.io/docs/latest/ 301!
 
 # Add redirects to account for Wave docs refresh


### PR DESCRIPTION
Per https://seqera.slack.com/archives/C040MFU06AE/p1739525549856709?thread_ts=1739489596.578989&cid=C040MFU06AE, adding 301 redirects to catch all Enterprise pages from latest and 24.3 and redirect them to 24.2 

Redirect to be removed when Cloud and ENT major latest versions are on parity. 