### PR TITLE
API Docs: Remove languages from language tab

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -401,6 +401,40 @@ export default async function createConfigAsync() {
         ],
         copyright: `© ${new Date().getFullYear()} Seqera`,
       },
+      languageTabs: [
+        {
+          highlight: "python",
+          language: "python",
+          logoClass: "python",
+        },
+        {
+          highlight: "bash",
+          language: "curl",
+          logoClass: "curl",
+        },
+        {
+          highlight: "java",
+          language: "java",
+          logoClass: "java",
+          variant: "unirest",
+        },
+        {
+          highlight: "javascript",
+          language: "javascript",
+          logoClass: "javascript",
+        },
+        {
+          highlight: "go",
+          language: "go",
+          logoClass: "go",
+        },
+        {
+          highlight: "powershell",
+          language: "powershell",
+          logoClass: "powershell",
+        },
+
+      ],
       prism: {
         theme: themes.oneLight,
         darkTheme: themes.oneDark,


### PR DESCRIPTION
The following reduces the number of exposed languages from the langage tabs to limit horizontal scrolling. 

The choice for removal was for niche languages or those which needed non standard library components to be installed. 