### PR TITLE
Fixing an error in the description of our timestamp in the Audit Log.

### DIFF
--- a/platform-enterprise_versioned_docs/version-24.1/monitoring/audit-logs.md
+++ b/platform-enterprise_versioned_docs/version-24.1/monitoring/audit-logs.md
@@ -24,7 +24,7 @@ Audit log entries record the following event details:
 - **Workspace ID**
 - **Workspace name**
 - **Client IP**: IP address of user/client initiating the event. Empty for Seqera-initiated events.
-- **Creation date**: Event timestamp in `YYYY-MM-DD-HH-MM-SS` format.
+- **Creation date**: Event timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ` (e.g., `2025-06-28T22:07:40Z`).
 
 ### Audit log events
 

--- a/platform-enterprise_versioned_docs/version-24.2/monitoring/audit-logs.md
+++ b/platform-enterprise_versioned_docs/version-24.2/monitoring/audit-logs.md
@@ -24,7 +24,7 @@ Audit log entries record the following event details:
 - **Workspace ID**
 - **Workspace name**
 - **Client IP**: IP address of user/client initiating the event. Empty for Seqera-initiated events.
-- **Creation date**: Event timestamp in `YYYY-MM-DD-HH-MM-SS` format.
+- **Creation date**: Event timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ` (e.g., `2025-06-28T22:07:40Z`).
 
 ### Audit log events
 

--- a/platform-enterprise_versioned_docs/version-25.1/monitoring/audit-logs.md
+++ b/platform-enterprise_versioned_docs/version-25.1/monitoring/audit-logs.md
@@ -24,7 +24,7 @@ Audit log entries record the following event details:
 - **Workspace ID**
 - **Workspace name**
 - **Client IP**: IP address of user/client initiating the event. Empty for Seqera-initiated events.
-- **Creation date**: Event timestamp in `YYYY-MM-DD-HH-MM-SS` format.
+- **Creation date**: Event timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ` (e.g., `2025-06-28T22:07:40Z`).
 
 ### Audit log events
 


### PR DESCRIPTION
It's in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ` (e.g., `2025-06-28T22:07:40Z`), not the `YYYY-MM-DD-HH-MM-SS` publicly stated.