### PR TITLE
Reorganize usage limits page

### DIFF
--- a/platform_versioned_docs/version-23.4/limits/limits.mdx
+++ b/platform_versioned_docs/version-23.4/limits/limits.mdx
@@ -9,22 +9,22 @@ Seqera Platform elements and features have default limits per organization and w
 
 ### Organizations
 
-| Description             | Free | Cloud Pro + Enterprise | 
-| ----------------------- | ---- | ---------------------- |
-| Members                 | 50   | 50, or per license     |
-| Workspaces              | 50   | 50, or per license     |
-| Teams                   | 20   | 20, or per license     |
-| Run history             | 250  | 250, or per license    |
-| Active runs             | 3    | 100, or per license    |
+| Description             | Basic | Cloud Pro + Enterprise | 
+| ----------------------- | ----- | ---------------------- |
+| Members                 | 50    | 50, or per license     |
+| Workspaces              | 50    | 50, or per license     |
+| Teams                   | 20    | 20, or per license     |
+| Run history             | 250   | 250, or per license    |
+| Active runs             | 3     | 100, or per license    |
 
 ### Workspaces
 
-| Description  | Free | Cloud Pro + Enterprise |
-| ------------ | ---- | ---------------------- |
-| Participants | 50   | 50, or per license     |
-| Pipelines    | 100  | 100, or per license    |
-| Datasets     | 100  | 1000, or per license   |
-| Labels       | 1000 | 1000, or per license   |
+| Description  | Basic | Cloud Pro + Enterprise |
+| ------------ | ----- | ---------------------- |
+| Participants | 50    | 50, or per license     |
+| Pipelines    | 100   | 100, or per license    |
+| Datasets     | 100   | 1000, or per license   |
+| Labels       | 1000  | 1000, or per license   |
 
 :::note 
 Some Enterprise instances on older licenses are limited to 100 labels per workspace. [Contact support](mailto:support@seqera.io) to upgrade your license.

--- a/platform_versioned_docs/version-23.4/limits/limits.mdx
+++ b/platform_versioned_docs/version-23.4/limits/limits.mdx
@@ -11,7 +11,7 @@ Seqera Platform elements and features have default limits per organization and w
 
 | Description             | Basic | Cloud Pro + Enterprise | 
 | ----------------------- | ----- | ---------------------- |
-| Members                 | 50    | 50, or per license     |
+| Members                 | 3     | 50, or per license     |
 | Workspaces              | 50    | 50, or per license     |
 | Teams                   | 20    | 20, or per license     |
 | Run history             | 250   | 250, or per license    |
@@ -21,7 +21,7 @@ Seqera Platform elements and features have default limits per organization and w
 
 | Description  | Basic | Cloud Pro + Enterprise |
 | ------------ | ----- | ---------------------- |
-| Participants | 50    | 50, or per license     |
+| Participants | 3     | 50, or per license     |
 | Pipelines    | 100   | 100, or per license    |
 | Datasets     | 100   | 1000, or per license   |
 | Labels       | 1000  | 1000, or per license   |

--- a/platform_versioned_docs/version-23.4/limits/limits.mdx
+++ b/platform_versioned_docs/version-23.4/limits/limits.mdx
@@ -1,18 +1,26 @@
 ---
 title: "Usage limits"
 description: "An overview of Seqera Cloud usage limits"
-date: "21 Apr 2023"
+date: "19 Feb 2025"
 tags: [limits]
 ---
 
-Seqera Platform elements and features have default limits per workspace and organization.
+Seqera Platform elements and features have default limits per organization and workspace.
+
+### Organizations
+
+| Description             | Free | Cloud Pro + Enterprise | 
+| ----------------------- | ---- | ---------------------- |
+| Members                 | 50   | 50, or per license     |
+| Workspaces              | 50   | 50, or per license     |
+| Teams                   | 20   | 20, or per license     |
+| Run history             | 250  | 250, or per license    |
+| Active runs             | 3    | 100, or per license    |
 
 ### Workspaces
 
 | Description  | Free | Cloud Pro + Enterprise |
 | ------------ | ---- | ---------------------- |
-| Active runs  | 5    | 100, or per license    |
-| Members      | 50   | 50, or per license     |
 | Participants | 50   | 50, or per license     |
 | Pipelines    | 100  | 100, or per license    |
 | Datasets     | 100  | 1000, or per license   |
@@ -21,13 +29,6 @@ Seqera Platform elements and features have default limits per workspace and orga
 :::note 
 Some Enterprise instances on older licenses are limited to 100 labels per workspace. [Contact support](mailto:support@seqera.io) to upgrade your license.
 :::
-
-### Organizations
-
-| Description | Free | Cloud Pro + Enterprise | 
-| ----------- | ---- | ---------------------- |
-| Workspaces  | 50   | 50, or per license     |
-| Teams       | 20   | 20, or per license     |
 
 ### Datasets
 

--- a/platform_versioned_docs/version-24.1/limits/limits.mdx
+++ b/platform_versioned_docs/version-24.1/limits/limits.mdx
@@ -16,7 +16,7 @@ Seqera Platform elements and features have default limits per organization and w
 | Teams                   | 20    | 20, or per license     |
 | Run history             | 250   | 250, or per license    |
 | Active runs             | 3     | 100, or per license    |
-| Running studio sessions | 1     | 1000, or per license   |
+| Running Studio sessions | 1     | 1000, or per license   |
 
 ### Workspaces
 

--- a/platform_versioned_docs/version-24.1/limits/limits.mdx
+++ b/platform_versioned_docs/version-24.1/limits/limits.mdx
@@ -9,23 +9,23 @@ Seqera Platform elements and features have default limits per organization and w
 
 ### Organizations
 
-| Description             | Free | Cloud Pro + Enterprise | 
-| ----------------------- | ---- | ---------------------- |
-| Members                 | 50   | 50, or per license     |
-| Workspaces              | 50   | 50, or per license     |
-| Teams                   | 20   | 20, or per license     |
-| Run history             | 250  | 250, or per license    |
-| Active runs             | 3    | 100, or per license    |
-| Running studio sessions | 1    | 1000, or per license   |
+| Description             | Basic | Cloud Pro + Enterprise | 
+| ----------------------- | ----- | ---------------------- |
+| Members                 | 50    | 50, or per license     |
+| Workspaces              | 50    | 50, or per license     |
+| Teams                   | 20    | 20, or per license     |
+| Run history             | 250   | 250, or per license    |
+| Active runs             | 3     | 100, or per license    |
+| Running studio sessions | 1     | 1000, or per license   |
 
 ### Workspaces
 
-| Description  | Free | Cloud Pro + Enterprise |
-| ------------ | ---- | ---------------------- |
-| Participants | 50   | 50, or per license     |
-| Pipelines    | 100  | 100, or per license    |
-| Datasets     | 100  | 1000, or per license   |
-| Labels       | 1000 | 1000, or per license   |
+| Description  | Basic | Cloud Pro + Enterprise |
+| ------------ | ----- | ---------------------- |
+| Participants | 50    | 50, or per license     |
+| Pipelines    | 100   | 100, or per license    |
+| Datasets     | 100   | 1000, or per license   |
+| Labels       | 1000  | 1000, or per license   |
 
 :::note 
 Some Enterprise instances on older licenses are limited to 100 labels per workspace. [Contact support](mailto:support@seqera.io) to upgrade your license.

--- a/platform_versioned_docs/version-24.1/limits/limits.mdx
+++ b/platform_versioned_docs/version-24.1/limits/limits.mdx
@@ -11,7 +11,7 @@ Seqera Platform elements and features have default limits per organization and w
 
 | Description             | Basic | Cloud Pro + Enterprise | 
 | ----------------------- | ----- | ---------------------- |
-| Members                 | 50    | 50, or per license     |
+| Members                 | 3     | 50, or per license     |
 | Workspaces              | 50    | 50, or per license     |
 | Teams                   | 20    | 20, or per license     |
 | Run history             | 250   | 250, or per license    |
@@ -22,7 +22,7 @@ Seqera Platform elements and features have default limits per organization and w
 
 | Description  | Basic | Cloud Pro + Enterprise |
 | ------------ | ----- | ---------------------- |
-| Participants | 50    | 50, or per license     |
+| Participants | 3     | 50, or per license     |
 | Pipelines    | 100   | 100, or per license    |
 | Datasets     | 100   | 1000, or per license   |
 | Labels       | 1000  | 1000, or per license   |

--- a/platform_versioned_docs/version-24.1/limits/limits.mdx
+++ b/platform_versioned_docs/version-24.1/limits/limits.mdx
@@ -1,18 +1,27 @@
 ---
 title: "Usage limits"
 description: "An overview of Seqera Cloud usage limits"
-date: "21 Apr 2023"
+date: "19 Feb 2025"
 tags: [limits]
 ---
 
-Seqera Platform elements and features have default limits per workspace and organization.
+Seqera Platform elements and features have default limits per organization and workspace.
+
+### Organizations
+
+| Description             | Free | Cloud Pro + Enterprise | 
+| ----------------------- | ---- | ---------------------- |
+| Members                 | 50   | 50, or per license     |
+| Workspaces              | 50   | 50, or per license     |
+| Teams                   | 20   | 20, or per license     |
+| Run history             | 250  | 250, or per license    |
+| Active runs             | 3    | 100, or per license    |
+| Running studio sessions | 1    | 1000, or per license   |
 
 ### Workspaces
 
 | Description  | Free | Cloud Pro + Enterprise |
 | ------------ | ---- | ---------------------- |
-| Active runs  | 5    | 100, or per license    |
-| Members      | 50   | 50, or per license     |
 | Participants | 50   | 50, or per license     |
 | Pipelines    | 100  | 100, or per license    |
 | Datasets     | 100  | 1000, or per license   |
@@ -22,24 +31,11 @@ Seqera Platform elements and features have default limits per workspace and orga
 Some Enterprise instances on older licenses are limited to 100 labels per workspace. [Contact support](mailto:support@seqera.io) to upgrade your license.
 :::
 
-### Organizations
-
-| Description | Free | Cloud Pro + Enterprise | 
-| ----------- | ---- | ---------------------- |
-| Workspaces  | 50   | 50, or per license     |
-| Teams       | 20   | 20, or per license     |
-
 ### Datasets
 
 | Description          | Default limit |
 | -------------------- | ------------- |
 | File size            | 10 MB         |
 | Versions per dataset | 100           |
-
-### Data Studios
-
-| Description                  | Free | Cloud Pro + Enterprise |
-| ---------------------------- | ---- | ---------------------- |
-| Running data studio sessions | 1    | 1000, or per license   |
 
 If you need higher limits and capabilities, [contact us](https://seqera.io/contact-us/) to discuss your application requirements.

--- a/platform_versioned_docs/version-24.2/limits/limits.mdx
+++ b/platform_versioned_docs/version-24.2/limits/limits.mdx
@@ -16,7 +16,7 @@ Seqera Platform elements and features have default limits per organization and w
 | Teams                   | 20    | 20, or per license     |
 | Run history             | 250   | 250, or per license    |
 | Active runs             | 3     | 100, or per license    |
-| Running studio sessions | 1     | 1000, or per license   |
+| Running Studio sessions | 1     | 1000, or per license   |
 
 ### Workspaces
 

--- a/platform_versioned_docs/version-24.2/limits/limits.mdx
+++ b/platform_versioned_docs/version-24.2/limits/limits.mdx
@@ -9,23 +9,23 @@ Seqera Platform elements and features have default limits per organization and w
 
 ### Organizations
 
-| Description             | Free | Cloud Pro + Enterprise | 
-| ----------------------- | ---- | ---------------------- |
-| Members                 | 50   | 50, or per license     |
-| Workspaces              | 50   | 50, or per license     |
-| Teams                   | 20   | 20, or per license     |
-| Run history             | 250  | 250, or per license    |
-| Active runs             | 3    | 100, or per license    |
-| Running studio sessions | 1    | 1000, or per license   |
+| Description             | Basic | Cloud Pro + Enterprise | 
+| ----------------------- | ----- | ---------------------- |
+| Members                 | 50    | 50, or per license     |
+| Workspaces              | 50    | 50, or per license     |
+| Teams                   | 20    | 20, or per license     |
+| Run history             | 250   | 250, or per license    |
+| Active runs             | 3     | 100, or per license    |
+| Running studio sessions | 1     | 1000, or per license   |
 
 ### Workspaces
 
-| Description  | Free | Cloud Pro + Enterprise |
-| ------------ | ---- | ---------------------- |
-| Participants | 50   | 50, or per license     |
-| Pipelines    | 100  | 100, or per license    |
-| Datasets     | 100  | 1000, or per license   |
-| Labels       | 1000 | 1000, or per license   |
+| Description  | Basic | Cloud Pro + Enterprise |
+| ------------ | ----- | ---------------------- |
+| Participants | 50    | 50, or per license     |
+| Pipelines    | 100   | 100, or per license    |
+| Datasets     | 100   | 1000, or per license   |
+| Labels       | 1000  | 1000, or per license   |
 
 :::note 
 Some Enterprise instances on older licenses are limited to 100 labels per workspace. [Contact support](mailto:support@seqera.io) to upgrade your license.

--- a/platform_versioned_docs/version-24.2/limits/limits.mdx
+++ b/platform_versioned_docs/version-24.2/limits/limits.mdx
@@ -11,7 +11,7 @@ Seqera Platform elements and features have default limits per organization and w
 
 | Description             | Basic | Cloud Pro + Enterprise | 
 | ----------------------- | ----- | ---------------------- |
-| Members                 | 50    | 50, or per license     |
+| Members                 | 3     | 50, or per license     |
 | Workspaces              | 50    | 50, or per license     |
 | Teams                   | 20    | 20, or per license     |
 | Run history             | 250   | 250, or per license    |
@@ -22,7 +22,7 @@ Seqera Platform elements and features have default limits per organization and w
 
 | Description  | Basic | Cloud Pro + Enterprise |
 | ------------ | ----- | ---------------------- |
-| Participants | 50    | 50, or per license     |
+| Participants | 3     | 50, or per license     |
 | Pipelines    | 100   | 100, or per license    |
 | Datasets     | 100   | 1000, or per license   |
 | Labels       | 1000  | 1000, or per license   |

--- a/platform_versioned_docs/version-24.2/limits/limits.mdx
+++ b/platform_versioned_docs/version-24.2/limits/limits.mdx
@@ -1,18 +1,27 @@
 ---
 title: "Usage limits"
 description: "An overview of Seqera Cloud usage limits"
-date: "21 Apr 2023"
+date: "19 Feb 2025"
 tags: [limits]
 ---
 
-Seqera Platform elements and features have default limits per workspace and organization.
+Seqera Platform elements and features have default limits per organization and workspace.
+
+### Organizations
+
+| Description             | Free | Cloud Pro + Enterprise | 
+| ----------------------- | ---- | ---------------------- |
+| Members                 | 50   | 50, or per license     |
+| Workspaces              | 50   | 50, or per license     |
+| Teams                   | 20   | 20, or per license     |
+| Run history             | 250  | 250, or per license    |
+| Active runs             | 3    | 100, or per license    |
+| Running studio sessions | 1    | 1000, or per license   |
 
 ### Workspaces
 
 | Description  | Free | Cloud Pro + Enterprise |
 | ------------ | ---- | ---------------------- |
-| Active runs  | 5    | 100, or per license    |
-| Members      | 50   | 50, or per license     |
 | Participants | 50   | 50, or per license     |
 | Pipelines    | 100  | 100, or per license    |
 | Datasets     | 100  | 1000, or per license   |
@@ -22,24 +31,11 @@ Seqera Platform elements and features have default limits per workspace and orga
 Some Enterprise instances on older licenses are limited to 100 labels per workspace. [Contact support](mailto:support@seqera.io) to upgrade your license.
 :::
 
-### Organizations
-
-| Description | Free | Cloud Pro + Enterprise | 
-| ----------- | ---- | ---------------------- |
-| Workspaces  | 50   | 50, or per license     |
-| Teams       | 20   | 20, or per license     |
-
 ### Datasets
 
 | Description          | Default limit |
 | -------------------- | ------------- |
 | File size            | 10 MB         |
 | Versions per dataset | 100           |
-
-### Data Studios
-
-| Description                  | Free | Cloud Pro + Enterprise |
-| ---------------------------- | ---- | ---------------------- |
-| Running data studio sessions | 1    | 1000, or per license   |
 
 If you need higher limits and capabilities, [contact us](https://seqera.io/contact-us/) to discuss your application requirements.

--- a/platform_versioned_docs/version-24.3/limits/limits.mdx
+++ b/platform_versioned_docs/version-24.3/limits/limits.mdx
@@ -16,7 +16,7 @@ Seqera Platform elements and features have default limits per organization and w
 | Teams                   | 20    | 20, or per license     |
 | Run history             | 250   | 250, or per license    |
 | Active runs             | 3     | 100, or per license    |
-| Running studio sessions | 1     | 1000, or per license   |
+| Running Studio sessions | 1     | 1000, or per license   |
 
 ### Workspaces
 

--- a/platform_versioned_docs/version-24.3/limits/limits.mdx
+++ b/platform_versioned_docs/version-24.3/limits/limits.mdx
@@ -9,23 +9,23 @@ Seqera Platform elements and features have default limits per organization and w
 
 ### Organizations
 
-| Description             | Free | Cloud Pro + Enterprise | 
-| ----------------------- | ---- | ---------------------- |
-| Members                 | 50   | 50, or per license     |
-| Workspaces              | 50   | 50, or per license     |
-| Teams                   | 20   | 20, or per license     |
-| Run history             | 250  | 250, or per license    |
-| Active runs             | 3    | 100, or per license    |
-| Running studio sessions | 1    | 1000, or per license   |
+| Description             | Basic | Cloud Pro + Enterprise | 
+| ----------------------- | ----- | ---------------------- |
+| Members                 | 50    | 50, or per license     |
+| Workspaces              | 50    | 50, or per license     |
+| Teams                   | 20    | 20, or per license     |
+| Run history             | 250   | 250, or per license    |
+| Active runs             | 3     | 100, or per license    |
+| Running studio sessions | 1     | 1000, or per license   |
 
 ### Workspaces
 
-| Description  | Free | Cloud Pro + Enterprise |
-| ------------ | ---- | ---------------------- |
-| Participants | 50   | 50, or per license     |
-| Pipelines    | 100  | 100, or per license    |
-| Datasets     | 100  | 1000, or per license   |
-| Labels       | 1000 | 1000, or per license   |
+| Description  | Basic | Cloud Pro + Enterprise |
+| ------------ | ----- | ---------------------- |
+| Participants | 50    | 50, or per license     |
+| Pipelines    | 100   | 100, or per license    |
+| Datasets     | 100   | 1000, or per license   |
+| Labels       | 1000  | 1000, or per license   |
 
 :::note 
 Some Enterprise instances on older licenses are limited to 100 labels per workspace. [Contact support](mailto:support@seqera.io) to upgrade your license.

--- a/platform_versioned_docs/version-24.3/limits/limits.mdx
+++ b/platform_versioned_docs/version-24.3/limits/limits.mdx
@@ -11,7 +11,7 @@ Seqera Platform elements and features have default limits per organization and w
 
 | Description             | Basic | Cloud Pro + Enterprise | 
 | ----------------------- | ----- | ---------------------- |
-| Members                 | 50    | 50, or per license     |
+| Members                 | 3     | 50, or per license     |
 | Workspaces              | 50    | 50, or per license     |
 | Teams                   | 20    | 20, or per license     |
 | Run history             | 250   | 250, or per license    |
@@ -22,7 +22,7 @@ Seqera Platform elements and features have default limits per organization and w
 
 | Description  | Basic | Cloud Pro + Enterprise |
 | ------------ | ----- | ---------------------- |
-| Participants | 50    | 50, or per license     |
+| Participants | 3     | 50, or per license     |
 | Pipelines    | 100   | 100, or per license    |
 | Datasets     | 100   | 1000, or per license   |
 | Labels       | 1000  | 1000, or per license   |

--- a/platform_versioned_docs/version-24.3/limits/limits.mdx
+++ b/platform_versioned_docs/version-24.3/limits/limits.mdx
@@ -1,18 +1,27 @@
 ---
 title: "Usage limits"
 description: "An overview of Seqera Cloud usage limits"
-date: "21 Apr 2023"
+date: "19 Feb 2025"
 tags: [limits]
 ---
 
-Seqera Platform elements and features have default limits per workspace and organization.
+Seqera Platform elements and features have default limits per organization and workspace.
+
+### Organizations
+
+| Description             | Free | Cloud Pro + Enterprise | 
+| ----------------------- | ---- | ---------------------- |
+| Members                 | 50   | 50, or per license     |
+| Workspaces              | 50   | 50, or per license     |
+| Teams                   | 20   | 20, or per license     |
+| Run history             | 250  | 250, or per license    |
+| Active runs             | 3    | 100, or per license    |
+| Running studio sessions | 1    | 1000, or per license   |
 
 ### Workspaces
 
 | Description  | Free | Cloud Pro + Enterprise |
 | ------------ | ---- | ---------------------- |
-| Active runs  | 5    | 100, or per license    |
-| Members      | 50   | 50, or per license     |
 | Participants | 50   | 50, or per license     |
 | Pipelines    | 100  | 100, or per license    |
 | Datasets     | 100  | 1000, or per license   |
@@ -22,24 +31,11 @@ Seqera Platform elements and features have default limits per workspace and orga
 Some Enterprise instances on older licenses are limited to 100 labels per workspace. [Contact support](mailto:support@seqera.io) to upgrade your license.
 :::
 
-### Organizations
-
-| Description | Free | Cloud Pro + Enterprise | 
-| ----------- | ---- | ---------------------- |
-| Workspaces  | 50   | 50, or per license     |
-| Teams       | 20   | 20, or per license     |
-
 ### Datasets
 
 | Description          | Default limit |
 | -------------------- | ------------- |
 | File size            | 10 MB         |
 | Versions per dataset | 100           |
-
-### Data Studios
-
-| Description                  | Free | Cloud Pro + Enterprise |
-| ---------------------------- | ---- | ---------------------- |
-| Running data studio sessions | 1    | 1000, or per license   |
 
 If you need higher limits and capabilities, [contact us](https://seqera.io/contact-us/) to discuss your application requirements.


### PR DESCRIPTION
- Moved Organizations above Workspaces (Org limits dictate Wksp limits)
- Move Studios into Organization-level group (doesn't need it's own section)
- Reduce number of Free-Tier Organization users to 3 (per new Free-Tier limits)
- Reduce number of concurrent (Active) runs from 5 to 3 (per Sales request) ready for Free-Tier messaging feature release (and reflect current pricing page)
- Update `Free` to `Basic` to reflect the pricing page verbiage