### PR TITLE
Test for better version visibility

### DIFF
--- a/platform_versioned_sidebars/version-24.3-sidebars.json
+++ b/platform_versioned_sidebars/version-24.3-sidebars.json
@@ -137,7 +137,7 @@
     },
     {
       "type": "category",
-      "label": "Enterprise",
+      "label": "Enterprise 24.2",
       "collapsed": true,
       "items": [
         "enterprise/index"


### PR DESCRIPTION
- Added version number to Enterprise menu item for better indication of what Ent version we're on.
- Docs remain within the previous version folder until bump.