### PR TITLE
docs(Wave): Update sidebar for newly released content

### DIFF
--- a/wave_docs/sidebar.json
+++ b/wave_docs/sidebar.json
@@ -10,6 +10,17 @@
         "provisioning"
       ]
     },
+    {
+      "type": "category",
+      "label": "Installation",
+      "collapsed": false,
+      "items": [
+        "install/docker-compose",
+        "install/kubernetes",
+        "install/configuring-wave",
+        "install/configuring-wave-build"
+      ]
+    },
     "nextflow",
     {
       "type": "category",


### PR DESCRIPTION
The following updates the sidebar for content included in this pull request. https://github.com/seqeralabs/wave/pull/843

It is not clear how to trigger a re-pull of this content without a pull request however we're using the sidebar from this repository vs the one included in the wave repo so it felt prudent to update it. 

