### PR TITLE
Admonitions: make header selector CSS more specific.

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -313,12 +313,10 @@ ol li {
   }
 }
 .theme-admonition {
-  div {
-    &:first-child {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-    }
+  div[class*="admonitionHeading"] {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
   }
   svg {
     &:first-child {
@@ -447,7 +445,7 @@ article .markdown pre code {
   background-color: #f8f8f8;
   font-size: .75rem !important;
 }
-html[data-theme="dark"]{ 
+html[data-theme="dark"]{
   article .markdown code {
     background: #1C1C1E;
     border: 1px solid rgba(255,255,255,.5);


### PR DESCRIPTION
Fixes issue where code blocks were being shown half-width in some contexts.

Before:

![CleanShot 2025-06-30 at 17 54 59@2x](https://github.com/user-attachments/assets/6fb323a8-d400-49e8-adc0-8acb0a831bd5)


After:

![CleanShot 2025-06-30 at 17 54 41@2x](https://github.com/user-attachments/assets/3ee121e3-f42a-4a97-901c-79493e7da42a)

@netlify /platform-cloud/studios/overview#docker-in-docker