### PR TITLE
Add info about security scan results and inspect container builds

### DIFF
--- a/platform_versioned_docs/version-24.2/data_studios/index.mdx
+++ b/platform_versioned_docs/version-24.2/data_studios/index.mdx
@@ -89,19 +89,19 @@ The default user is the `root` account. The following [conda-forge](https://cond
 
 To install additional Python packages during a running session, execute `!pip install <packagename>` commands in your notebook environment. Additional system-level packages can be installed in a terminal window using `apt install <packagename>`.
 
-To see the list of all JupyterLab image templates available, see [public.cr.seqera.io/repo/platform/data-studio-jupyter][ds-jupyter].
+To see the list of all JupyterLab image templates available, including security scan results or to inspect the container specification, see [public.cr.seqera.io/repo/platform/data-studio-jupyter][ds-jupyter].
 
 **RStudio Server 4.4.1**
 
 The default user is the `root` account. To install R packages during a running session, execute `install.packages("<packagename>")` commands in your notebook environment. Additional system-level packages can be installed in a terminal window using `apt install <packagename>`.
 
-To see the list of all RStudio Server image templates available, see [public.cr.seqera.io/repo/platform/data-studio-rstudio][ds-rstudio].
+To see the list of all RStudio Server image templates available, including security scan results or to inspect the container specification, see [public.cr.seqera.io/repo/platform/data-studio-rstudio][ds-rstudio].
 
 **Visual Studio Code 1.93.1**
 
 [Visual Studio Code][def-vsc] is an integrated development environment (IDE) that supports many programming languages. The default user is the `root` account. The container template image ships with the latest stable version of [Nextflow] and the [VSCode extension for Nextflow][nf-lang-server] to make troubleshooting Nextflow workflows easier. To install additional extensions during a running session, select **Extensions**. Additional system-level packages can be installed in a terminal window using `apt install <packagename>`.
 
-To see the list of all Visual Studio Code image templates available, see [public.cr.seqera.io/platform/data-studio-vscode][ds-vscode].
+To see the list of all Visual Studio Code image templates available, including security scan results or to inspect the container specification, see [public.cr.seqera.io/platform/data-studio-vscode][ds-vscode].
 
 **Xpra 6.2.0**
 
@@ -109,7 +109,7 @@ To see the list of all Visual Studio Code image templates available, see [public
 
 The default user is the `root` account. The image is based on `ubuntu:jammy`. Additional system-level packages can be installed during a running session in a terminal window using `apt install <package_name>`.
 
-To see the list of all Xpra image templates available, see [public.cr.seqera.io/repo/platform/data-studio-xpra][ds-xpra].
+To see the list of all Xpra image templates available, including security scan results or to inspect the container specification, see [public.cr.seqera.io/repo/platform/data-studio-xpra][ds-xpra].
 
 ## Studios statuses
 

--- a/platform_versioned_docs/version-24.3/data_studios/index.mdx
+++ b/platform_versioned_docs/version-24.3/data_studios/index.mdx
@@ -89,19 +89,19 @@ The default user is the `root` account. The following [conda-forge](https://cond
 
 To install additional Python packages during a running session, execute `!pip install <packagename>` commands in your notebook environment. Additional system-level packages can be installed in a terminal window using `apt install <packagename>`.
 
-To see the list of all JupyterLab image templates available, see [public.cr.seqera.io/repo/platform/data-studio-jupyter][ds-jupyter].
+To see the list of all JupyterLab image templates available, including security scan results or to inspect the container specification, see [public.cr.seqera.io/repo/platform/data-studio-jupyter][ds-jupyter].
 
 **RStudio Server 4.4.1**
 
 The default user is the `root` account. To install R packages during a running session, execute `install.packages("<packagename>")` commands in your notebook environment. Additional system-level packages can be installed in a terminal window using `apt install <packagename>`.
 
-To see the list of all RStudio Server image templates available, see [public.cr.seqera.io/repo/platform/data-studio-rstudio][ds-rstudio].
+To see the list of all RStudio Server image templates available, including security scan results or to inspect the container specification, see [public.cr.seqera.io/repo/platform/data-studio-rstudio][ds-rstudio].
 
 **Visual Studio Code 1.93.1**
 
 [Visual Studio Code][def-vsc] is an integrated development environment (IDE) that supports many programming languages. The default user is the `root` account. The container template image ships with the latest stable version of [Nextflow] and the [VSCode extension for Nextflow][nf-lang-server] to make troubleshooting Nextflow workflows easier. To install additional extensions during a running session, select **Extensions**. Additional system-level packages can be installed in a terminal window using `apt install <packagename>`.
 
-To see the list of all Visual Studio Code image templates available, see [public.cr.seqera.io/platform/data-studio-vscode][ds-vscode].
+To see the list of all Visual Studio Code image templates available, including security scan results or to inspect the container specification, see [public.cr.seqera.io/platform/data-studio-vscode][ds-vscode].
 
 **Xpra 6.2.0**
 
@@ -109,7 +109,7 @@ To see the list of all Visual Studio Code image templates available, see [public
 
 The default user is the `root` account. The image is based on `ubuntu:jammy`. Additional system-level packages can be installed during a running session in a terminal window using `apt install <package_name>`.
 
-To see the list of all Xpra image templates available, see [public.cr.seqera.io/repo/platform/data-studio-xpra][ds-xpra].
+To see the list of all Xpra image templates available, including security scan results or to inspect the container specification, see [public.cr.seqera.io/repo/platform/data-studio-xpra][ds-xpra].
 
 ## Session statuses
 


### PR DESCRIPTION
Very minor update noting that container registry also includes security scan results and users can inspect container builds.