### PR TITLE
docs: update redis version in manifests

### DIFF
--- a/platform_versioned_docs/version-24.2/enterprise/_templates/cloudformation/aws-ecs-cloudformation.json
+++ b/platform_versioned_docs/version-24.2/enterprise/_templates/cloudformation/aws-ecs-cloudformation.json
@@ -69,7 +69,7 @@
                 "ContainerDefinitions": [
                     {
                     "Name": "redis",
-                    "Image": "cr.seqera.io/public/redis:6.0",
+                    "Image": "cr.seqera.io/public/redis:7.0.10",
                     "Memory": 2000,
                     "Cpu": 0,
                     "PortMappings": [{

--- a/platform_versioned_docs/version-24.2/enterprise/_templates/docker/docker-compose.yml
+++ b/platform_versioned_docs/version-24.2/enterprise/_templates/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - $HOME/.tower/db/mysql:/var/lib/mysql
 
   redis:
-    image: cr.seqera.io/public/redis:6.0
+    image: cr.seqera.io/public/redis:7.0.10
     platform: linux/amd64
     networks:
       - backend

--- a/platform_versioned_docs/version-24.2/enterprise/_templates/k8s/redis.aks.yml
+++ b/platform_versioned_docs/version-24.2/enterprise/_templates/k8s/redis.aks.yml
@@ -44,7 +44,7 @@ spec:
         app: redis
     spec:
       containers:
-        - image: cr.seqera.io/public/redis:6.0
+        - image: cr.seqera.io/public/redis:7.0.10
           name: redis
           args:
             - --appendonly yes

--- a/platform_versioned_docs/version-24.2/enterprise/_templates/k8s/redis.eks.yml
+++ b/platform_versioned_docs/version-24.2/enterprise/_templates/k8s/redis.eks.yml
@@ -44,7 +44,7 @@ spec:
         app: redis
     spec:
       containers:
-        - image: cr.seqera.io/public/redis:6.0
+        - image: cr.seqera.io/public/redis:7.0.10
           name: redis
           args:
             - --appendonly yes

--- a/platform_versioned_docs/version-24.2/enterprise/_templates/k8s/redis.gke.yml
+++ b/platform_versioned_docs/version-24.2/enterprise/_templates/k8s/redis.gke.yml
@@ -29,7 +29,7 @@ spec:
         app: redis
     spec:
       containers:
-        - image: cr.seqera.io/public/redis:6.0
+        - image: cr.seqera.io/public/redis:7.0.10
           name: redis
           args:
             - --appendonly yes


### PR DESCRIPTION
The following updates redis related manifests for `24.X` release notes to have a compatible version of docker - following on from https://github.com/seqeralabs/docs/pull/500

We use this version of Redis for internal preview environments.  