### PR TITLE
fix: Codeblock vertical scrolling EDU-679 / DP-867

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "markdownlint-cli2": "^0.17.1",
         "path": "^0.12.7",
         "postcss": "^8.4.32",
-        "prettier": "^3.0.3",
+        "prettier": "^3.5.3",
         "simple-git": "^3.19.1",
         "tailwindcss": "^3.3.6",
         "typescript": "^4.7.4"
@@ -17372,9 +17372,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "markdownlint-cli2": "^0.17.1",
     "path": "^0.12.7",
     "postcss": "^8.4.32",
-    "prettier": "^3.0.3",
+    "prettier": "^3.5.3",
     "simple-git": "^3.19.1",
     "tailwindcss": "^3.3.6",
     "typescript": "^4.7.4"

--- a/platform-enterprise_versioned_docs/version-23.1/enterprise/stylesheets/fonts.css
+++ b/platform-enterprise_versioned_docs/version-23.1/enterprise/stylesheets/fonts.css
@@ -1,83 +1,104 @@
 @font-face {
-  font-family: 'SF UI Display';
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Ultralight.eot');
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Ultralight.eot?#iefix') format('embedded-opentype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Ultralight.svg#SFUIDisplay-Ultralight') format('svg'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Ultralight.ttf') format('truetype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Ultralight.woff') format('woff'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Ultralight.woff2') format('woff2');
+  font-family: "SF UI Display";
+  src: url("./fonts/sf-ui-display/SFUIDisplay-Ultralight.eot");
+  src:
+    url("./fonts/sf-ui-display/SFUIDisplay-Ultralight.eot?#iefix")
+      format("embedded-opentype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Ultralight.svg#SFUIDisplay-Ultralight")
+      format("svg"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Ultralight.ttf") format("truetype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Ultralight.woff") format("woff"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Ultralight.woff2") format("woff2");
   font-weight: 100;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'SF UI Display';
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Thin.eot');
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Thin.eot?#iefix') format('embedded-opentype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Thin.svg#SFUIDisplay-Thin') format('svg'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Thin.ttf') format('truetype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Thin.woff') format('woff'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Thin.woff2') format('woff2');
+  font-family: "SF UI Display";
+  src: url("./fonts/sf-ui-display/SFUIDisplay-Thin.eot");
+  src:
+    url("./fonts/sf-ui-display/SFUIDisplay-Thin.eot?#iefix")
+      format("embedded-opentype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Thin.svg#SFUIDisplay-Thin")
+      format("svg"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Thin.ttf") format("truetype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Thin.woff") format("woff"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Thin.woff2") format("woff2");
   font-weight: 200;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'SF UI Display';
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Light.eot');
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Light.eot?#iefix') format('embedded-opentype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Light.svg#SFUIDisplay-Light') format('svg'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Light.ttf') format('truetype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Light.woff') format('woff'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Light.woff2') format('woff2');
+  font-family: "SF UI Display";
+  src: url("./fonts/sf-ui-display/SFUIDisplay-Light.eot");
+  src:
+    url("./fonts/sf-ui-display/SFUIDisplay-Light.eot?#iefix")
+      format("embedded-opentype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Light.svg#SFUIDisplay-Light")
+      format("svg"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Light.ttf") format("truetype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Light.woff") format("woff"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Light.woff2") format("woff2");
   font-weight: 300;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'SF UI Display';
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Medium.eot');
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Medium.eot?#iefix') format('embedded-opentype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Medium.svg#SFUIDisplay-Medium') format('svg'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Medium.ttf') format('truetype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Medium.woff') format('woff'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Medium.woff2') format('woff2');
+  font-family: "SF UI Display";
+  src: url("./fonts/sf-ui-display/SFUIDisplay-Medium.eot");
+  src:
+    url("./fonts/sf-ui-display/SFUIDisplay-Medium.eot?#iefix")
+      format("embedded-opentype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Medium.svg#SFUIDisplay-Medium")
+      format("svg"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Medium.ttf") format("truetype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Medium.woff") format("woff"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Medium.woff2") format("woff2");
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'SF UI Display';
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Semibold.eot');
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Semibold.eot?#iefix') format('embedded-opentype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Semibold.svg#SFUIDisplay-Semibold') format('svg'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Semibold.ttf') format('truetype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Semibold.woff') format('woff'),
-       url('./SFUIDisplay-Semibold.woff2') format('woff2');
+  font-family: "SF UI Display";
+  src: url("./fonts/sf-ui-display/SFUIDisplay-Semibold.eot");
+  src:
+    url("./fonts/sf-ui-display/SFUIDisplay-Semibold.eot?#iefix")
+      format("embedded-opentype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Semibold.svg#SFUIDisplay-Semibold")
+      format("svg"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Semibold.ttf") format("truetype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Semibold.woff") format("woff"),
+    url("./SFUIDisplay-Semibold.woff2") format("woff2");
   font-weight: 500;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'SF UI Display';
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Bold.eot');
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Bold.eot?#iefix') format('embedded-opentype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Bold.svg#SFUIDisplay-Bold') format('svg'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Bold.ttf') format('truetype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Bold.woff') format('woff'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Bold.woff2') format('woff2');
+  font-family: "SF UI Display";
+  src: url("./fonts/sf-ui-display/SFUIDisplay-Bold.eot");
+  src:
+    url("./fonts/sf-ui-display/SFUIDisplay-Bold.eot?#iefix")
+      format("embedded-opentype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Bold.svg#SFUIDisplay-Bold")
+      format("svg"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Bold.ttf") format("truetype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Bold.woff") format("woff"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Bold.woff2") format("woff2");
   font-weight: 600;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'SF UI Display';
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Heavy.eot');
-  src: url('./fonts/sf-ui-display/SFUIDisplay-Heavy.eot?#iefix') format('embedded-opentype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Heavy.svg#SFUIDisplay-Heavy') format('svg'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Heavy.ttf') format('truetype'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Heavy.woff') format('woff'),
-       url('./fonts/sf-ui-display/SFUIDisplay-Heavy.woff2') format('woff2');
+  font-family: "SF UI Display";
+  src: url("./fonts/sf-ui-display/SFUIDisplay-Heavy.eot");
+  src:
+    url("./fonts/sf-ui-display/SFUIDisplay-Heavy.eot?#iefix")
+      format("embedded-opentype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Heavy.svg#SFUIDisplay-Heavy")
+      format("svg"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Heavy.ttf") format("truetype"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Heavy.woff") format("woff"),
+    url("./fonts/sf-ui-display/SFUIDisplay-Heavy.woff2") format("woff2");
   font-weight: 700;
   font-style: normal;
 }

--- a/platform-enterprise_versioned_docs/version-23.1/enterprise/stylesheets/overrides.css
+++ b/platform-enterprise_versioned_docs/version-23.1/enterprise/stylesheets/overrides.css
@@ -13,7 +13,7 @@ strong {
   font-size: 20px;
   font-weight: 600;
   color: #000;
-  padding-bottom: .3em;
+  padding-bottom: 0.3em;
 }
 
 .mdx-typeset p {

--- a/src/components/Button/styles.module.css
+++ b/src/components/Button/styles.module.css
@@ -8,7 +8,7 @@
   border-radius: 8px;
   font-weight: 600;
   transition: all 0.2s;
-  text-decoration: none ;
+  text-decoration: none;
   cursor: pointer;
   &:hover .arrow {
     transform: translateX(3px);
@@ -109,8 +109,8 @@
 }
 .alt {
   &:hover {
-    background-color: var(--color-blu-700) ;
-    border-color: var(--color-blu-700) ;
-    color: #fff ;
+    background-color: var(--color-blu-700);
+    border-color: var(--color-blu-700);
+    color: #fff;
   }
 }

--- a/src/components/Button/styles.module.css
+++ b/src/components/Button/styles.module.css
@@ -8,7 +8,7 @@
   border-radius: 8px;
   font-weight: 600;
   transition: all 0.2s;
-  text-decoration: none !important;
+  text-decoration: none ;
   cursor: pointer;
   &:hover .arrow {
     transform: translateX(3px);
@@ -109,8 +109,8 @@
 }
 .alt {
   &:hover {
-    background-color: var(--color-blu-700) !important;
-    border-color: var(--color-blu-700) !important;
-    color: #fff !important;
+    background-color: var(--color-blu-700) ;
+    border-color: var(--color-blu-700) ;
+    color: #fff ;
   }
 }

--- a/src/components/Card/styles.module.css
+++ b/src/components/Card/styles.module.css
@@ -5,7 +5,7 @@
   background: white;
   border-color: var(--ifm-toc-border-color);
   font-size: 14px;
-  color: #160f26 ;
+  color: #160f26;
   transition: all 0.3s;
 }
 .card:hover {
@@ -26,7 +26,7 @@
   box-shadow: 0 0 15px rgba(226, 134, 80);
 }
 .card.platform:hover {
-  box-shadow: 0 0 15px #110C1C;
+  box-shadow: 0 0 15px #110c1c;
 }
 .card.platform svg {
   height: 25px;
@@ -36,9 +36,9 @@
 html[data-theme="dark"] {
   & .card {
     background: rgba(0, 0, 0, 0.5);
-    color: var(--color-brand-300) ;
+    color: var(--color-brand-300);
     & svg path[fill="#160F26"] {
-      fill: var(--color-brand-200) ;
+      fill: var(--color-brand-200);
     }
   }
   & .card.platform:hover {

--- a/src/components/Card/styles.module.css
+++ b/src/components/Card/styles.module.css
@@ -5,7 +5,7 @@
   background: white;
   border-color: var(--ifm-toc-border-color);
   font-size: 14px;
-  color: #160f26 !important;
+  color: #160f26 ;
   transition: all 0.3s;
 }
 .card:hover {
@@ -36,9 +36,9 @@
 html[data-theme="dark"] {
   & .card {
     background: rgba(0, 0, 0, 0.5);
-    color: var(--color-brand-300) !important;
+    color: var(--color-brand-300) ;
     & svg path[fill="#160F26"] {
-      fill: var(--color-brand-200) !important;
+      fill: var(--color-brand-200) ;
     }
   }
   & .card.platform:hover {

--- a/src/components/Search/AlgoliaSearch.module.css
+++ b/src/components/Search/AlgoliaSearch.module.css
@@ -1,44 +1,44 @@
 .searchContainer {
-    position: relative;
-    width: 100%;
-    max-width: 600px;
-    margin: 0 auto;
-  }
-  
-  .searchContainer :global(.aa-Input) {
-    padding: 16px;
-    font-size: 15px;
-    border: 1px solid var(--color-brand-300);
-    border-radius: 8px;
-    background: var(--color-brand-100);
-    width: 100%;
-  }
-  
-  .searchContainer :global(.aa-Input:focus) {
-    outline: none;
-    border-color: var(--color-product);
-  }
-  
-  .searchContainer :global(.aa-Panel) {
-    border: 1px solid var(--color-brand-300);
-    border-radius: 8px;
-    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
-  }
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+}
 
-  :global(.aa-Item) {
-    margin-bottom: 6px;
-  }
-  
-  .searchContainer :global(.aa-Item) {
-    padding: 8px 16px;
-  }
-  
-  .searchContainer :global(.aa-ItemTitle) {
-    font-weight: 500;
-    margin-bottom: 4px;
-  }
-  
-  .searchContainer :global(.aa-ItemDescription) {
-    font-size: 14px;
-    color: var(--color-brand-600);
-  }
+.searchContainer :global(.aa-Input) {
+  padding: 16px;
+  font-size: 15px;
+  border: 1px solid var(--color-brand-300);
+  border-radius: 8px;
+  background: var(--color-brand-100);
+  width: 100%;
+}
+
+.searchContainer :global(.aa-Input:focus) {
+  outline: none;
+  border-color: var(--color-product);
+}
+
+.searchContainer :global(.aa-Panel) {
+  border: 1px solid var(--color-brand-300);
+  border-radius: 8px;
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+}
+
+:global(.aa-Item) {
+  margin-bottom: 6px;
+}
+
+.searchContainer :global(.aa-Item) {
+  padding: 8px 16px;
+}
+
+.searchContainer :global(.aa-ItemTitle) {
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.searchContainer :global(.aa-ItemDescription) {
+  font-size: 14px;
+  color: var(--color-brand-600);
+}

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,27 +1,27 @@
 import React, { createElement, useState, useEffect, useRef } from "react";
 
 // Import the required components
-import ProductItem, { setCloseSearchModalCallback } from './ProductItem';
-import { getAlgoliaResults } from '@algolia/autocomplete-js';
+import ProductItem, { setCloseSearchModalCallback } from "./ProductItem";
+import { getAlgoliaResults } from "@algolia/autocomplete-js";
 // Use direct CommonJS import pattern
 import Autosearch from "./AlgoliaSearch";
 import AiIcon from "../../theme/Navbar/Layout/SeqeraHeader/HeaderDesktop/NavItems/images/AiIcon";
 import SearchIcon from "./SearchIcon";
 // Import algoliasearch
-import algoliasearch from 'algoliasearch';
+import algoliasearch from "algoliasearch";
 
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
 export default function Search() {
-  const {siteConfig} = useDocusaurusContext();
-  const algoliaConfig = siteConfig.customFields?.algolia as any || {};
+  const { siteConfig } = useDocusaurusContext();
+  const algoliaConfig = (siteConfig.customFields?.algolia as any) || {};
   const appId = algoliaConfig.appId;
   const apiKey = algoliaConfig.apiKey;
   const envIndexName = algoliaConfig.indexName;
 
   // Create the search client
   const searchClient = algoliasearch(appId, apiKey);
-  
+
   // Add getRecommendations method to the client to fix the linter error
   (searchClient as any).getRecommendations = async () => ({ results: [] });
 
@@ -33,19 +33,19 @@ export default function Search() {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       // Check for Command+K (Mac) or Ctrl+K (Windows/Linux)
-      if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
-        setIsOpen(prevIsOpen => !prevIsOpen);
+        setIsOpen((prevIsOpen) => !prevIsOpen);
       }
       // Close on Escape key
-      if (event.key === 'Escape' && isOpen) {
+      if (event.key === "Escape" && isOpen) {
         setIsOpen(false);
       }
     };
 
-    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown);
     return () => {
-      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener("keydown", handleKeyDown);
     };
   }, [isOpen]);
 
@@ -54,18 +54,18 @@ export default function Search() {
     if (isOpen) {
       // Save the current scroll position
       const scrollY = window.scrollY;
-      
+
       // Add styles to prevent scrolling on the body
-      document.body.style.position = 'fixed';
+      document.body.style.position = "fixed";
       document.body.style.top = `-${scrollY}px`;
-      document.body.style.width = '100%';
-      
+      document.body.style.width = "100%";
+
       return () => {
         // Re-enable scrolling when component unmounts or modal closes
-        document.body.style.position = '';
-        document.body.style.top = '';
-        document.body.style.width = '';
-        
+        document.body.style.position = "";
+        document.body.style.top = "";
+        document.body.style.width = "";
+
         // Restore scroll position
         window.scrollTo(0, scrollY);
       };
@@ -78,7 +78,7 @@ export default function Search() {
       // Small timeout to ensure the input is in the DOM
       setTimeout(() => {
         // Direct focus to the input element inside the Autosearch container
-        const inputElement = containerRef.current?.querySelector('input');
+        const inputElement = containerRef.current?.querySelector("input");
         if (inputElement) {
           inputElement.focus();
         }
@@ -90,22 +90,24 @@ export default function Search() {
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       // Check if the click is inside the modal or any Algolia autocomplete elements
-      const isInsideModal = modalRef.current && modalRef.current.contains(event.target as Node);
-      
+      const isInsideModal =
+        modalRef.current && modalRef.current.contains(event.target as Node);
+
       // Check if the click is inside any Algolia autocomplete elements
-      const isInsideAutocomplete = 
-        (event.target as Element)?.closest('.aa-Panel')
-      
+      const isInsideAutocomplete = (event.target as Element)?.closest(
+        ".aa-Panel",
+      );
+
       if (!isInsideModal && !isInsideAutocomplete) {
         setIsOpen(false);
       }
     };
-    
+
     if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener("mousedown", handleClickOutside);
     }
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener("mousedown", handleClickOutside);
     };
   }, [isOpen]);
 
@@ -117,13 +119,15 @@ export default function Search() {
     if (!modalElement) return;
 
     const focusableElements = modalElement.querySelectorAll(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
     );
     const firstFocusableElement = focusableElements[0] as HTMLElement;
-    const lastFocusableElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+    const lastFocusableElement = focusableElements[
+      focusableElements.length - 1
+    ] as HTMLElement;
 
     const handleTabKey = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab') return;
+      if (e.key !== "Tab") return;
 
       if (e.shiftKey) {
         if (document.activeElement === firstFocusableElement) {
@@ -138,9 +142,9 @@ export default function Search() {
       }
     };
 
-    modalElement.addEventListener('keydown', handleTabKey);
+    modalElement.addEventListener("keydown", handleTabKey);
     return () => {
-      modalElement.removeEventListener('keydown', handleTabKey);
+      modalElement.removeEventListener("keydown", handleTabKey);
     };
   }, [isOpen]);
 
@@ -148,24 +152,24 @@ export default function Search() {
   useEffect(() => {
     if (isOpen) {
       // Apply CSS to ensure dropdowns appear above the modal
-      const style = document.createElement('style');
-      style.id = 'search-z-index-fix';
+      const style = document.createElement("style");
+      style.id = "search-z-index-fix";
       style.innerHTML = `
         .aa-Panel {
-          z-index: 9999 !important;
+          z-index: 9999 ;
         }
         .aa-DetachedOverlay {
-          z-index: 9998 !important;
+          z-index: 9998 ;
         }
         .aa-DetachedContainer {
-          z-index: 9999 !important;
+          z-index: 9999 ;
         }
       `;
       document.head.appendChild(style);
-      
+
       return () => {
         // Clean up when component unmounts or modal closes
-        const styleElement = document.getElementById('search-z-index-fix');
+        const styleElement = document.getElementById("search-z-index-fix");
         if (styleElement) {
           styleElement.remove();
         }
@@ -177,144 +181,163 @@ export default function Search() {
     <>
       {isOpen && (
         <div className="fixed inset-0 bg-black bg-opacity-25 z-40 flex items-start justify-center pt-1">
-          <div 
-            ref={modalRef} 
+          <div
+            ref={modalRef}
             className="w-full max-w-2xl bg-white rounded-tl-md rounded-tr-md top-20 border-blue-500 border p-2 max-lg:rounded-bl-md max-lg:rounded-br-md"
-            style={{ position: 'relative', zIndex: 50, maxHeight: '80vh', overflowY: 'auto' }}
+            style={{
+              position: "relative",
+              zIndex: 50,
+              maxHeight: "80vh",
+              overflowY: "auto",
+            }}
           >
             <div ref={containerRef}>
               <Autosearch
                 openOnFocus={true}
                 classNames={{
-                  form: 'custom-search-form',
-                  input: 'custom-search-input',
-                  panel: 'custom-search-panel',
-                  item: 'custom-search-item',
+                  form: "custom-search-form",
+                  input: "custom-search-input",
+                  panel: "custom-search-panel",
+                  item: "custom-search-item",
                 }}
                 getSources={({ query }) => {
                   const aiThreadItem = {
-                    id: 'ai-thread',
-                    url: query ? `https://seqera.io/ask-ai?prompt=${query}` : 'https://seqera.io/ask-ai',
-                    title: 'Start a new thread with Seqera AI',
-                    type: 'ai-thread'
+                    id: "ai-thread",
+                    url: query
+                      ? `https://seqera.io/ask-ai?prompt=${query}`
+                      : "https://seqera.io/ask-ai",
+                    title: "Start a new thread with Seqera AI",
+                    type: "ai-thread",
                   };
 
                   if (!query) {
-                    return [{
-                      sourceId: 'empty-state',
+                    return [
+                      {
+                        sourceId: "empty-state",
+                        getItems() {
+                          return [];
+                        },
+                        templates: {
+                          header() {
+                            return (
+                              <div className="flex flex-col w-full m-0 p-0">
+                                <ul className="typo-small flex flex-col w-full p-0 m-0">
+                                  <li className="hover:bg-gray-100 flex flex-row w-full">
+                                    <a
+                                      href={aiThreadItem.url}
+                                      onClick={(e) => {
+                                        e.preventDefault();
+                                        window.location.href = aiThreadItem.url;
+                                      }}
+                                      className="aa-ItemLink flex items-center p-3"
+                                      tabIndex={0}
+                                      aria-label={aiThreadItem.title}
+                                    >
+                                      <div className="aa-ItemContent">
+                                        <div className="flex items-center font-normal">
+                                          <AiIcon className="mr-2 w-5 h-5" />
+                                          {aiThreadItem.title}
+                                        </div>
+                                      </div>
+                                    </a>
+                                  </li>
+                                </ul>
+                                <div className="text-gray-1000 font-medium typo-small px-3 py-2 mt-1">
+                                  Documentation
+                                </div>
+                              </div>
+                            );
+                          },
+                          noResults() {
+                            return (
+                              <div className="pt-0 pb-6 text-sm text-gray-500 font-normal">
+                                Search docs or ask with Seqera AI...
+                              </div>
+                            );
+                          },
+                        },
+                      },
+                    ];
+                  }
+
+                  return [
+                    {
+                      sourceId: "ai-thread",
                       getItems() {
-                        return [];
+                        return [aiThreadItem];
                       },
                       templates: {
-                        header() {
+                        item({ item }) {
                           return (
                             <div className="flex flex-col w-full m-0 p-0">
                               <ul className="typo-small flex flex-col w-full p-0 m-0">
                                 <li className="hover:bg-gray-100 flex flex-row w-full">
-                                  <a 
-                                    href={aiThreadItem.url} 
+                                  <a
+                                    href={item.url}
                                     onClick={(e) => {
                                       e.preventDefault();
-                                      window.location.href = aiThreadItem.url;
+                                      window.location.href = item.url;
                                     }}
                                     className="aa-ItemLink flex items-center p-3"
                                     tabIndex={0}
-                                    aria-label={aiThreadItem.title}
+                                    aria-label={item.title}
                                   >
                                     <div className="aa-ItemContent">
                                       <div className="flex items-center font-normal">
                                         <AiIcon className="mr-2 w-5 h-5" />
-                                        {aiThreadItem.title}
+                                        {item.title}
                                       </div>
                                     </div>
                                   </a>
                                 </li>
                               </ul>
-                              <div className="text-gray-1000 font-medium typo-small px-3 py-2 mt-1">Documentation</div>
                             </div>
                           );
                         },
-                        noResults() {
+                      },
+                    },
+                    {
+                      sourceId: "docs",
+                      getItems() {
+                        return getAlgoliaResults({
+                          searchClient,
+                          queries: [
+                            {
+                              indexName: envIndexName,
+                              params: {
+                                query,
+                                hitsPerPage: 5,
+                                attributesToHighlight: ["*"],
+                              },
+                            },
+                          ],
+                        });
+                      },
+                      templates: {
+                        item({ item, components }) {
                           return (
-                            <div className="pt-0 pb-6 text-sm text-gray-500 font-normal">
-                              Search docs or ask with Seqera AI...
+                            <ProductItem hit={item} components={components} />
+                          );
+                        },
+                        header() {
+                          return (
+                            <div className="text-gray-1000 font-medium typo-small px-3 py-2 mt-1">
+                              Documentation
                             </div>
                           );
-                        }
-                      }
-                    }];
-                  }
-                  
-                  return [{
-                    sourceId: 'ai-thread',
-                    getItems() {
-                      return [aiThreadItem];
-                    },
-                    templates: {
-                      item({ item }) {
-                        return (
-                          <div className="flex flex-col w-full m-0 p-0">
-                            <ul className="typo-small flex flex-col w-full p-0 m-0">
-                              <li className="hover:bg-gray-100 flex flex-row w-full">
-                                <a 
-                                  href={item.url} 
-                                  onClick={(e) => {
-                                    e.preventDefault();
-                                    window.location.href = item.url;
-                                  }}
-                                  className="aa-ItemLink flex items-center p-3"
-                                  tabIndex={0}
-                                  aria-label={item.title}
-                                >
-                                  <div className="aa-ItemContent">
-                                    <div className="flex items-center font-normal">
-                                      <AiIcon className="mr-2 w-5 h-5" />
-                                      {item.title}
-                                    </div>
-                                  </div>
-                                </a>
-                              </li>
-                            </ul>
-                          </div>
-                        );
-                      }
-                    }
-                  },
-                  {
-                    sourceId: 'docs',
-                    getItems() {
-                      return getAlgoliaResults({
-                        searchClient,
-                        queries: [
-                          {
-                            indexName: envIndexName,
-                            params: {
-                              query,
-                              hitsPerPage: 5,
-                              attributesToHighlight: ['*'],
-                            },
-                          },
-                        ],
-                      });
-                    },
-                    templates: {
-                      item({ item, components }) {
-                        return <ProductItem hit={item} components={components} />;
+                        },
+                        noResults({ state }) {
+                          return (
+                            <div className="typo-small">
+                              <p className="text-gray-1000 font-medium typo-small">
+                                No results for "<b>{`${state?.query}`}</b>"
+                              </p>
+                            </div>
+                          );
+                        },
                       },
-                      header() {
-                        return (
-                          <div className="text-gray-1000 font-medium typo-small px-3 py-2 mt-1">Documentation</div>
-                        );
-                      },
-                      noResults({ state }) {
-                        return (
-                          <div className="typo-small">
-                            <p className="text-gray-1000 font-medium typo-small">No results for "<b>{`${state?.query}`}</b>"</p>
-                          </div>
-                        );
-                      }
-                    }
-                  }];
+                    },
+                  ];
                 }}
                 debug={true}
               />
@@ -322,21 +345,37 @@ export default function Search() {
           </div>
         </div>
       )}
-      
+
       {/* Optional: Add a button to open the search */}
-      <div 
+      <div
         onClick={() => setIsOpen(true)}
         className="md:flex items-center px-3 py-2 rounded-md text-sm text-gray-800 cursor-pointer hover:text-gray-1000 transition-all duration-100 min-w-50 content-center"
-        style={{ 
-          boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.25)',
-          height: '44px',
+        style={{
+          boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.25)",
+          height: "44px",
         }}
       >
-        <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        <svg
+          className="w-4 h-4 mr-2"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
         </svg>
-        Search docs... 
-        <span className="ml-2 text-xs px-1.5 py-0.5 rounded" style={{ border: '1px solid #d1d5db' }}>⌘K</span>
+        Search docs...
+        <span
+          className="ml-2 text-xs px-1.5 py-0.5 rounded"
+          style={{ border: "1px solid #d1d5db" }}
+        >
+          ⌘K
+        </span>
       </div>
     </>
   );

--- a/src/components/Search/algolia-theme.css
+++ b/src/components/Search/algolia-theme.css
@@ -159,8 +159,8 @@
 
 
 .custom-search-panel {
-  position: fixed !important;
+  position: fixed ;
 }
 .aa-DetachedContainer .aa-Panel {
-  position: relative !important;
+  position: relative ;
 }

--- a/src/components/Search/algolia-theme.css
+++ b/src/components/Search/algolia-theme.css
@@ -5,13 +5,15 @@
   --aa-input-background: #f9fafb;
   --aa-input-border-color: #e5e7eb;
   --aa-item-hover-color: #f3f4f6;
-  --aa-spacing-half: calc(calc(16*1*1px)/2);
+  --aa-spacing-half: calc(calc(16 * 1 * 1px) / 2);
   /* Add more variables as needed */
 }
 
 .aa-Form {
   background-color: var(--aa-input-background);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.12);
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.08),
+    0 1px 2px rgba(0, 0, 0, 0.12);
 }
 
 /* Continue styling using variables */
@@ -42,7 +44,7 @@
   outline: none;
   background-color: transparent;
   @media (min-width: 768px) {
-    font-size: .875rem;
+    font-size: 0.875rem;
   }
 }
 
@@ -78,7 +80,7 @@
 }
 
 .aa-Source[data-autocomplete-source-id="ai-thread"] .aa-Item {
-  padding: .5rem 0;
+  padding: 0.5rem 0;
 }
 
 .aa-Item:hover {
@@ -106,7 +108,8 @@
 }
 
 /* Section headers */
-.aa-SourceHeader, .aa-SourceFooterHeader {
+.aa-SourceHeader,
+.aa-SourceFooterHeader {
   /* padding: 0.35rem .75rem; */
   font-weight: 600;
   /* color: #1f2937; */
@@ -116,7 +119,7 @@
 }
 
 .aa-SourceNoResults {
-  padding: 0.35rem .75rem 0;
+  padding: 0.35rem 0.75rem 0;
 }
 
 .aa-SourceFooter ul {
@@ -145,7 +148,6 @@
   /* box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.12); */
 }
 
-
 /* .aa-SubmitButton {
   background-color: #0284c7; 
   color: white;
@@ -157,10 +159,9 @@
   color: #0284c7;
 }  */
 
-
 .custom-search-panel {
-  position: fixed ;
+  position: fixed;
 }
 .aa-DetachedContainer .aa-Panel {
-  position: relative ;
+  position: relative;
 }

--- a/src/css/fonts/degular.css
+++ b/src/css/fonts/degular.css
@@ -1,4 +1,4 @@
- @font-face {
+@font-face {
   font-family: "Degular";
   src: url("/static/fonts/degular/Degular-Thin.woff2") format("woff2");
   src: url("/static/fonts/degular/Degular-Thin.woff") format("woff");
@@ -28,7 +28,7 @@
   src: url("/static/fonts/degular/Degular-Medium.woff") format("woff");
   font-weight: 500;
   font-style: medium;
-} 
+}
 
 @font-face {
   font-family: "Degular";
@@ -52,4 +52,4 @@
   src: url("/static/fonts/degular/Degular-Black.woff") format("woff");
   font-weight: 800;
   font-style: black;
-} 
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -90,7 +90,7 @@ svg.excalidraw path[fill="#fff"] {
   .navbar {
     height: 0;
     width: 0;
-    display: none !important;
+    display: none ;
   }
 }
 
@@ -150,4 +150,17 @@ nav.menu .menu__list-item--collapsed .menu__link--sublist:after,
     background: rgba(0, 0, 0, 0.2);
     color: #98a3ff;
   }
+}
+
+/* Allow Code Block Expansion */
+.theme-code-block pre {
+  max-height: none ;
+  height: auto ;
+  overflow-y: visible ;
+}
+
+.theme-code-block code {
+  max-height: none ;
+  height: auto ;
+  overflow-y: visible ;
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -90,7 +90,7 @@ svg.excalidraw path[fill="#fff"] {
   .navbar {
     height: 0;
     width: 0;
-    display: none ;
+    display: none;
   }
 }
 
@@ -154,13 +154,13 @@ nav.menu .menu__list-item--collapsed .menu__link--sublist:after,
 
 /* Allow Code Block Expansion */
 .theme-code-block pre {
-  max-height: none ;
-  height: auto ;
-  overflow-y: visible ;
+  max-height: none;
+  height: auto;
+  overflow-y: visible;
 }
 
 .theme-code-block code {
-  max-height: none ;
-  height: auto ;
-  overflow-y: visible ;
+  max-height: none;
+  height: auto;
+  overflow-y: visible;
 }

--- a/src/css/misc.css
+++ b/src/css/misc.css
@@ -14,10 +14,10 @@ html:not(.plugin-id-platform) .navbar .dropdown {
 }
 
 ol li > p:first-child {
-  margin-top: 0 ;
+  margin-top: 0;
 }
 ol li > p:last-child {
-  margin-bottom: 0 ;
+  margin-bottom: 0;
 }
 
 /**
@@ -29,26 +29,26 @@ Material Design Icons (SVG)
 }
 
 /* Inject theme-specific styling for <details> elements */
-[data-theme='light'] {
+[data-theme="light"] {
   --details-bg: #fff;
   --details-code-bg: rgb(246, 247, 248);
 }
 
-[data-theme='dark'] {
+[data-theme="dark"] {
   --details-bg: rgb(25, 60, 71);
   --details-code-bg: var(--ifm-code-background);
 }
 
 details {
-  background-color: var(--details-bg) ;
-  border-top-width: 0 ;
-  border-bottom-width: 0 ;
-  border-right-width: 0 ;
-  border-left-width: 5px ;
+  background-color: var(--details-bg);
+  border-top-width: 0;
+  border-bottom-width: 0;
+  border-right-width: 0;
+  border-left-width: 5px;
 }
 
 details.alert > div > div {
-  border-top: 1px solid #000 ;
+  border-top: 1px solid #000;
 }
 
 details.alert code {

--- a/src/css/misc.css
+++ b/src/css/misc.css
@@ -14,10 +14,10 @@ html:not(.plugin-id-platform) .navbar .dropdown {
 }
 
 ol li > p:first-child {
-  margin-top: 0 !important;
+  margin-top: 0 ;
 }
 ol li > p:last-child {
-  margin-bottom: 0 !important;
+  margin-bottom: 0 ;
 }
 
 /**
@@ -40,15 +40,15 @@ Material Design Icons (SVG)
 }
 
 details {
-  background-color: var(--details-bg) !important;
-  border-top-width: 0 !important;
-  border-bottom-width: 0 !important;
-  border-right-width: 0 !important;
-  border-left-width: 5px !important;
+  background-color: var(--details-bg) ;
+  border-top-width: 0 ;
+  border-bottom-width: 0 ;
+  border-right-width: 0 ;
+  border-left-width: 5px ;
 }
 
 details.alert > div > div {
-  border-top: 1px solid #000 !important;
+  border-top: 1px solid #000 ;
 }
 
 details.alert code {

--- a/src/css/search.css
+++ b/src/css/search.css
@@ -54,7 +54,9 @@
 
 .ais-Hits-item:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
 }
 
 /* Pagination */
@@ -94,7 +96,7 @@
 }
 
 /* Dark mode support */
-[data-theme='dark'] {
+[data-theme="dark"] {
   .ais-SearchBox-form {
     background-color: var(--aa-searchbox-background);
     border-color: var(--aa-searchbox-border-color);
@@ -107,4 +109,4 @@
   .ais-Pagination-link {
     color: var(--aa-text-color-dark);
   }
-} 
+}

--- a/src/css/theme-colors.css
+++ b/src/css/theme-colors.css
@@ -79,20 +79,20 @@ html[data-theme="light"] .menu__link--sublist-caret:after {
   background-image: url("data:image/svg+xml,%3Csvg width='25' height='24' viewBox='0 0 25 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12.4943 10.4038L7.7174 15.1615L7.16162 14.6057L12.4943 9.29225L17.8078 14.6057L17.252 15.1615L12.4943 10.4038Z' fill='%23160F26'/%3E%3C/svg%3E%0A");
 }
 html[data-theme="light"] .menu__list-item-collapsible--active {
-  background-color: var(--color-wave) ;
+  background-color: var(--color-wave);
 }
 html[data-theme="light"] .menu__list-item-collapsible > a.menu__link--active {
-  color: var(--color-brand-1400) ;
+  color: var(--color-brand-1400);
 }
 html[data-theme="light"]
   .menu__list-item-collapsible--active
   > a.menu__link--active {
-  color: white ;
+  color: white;
 }
 
 /* Search modal */
 html[data-theme="light"] .DocSearch-Logo svg * {
-  fill: var(--ifm-font-color-base) ;
+  fill: var(--ifm-font-color-base);
   opacity: 0.6;
 }
 

--- a/src/css/theme-colors.css
+++ b/src/css/theme-colors.css
@@ -79,20 +79,20 @@ html[data-theme="light"] .menu__link--sublist-caret:after {
   background-image: url("data:image/svg+xml,%3Csvg width='25' height='24' viewBox='0 0 25 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12.4943 10.4038L7.7174 15.1615L7.16162 14.6057L12.4943 9.29225L17.8078 14.6057L17.252 15.1615L12.4943 10.4038Z' fill='%23160F26'/%3E%3C/svg%3E%0A");
 }
 html[data-theme="light"] .menu__list-item-collapsible--active {
-  background-color: var(--color-wave) !important;
+  background-color: var(--color-wave) ;
 }
 html[data-theme="light"] .menu__list-item-collapsible > a.menu__link--active {
-  color: var(--color-brand-1400) !important;
+  color: var(--color-brand-1400) ;
 }
 html[data-theme="light"]
   .menu__list-item-collapsible--active
   > a.menu__link--active {
-  color: white !important;
+  color: white ;
 }
 
 /* Search modal */
 html[data-theme="light"] .DocSearch-Logo svg * {
-  fill: var(--ifm-font-color-base) !important;
+  fill: var(--ifm-font-color-base) ;
   opacity: 0.6;
 }
 

--- a/src/modules/Homepage/styles.module.css
+++ b/src/modules/Homepage/styles.module.css
@@ -19,7 +19,7 @@ a {
 
 pre,
 code {
-  max-height: 300px ;
+  max-height: 300px;
 }
 
 .page {

--- a/src/modules/Homepage/styles.module.css
+++ b/src/modules/Homepage/styles.module.css
@@ -19,7 +19,7 @@ a {
 
 pre,
 code {
-  max-height: 300px !important;
+  max-height: 300px ;
 }
 
 .page {

--- a/src/theme/BlogLayout/styles.module.css
+++ b/src/theme/BlogLayout/styles.module.css
@@ -27,6 +27,6 @@
     flex-wrap: nowrap;
   }
   .blogContent {
-    max-width: 75% !important;
+    max-width: 75% ;
   }
 }

--- a/src/theme/BlogLayout/styles.module.css
+++ b/src/theme/BlogLayout/styles.module.css
@@ -27,6 +27,6 @@
     flex-wrap: nowrap;
   }
   .blogContent {
-    max-width: 75% ;
+    max-width: 75%;
   }
 }

--- a/src/theme/BlogPostItem/Footer/styles.module.css
+++ b/src/theme/BlogPostItem/Footer/styles.module.css
@@ -1,8 +1,8 @@
 .blogFooter {
-    margin-top: 1rem;
-    border-bottom: 1px solid rgba(100,100,100,0.2);
+  margin-top: 1rem;
+  border-bottom: 1px solid rgba(100, 100, 100, 0.2);
 }
 .readMore {
-    padding-bottom: 1rem;
-    color: var(--brand-color);
+  padding-bottom: 1rem;
+  color: var(--brand-color);
 }

--- a/src/theme/BlogSidebar/Desktop/styles.module.css
+++ b/src/theme/BlogSidebar/Desktop/styles.module.css
@@ -1,5 +1,5 @@
 .blogAside {
-  width: var(--doc-sidebar-width) ;
+  width: var(--doc-sidebar-width);
   padding: 30px;
 }
 [data-theme="light"] .blogAside {
@@ -60,7 +60,6 @@
   }
 }
 
-
 .backToDocs {
   font-size: 0.9rem;
   color: var(--color-brand-600);
@@ -70,25 +69,25 @@
   color: var(--color-brand-400);
 }
 
-
 .sidebarItemLink {
   border-radius: 5px;
   font-weight: 400;
   font-size: 0.9rem;
   display: block;
   line-height: 1.25;
-  padding: var(--ifm-menu-link-padding-vertical) var(--ifm-menu-link-padding-horizontal);
+  padding: var(--ifm-menu-link-padding-vertical)
+    var(--ifm-menu-link-padding-horizontal);
 }
-[data-theme='light'] .blogAside {
+[data-theme="light"] .blogAside {
   .sidebarItemLink {
     color: #000;
   }
   .sidebarItemLinkActive {
-    background: #E8EBFC;
-    color: #4256E7;
+    background: #e8ebfc;
+    color: #4256e7;
   }
 }
-[data-theme='dark'] .blogAside {
+[data-theme="dark"] .blogAside {
   .sidebarItemLink {
     color: rgba(255, 255, 255, 0.9);
   }
@@ -100,7 +99,6 @@
 
 .sidebarItem {
   margin-top: 0.25rem;
-
 }
 
 .sidebarItemLink:hover {

--- a/src/theme/BlogSidebar/Desktop/styles.module.css
+++ b/src/theme/BlogSidebar/Desktop/styles.module.css
@@ -1,5 +1,5 @@
 .blogAside {
-  width: var(--doc-sidebar-width) !important;
+  width: var(--doc-sidebar-width) ;
   padding: 30px;
 }
 [data-theme="light"] .blogAside {

--- a/src/theme/ColorModeToggle/styles.module.css
+++ b/src/theme/ColorModeToggle/styles.module.css
@@ -18,8 +18,8 @@
   background: var(--ifm-color-emphasis-200);
 }
 
-[data-theme='light'] .darkToggleIcon,
-[data-theme='dark'] .lightToggleIcon {
+[data-theme="light"] .darkToggleIcon,
+[data-theme="dark"] .lightToggleIcon {
   display: none;
 }
 

--- a/src/theme/DocSidebar/Desktop/ProductSwitcher/styles.module.css
+++ b/src/theme/DocSidebar/Desktop/ProductSwitcher/styles.module.css
@@ -2,7 +2,7 @@
   position: relative;
   margin: 8px 0 0 0;
   .button {
-    border-bottom-color: var(--color-brand-200) !important;
+    border-bottom-color: var(--color-brand-200) ;
     z-index: 10;
     &:after {
       background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="4 4 16 16"><path d="M11.8152 13.1989L10.0167 11.1432C9.80447 10.9013 9.97697 10.5214 10.2991 10.5214H13.8961C13.9682 10.5214 14.0388 10.5421 14.0994 10.5811C14.16 10.6201 14.2081 10.6758 14.2379 10.7414C14.2677 10.8071 14.2779 10.8799 14.2674 10.9512C14.2569 11.0226 14.226 11.0893 14.1785 11.1435L12.38 13.1985C12.3448 13.2388 12.3014 13.2711 12.2527 13.2932C12.204 13.3153 12.1511 13.3268 12.0976 13.3268C12.0441 13.3268 11.9912 13.3153 11.9425 13.2932C11.8938 13.2711 11.8504 13.2388 11.8152 13.1985V13.1989Z" /></svg>')
@@ -34,7 +34,7 @@
   font-size: 13px;
   font-family: Inter, sans-serif;
   & .caret {
-    fill: var(--color-brand-800) !important;
+    fill: var(--color-brand-800) ;
     width: 18px;
     height: 18px;
     fill: #000;
@@ -118,9 +118,9 @@
 [data-theme="dark"] {
   & .switcher {
     & .button {
-      border-bottom-color: var(--color-brand-800) !important;
+      border-bottom-color: var(--color-brand-800) ;
       & .caret {
-        fill: #fff !important;
+        fill: #fff ;
       }
     }
     & .items {

--- a/src/theme/DocSidebar/Desktop/ProductSwitcher/styles.module.css
+++ b/src/theme/DocSidebar/Desktop/ProductSwitcher/styles.module.css
@@ -2,7 +2,7 @@
   position: relative;
   margin: 8px 0 0 0;
   .button {
-    border-bottom-color: var(--color-brand-200) ;
+    border-bottom-color: var(--color-brand-200);
     z-index: 10;
     &:after {
       background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="4 4 16 16"><path d="M11.8152 13.1989L10.0167 11.1432C9.80447 10.9013 9.97697 10.5214 10.2991 10.5214H13.8961C13.9682 10.5214 14.0388 10.5421 14.0994 10.5811C14.16 10.6201 14.2081 10.6758 14.2379 10.7414C14.2677 10.8071 14.2779 10.8799 14.2674 10.9512C14.2569 11.0226 14.226 11.0893 14.1785 11.1435L12.38 13.1985C12.3448 13.2388 12.3014 13.2711 12.2527 13.2932C12.204 13.3153 12.1511 13.3268 12.0976 13.3268C12.0441 13.3268 11.9912 13.3153 11.9425 13.2932C11.8938 13.2711 11.8504 13.2388 11.8152 13.1985V13.1989Z" /></svg>')
@@ -34,7 +34,7 @@
   font-size: 13px;
   font-family: Inter, sans-serif;
   & .caret {
-    fill: var(--color-brand-800) ;
+    fill: var(--color-brand-800);
     width: 18px;
     height: 18px;
     fill: #000;
@@ -118,9 +118,9 @@
 [data-theme="dark"] {
   & .switcher {
     & .button {
-      border-bottom-color: var(--color-brand-800) ;
+      border-bottom-color: var(--color-brand-800);
       & .caret {
-        fill: #fff ;
+        fill: #fff;
       }
     }
     & .items {

--- a/src/theme/DocSidebar/Desktop/styles.module.css
+++ b/src/theme/DocSidebar/Desktop/styles.module.css
@@ -1,7 +1,8 @@
 :global(.theme-doc-sidebar-container) {
-  border-right: 0 !important;
+  border-right: 0;
   margin-top: unset !important;
 }
+
 [data-theme="light"] :global(.theme-doc-sidebar-container) {
   background: rgb(249, 249, 249);
 }
@@ -19,8 +20,8 @@
   }
   /* Remove strange padding around docs sidebar nav */
   & div[class^="sidebar"] {
-    padding-top: 0 !important;
-    width: auto !important;
+    padding-top: 0 ;
+    width: auto ;
   }
 }
 .sidebarHeader {

--- a/src/theme/DocSidebar/Desktop/styles.module.css
+++ b/src/theme/DocSidebar/Desktop/styles.module.css
@@ -20,8 +20,8 @@
   }
   /* Remove strange padding around docs sidebar nav */
   & div[class^="sidebar"] {
-    padding-top: 0 ;
-    width: auto ;
+    padding-top: 0;
+    width: auto;
   }
 }
 .sidebarHeader {
@@ -31,10 +31,18 @@
 }
 .sidebarHeaderFade {
   height: 15px;
-  background: linear-gradient(180deg, rgba(249,249,249,1) 0%, rgba(249,249,249,0) 100%);
+  background: linear-gradient(
+    180deg,
+    rgba(249, 249, 249, 1) 0%,
+    rgba(249, 249, 249, 0) 100%
+  );
 }
 [data-theme="dark"] .sidebarHeaderFade {
-  background: linear-gradient(180deg, rgba(27, 24, 35,0.5) 0%, rgba(27, 24, 35,0) 100%) ;
+  background: linear-gradient(
+    180deg,
+    rgba(27, 24, 35, 0.5) 0%,
+    rgba(27, 24, 35, 0) 100%
+  );
 }
 .sidebarNav {
   margin-top: -15px;

--- a/src/theme/Navbar/Layout/SeqeraHeader/HeaderDesktop/NavItems/styles.module.css
+++ b/src/theme/Navbar/Layout/SeqeraHeader/HeaderDesktop/NavItems/styles.module.css
@@ -36,14 +36,14 @@
     display: inline-block;
     padding: 3px 8px;
     margin: 4px;
-    background: #E6E5E8;
+    background: #e6e5e8;
     border: 1px solid var(--color-brand);
     border-radius: 12px;
     font-size: 10px;
     line-height: 0.8;
     color: var(--color-brand-1100);
   }
-  
+
   &:hover,
   &.active {
     background-color: var(--color-brand-200);

--- a/src/theme/Navbar/MobileSidebar/SeqeraMenu/Category/Products/styles.module.css
+++ b/src/theme/Navbar/MobileSidebar/SeqeraMenu/Category/Products/styles.module.css
@@ -1,7 +1,7 @@
 .products {
   & li {
     & a {
-      display: flex ;
+      display: flex;
       align-items: center;
       & svg {
         width: 16px;
@@ -16,6 +16,6 @@
 }
 html[data-theme="dark"] {
   & .products li a svg path[fill="#160F26"] {
-    fill: white ;
+    fill: white;
   }
 }

--- a/src/theme/Navbar/MobileSidebar/SeqeraMenu/Category/Products/styles.module.css
+++ b/src/theme/Navbar/MobileSidebar/SeqeraMenu/Category/Products/styles.module.css
@@ -1,7 +1,7 @@
 .products {
   & li {
     & a {
-      display: flex !important;
+      display: flex ;
       align-items: center;
       & svg {
         width: 16px;
@@ -16,6 +16,6 @@
 }
 html[data-theme="dark"] {
   & .products li a svg path[fill="#160F26"] {
-    fill: white !important;
+    fill: white ;
   }
 }

--- a/src/theme/Navbar/Search/styles.module.css
+++ b/src/theme/Navbar/Search/styles.module.css
@@ -44,27 +44,24 @@ See https://github.com/facebook/docusaurus/pull/9385
 /* Dark mode */
 
 html[data-theme="dark"] {
-  --docsearch-text-color: #f5f6f7 ;
-  --docsearch-container-background: rgba(9, 10, 17, 0.8) ;
-  --docsearch-modal-background: #15172a ;
-  --docsearch-modal-shadow: inset 1px 1px 0 0 #2c2e40, 0 3px 8px 0 #000309 ;
-  --docsearch-searchbox-background: #090a11 ;
-  --docsearch-searchbox-focus-background: #000 ;
-  --docsearch-hit-color: #bec3c9 ;
-  --docsearch-hit-shadow: none ;
-  --docsearch-hit-background: #090a11 ;
-  --docsearch-key-gradient: linear-gradient(
-    -26.5deg,
-    #565872,
-    #31355b
-  ) ;
-  --docsearch-key-shadow: inset 0 -2px 0 0 #282d55, inset 0 0 1px 1px #51577d,
-    0 2px 2px 0 rgba(3, 4, 9, 0.3) ;
-  --docsearch-footer-background: #1e2136 ;
-  --docsearch-footer-shadow: inset 0 1px 0 0 rgba(73, 76, 106, 0.5),
-    0 -4px 8px 0 rgba(0, 0, 0, 0.2) ;
-  --docsearch-logo-color: #fff ;
-  --docsearch-muted-color: #7f8497 ;
+  --docsearch-text-color: #f5f6f7;
+  --docsearch-container-background: rgba(9, 10, 17, 0.8);
+  --docsearch-modal-background: #15172a;
+  --docsearch-modal-shadow: inset 1px 1px 0 0 #2c2e40, 0 3px 8px 0 #000309;
+  --docsearch-searchbox-background: #090a11;
+  --docsearch-searchbox-focus-background: #000;
+  --docsearch-hit-color: #bec3c9;
+  --docsearch-hit-shadow: none;
+  --docsearch-hit-background: #090a11;
+  --docsearch-key-gradient: linear-gradient(-26.5deg, #565872, #31355b);
+  --docsearch-key-shadow:
+    inset 0 -2px 0 0 #282d55, inset 0 0 1px 1px #51577d,
+    0 2px 2px 0 rgba(3, 4, 9, 0.3);
+  --docsearch-footer-background: #1e2136;
+  --docsearch-footer-shadow:
+    inset 0 1px 0 0 rgba(73, 76, 106, 0.5), 0 -4px 8px 0 rgba(0, 0, 0, 0.2);
+  --docsearch-logo-color: #fff;
+  --docsearch-muted-color: #7f8497;
   & :global(.DocSearch) {
     & :global(.DocSearch-Search-Icon) {
       color: var(--color-brand-900);

--- a/src/theme/Navbar/Search/styles.module.css
+++ b/src/theme/Navbar/Search/styles.module.css
@@ -44,27 +44,27 @@ See https://github.com/facebook/docusaurus/pull/9385
 /* Dark mode */
 
 html[data-theme="dark"] {
-  --docsearch-text-color: #f5f6f7 !important;
-  --docsearch-container-background: rgba(9, 10, 17, 0.8) !important;
-  --docsearch-modal-background: #15172a !important;
-  --docsearch-modal-shadow: inset 1px 1px 0 0 #2c2e40, 0 3px 8px 0 #000309 !important;
-  --docsearch-searchbox-background: #090a11 !important;
-  --docsearch-searchbox-focus-background: #000 !important;
-  --docsearch-hit-color: #bec3c9 !important;
-  --docsearch-hit-shadow: none !important;
-  --docsearch-hit-background: #090a11 !important;
+  --docsearch-text-color: #f5f6f7 ;
+  --docsearch-container-background: rgba(9, 10, 17, 0.8) ;
+  --docsearch-modal-background: #15172a ;
+  --docsearch-modal-shadow: inset 1px 1px 0 0 #2c2e40, 0 3px 8px 0 #000309 ;
+  --docsearch-searchbox-background: #090a11 ;
+  --docsearch-searchbox-focus-background: #000 ;
+  --docsearch-hit-color: #bec3c9 ;
+  --docsearch-hit-shadow: none ;
+  --docsearch-hit-background: #090a11 ;
   --docsearch-key-gradient: linear-gradient(
     -26.5deg,
     #565872,
     #31355b
-  ) !important;
+  ) ;
   --docsearch-key-shadow: inset 0 -2px 0 0 #282d55, inset 0 0 1px 1px #51577d,
-    0 2px 2px 0 rgba(3, 4, 9, 0.3) !important;
-  --docsearch-footer-background: #1e2136 !important;
+    0 2px 2px 0 rgba(3, 4, 9, 0.3) ;
+  --docsearch-footer-background: #1e2136 ;
   --docsearch-footer-shadow: inset 0 1px 0 0 rgba(73, 76, 106, 0.5),
-    0 -4px 8px 0 rgba(0, 0, 0, 0.2) !important;
-  --docsearch-logo-color: #fff !important;
-  --docsearch-muted-color: #7f8497 !important;
+    0 -4px 8px 0 rgba(0, 0, 0, 0.2) ;
+  --docsearch-logo-color: #fff ;
+  --docsearch-muted-color: #7f8497 ;
   & :global(.DocSearch) {
     & :global(.DocSearch-Search-Icon) {
       color: var(--color-brand-900);


### PR DESCRIPTION
# Summary

The following is an attempt at fixing the code block vertical scrolling in the docs site which can be seen at the following URL for example https://docs.seqera.io/platform-enterprise/25.1/seqerakit/yaml-configuration the "fixed" version can be seen at https://deploy-preview-572--seqera-docs.netlify.app/platform-enterprise/25.1//seqerakit/yaml-configuration 

## Changes

I managed to track down some conflicting resources between thin-scrollbar & the global theme for all my attempts I could not debug the explicit positioning in CSS required to make this work due to the number of `!important` directives within the codebase so I initially worked on the removal of as many of these as possible resulting in the removal of all `!important` blocks except the following found in `src/theme/DocSidebar/Desktop/styles.module.css` which controls the sidebar positioning - without this it is nested under the banner.

```yaml
:global(.theme-doc-sidebar-container) {
  border-right: 0;
  margin-top: unset !important;
}
```

Addition of the two following items to `src/css/main.css`

```yaml
.theme-code-block pre {
  max-height: none;
  height: auto;
  overflow-y: visible !important;
}

.theme-code-block code {
  max-height: none;
  height: auto;
  overflow-y: visible !important;
}
```

## Testing

Honestly I don't know how to fully validate and test these changes however I reviewed the docs layouts on the following and see no notable differences. 

- mobile
  - safari
  - chrome (Android & Linux)
- desktop
  - safari
  - chrome
  


