### PR TITLE
Add link to nextflow install docs in platform requirements

### DIFF
--- a/platform-cloud/docs/compute-envs/hpc.md
+++ b/platform-cloud/docs/compute-envs/hpc.md
@@ -19,7 +19,7 @@ To launch pipelines into an **HPC** cluster from Seqera, the following requireme
 
 - The cluster should allow outbound connections to the Seqera web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Credentials
 

--- a/platform-enterprise_versioned_docs/version-22.4/compute-envs/altair-grid-engine.md
+++ b/platform-enterprise_versioned_docs/version-22.4/compute-envs/altair-grid-engine.md
@@ -15,7 +15,7 @@ To launch pipelines into a **Grid Engine** cluster from Tower, the following req
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ### Compute Environment
 

--- a/platform-enterprise_versioned_docs/version-22.4/compute-envs/altair-grid-engine.md
+++ b/platform-enterprise_versioned_docs/version-22.4/compute-envs/altair-grid-engine.md
@@ -15,7 +15,7 @@ To launch pipelines into a **Grid Engine** cluster from Tower, the following req
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) should be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
 
 ### Compute Environment
 

--- a/platform-enterprise_versioned_docs/version-22.4/compute-envs/altair-pbs-pro.md
+++ b/platform-enterprise_versioned_docs/version-22.4/compute-envs/altair-pbs-pro.md
@@ -15,7 +15,7 @@ To launch pipelines into a **PBS Pro** cluster from Tower, the following require
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ### Compute Environment
 

--- a/platform-enterprise_versioned_docs/version-22.4/compute-envs/altair-pbs-pro.md
+++ b/platform-enterprise_versioned_docs/version-22.4/compute-envs/altair-pbs-pro.md
@@ -15,7 +15,7 @@ To launch pipelines into a **PBS Pro** cluster from Tower, the following require
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) should be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
 
 ### Compute Environment
 

--- a/platform-enterprise_versioned_docs/version-22.4/compute-envs/lsf.md
+++ b/platform-enterprise_versioned_docs/version-22.4/compute-envs/lsf.md
@@ -15,7 +15,7 @@ To launch pipelines into an **LSF** cluster from Tower, the following requiremen
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) should be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
 
 ### Compute Environment
 

--- a/platform-enterprise_versioned_docs/version-22.4/compute-envs/lsf.md
+++ b/platform-enterprise_versioned_docs/version-22.4/compute-envs/lsf.md
@@ -15,7 +15,7 @@ To launch pipelines into an **LSF** cluster from Tower, the following requiremen
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ### Compute Environment
 

--- a/platform-enterprise_versioned_docs/version-22.4/compute-envs/moab.md
+++ b/platform-enterprise_versioned_docs/version-22.4/compute-envs/moab.md
@@ -15,7 +15,7 @@ To launch pipelines into a **Moab** cluster from Tower, the following requiremen
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ### Compute Environment
 

--- a/platform-enterprise_versioned_docs/version-22.4/compute-envs/moab.md
+++ b/platform-enterprise_versioned_docs/version-22.4/compute-envs/moab.md
@@ -15,7 +15,7 @@ To launch pipelines into a **Moab** cluster from Tower, the following requiremen
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) should be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
 
 ### Compute Environment
 

--- a/platform-enterprise_versioned_docs/version-22.4/compute-envs/slurm.md
+++ b/platform-enterprise_versioned_docs/version-22.4/compute-envs/slurm.md
@@ -15,7 +15,7 @@ To launch pipelines into a **Slurm** cluster from Tower, the following requireme
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ### Compute Environment
 

--- a/platform-enterprise_versioned_docs/version-22.4/compute-envs/slurm.md
+++ b/platform-enterprise_versioned_docs/version-22.4/compute-envs/slurm.md
@@ -15,7 +15,7 @@ To launch pipelines into a **Slurm** cluster from Tower, the following requireme
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) should be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
 
 ### Compute Environment
 

--- a/platform-enterprise_versioned_docs/version-23.1/compute-envs/altair-grid-engine.md
+++ b/platform-enterprise_versioned_docs/version-23.1/compute-envs/altair-grid-engine.md
@@ -15,7 +15,7 @@ To launch pipelines into a **Grid Engine** cluster from Tower, the following req
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Compute environment
 

--- a/platform-enterprise_versioned_docs/version-23.1/compute-envs/altair-pbs-pro.md
+++ b/platform-enterprise_versioned_docs/version-23.1/compute-envs/altair-pbs-pro.md
@@ -15,7 +15,7 @@ To launch pipelines into a **PBS Pro** cluster from Tower, the following require
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Compute environment
 

--- a/platform-enterprise_versioned_docs/version-23.1/compute-envs/hpc.md
+++ b/platform-enterprise_versioned_docs/version-23.1/compute-envs/hpc.md
@@ -19,7 +19,7 @@ To launch pipelines into an **HPC** cluster from Tower, the following requiremen
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Compute environment
 

--- a/platform-enterprise_versioned_docs/version-23.1/compute-envs/lsf.md
+++ b/platform-enterprise_versioned_docs/version-23.1/compute-envs/lsf.md
@@ -15,7 +15,7 @@ To launch pipelines into an **LSF** cluster from Tower, the following requiremen
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Compute environment
 

--- a/platform-enterprise_versioned_docs/version-23.1/compute-envs/moab.md
+++ b/platform-enterprise_versioned_docs/version-23.1/compute-envs/moab.md
@@ -15,7 +15,7 @@ To launch pipelines into a **Moab** cluster from Tower, the following requiremen
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Compute environment
 

--- a/platform-enterprise_versioned_docs/version-23.1/compute-envs/slurm.md
+++ b/platform-enterprise_versioned_docs/version-23.1/compute-envs/slurm.md
@@ -15,7 +15,7 @@ To launch pipelines into a **Slurm** cluster from Tower, the following requireme
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Compute environment
 

--- a/platform-enterprise_versioned_docs/version-23.2/compute-envs/altair-grid-engine.md
+++ b/platform-enterprise_versioned_docs/version-23.2/compute-envs/altair-grid-engine.md
@@ -15,7 +15,7 @@ To launch pipelines into a **Grid Engine** cluster from Tower, the following req
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Compute environment
 

--- a/platform-enterprise_versioned_docs/version-23.2/compute-envs/altair-pbs-pro.md
+++ b/platform-enterprise_versioned_docs/version-23.2/compute-envs/altair-pbs-pro.md
@@ -15,7 +15,7 @@ To launch pipelines into a **PBS Pro** cluster from Tower, the following require
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Compute environment
 

--- a/platform-enterprise_versioned_docs/version-23.2/compute-envs/hpc.md
+++ b/platform-enterprise_versioned_docs/version-23.2/compute-envs/hpc.md
@@ -19,7 +19,7 @@ To launch pipelines into an **HPC** cluster from Tower, the following requiremen
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Compute environment
 

--- a/platform-enterprise_versioned_docs/version-23.2/compute-envs/lsf.md
+++ b/platform-enterprise_versioned_docs/version-23.2/compute-envs/lsf.md
@@ -15,7 +15,7 @@ To launch pipelines into an **LSF** cluster from Tower, the following requiremen
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Compute environment
 

--- a/platform-enterprise_versioned_docs/version-23.2/compute-envs/moab.md
+++ b/platform-enterprise_versioned_docs/version-23.2/compute-envs/moab.md
@@ -15,7 +15,7 @@ To launch pipelines into a **Moab** cluster from Tower, the following requiremen
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Compute environment
 

--- a/platform-enterprise_versioned_docs/version-23.2/compute-envs/slurm.md
+++ b/platform-enterprise_versioned_docs/version-23.2/compute-envs/slurm.md
@@ -15,7 +15,7 @@ To launch pipelines into a **Slurm** cluster from Tower, the following requireme
 
 - The cluster should allow outbound connections to the Tower web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Compute environment
 

--- a/platform-enterprise_versioned_docs/version-23.3/compute-envs/hpc.md
+++ b/platform-enterprise_versioned_docs/version-23.3/compute-envs/hpc.md
@@ -19,7 +19,7 @@ To launch pipelines into an **HPC** cluster from Seqera, the following requireme
 
 - The cluster should allow outbound connections to the Seqera web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Seqera HPC compute environment
 

--- a/platform-enterprise_versioned_docs/version-23.4/compute-envs/hpc.md
+++ b/platform-enterprise_versioned_docs/version-23.4/compute-envs/hpc.md
@@ -19,7 +19,7 @@ To launch pipelines into an **HPC** cluster from Seqera, the following requireme
 
 - The cluster should allow outbound connections to the Seqera web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Seqera HPC compute environment
 

--- a/platform-enterprise_versioned_docs/version-24.1/compute-envs/hpc.md
+++ b/platform-enterprise_versioned_docs/version-24.1/compute-envs/hpc.md
@@ -19,7 +19,7 @@ To launch pipelines into an **HPC** cluster from Seqera, the following requireme
 
 - The cluster should allow outbound connections to the Seqera web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Credentials
 

--- a/platform-enterprise_versioned_docs/version-24.2/compute-envs/hpc.md
+++ b/platform-enterprise_versioned_docs/version-24.2/compute-envs/hpc.md
@@ -19,7 +19,7 @@ To launch pipelines into an **HPC** cluster from Seqera, the following requireme
 
 - The cluster should allow outbound connections to the Seqera web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Credentials
 

--- a/platform-enterprise_versioned_docs/version-25.1/compute-envs/hpc.md
+++ b/platform-enterprise_versioned_docs/version-25.1/compute-envs/hpc.md
@@ -19,7 +19,7 @@ To launch pipelines into an **HPC** cluster from Seqera, the following requireme
 
 - The cluster should allow outbound connections to the Seqera web service.
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
-- The Nextflow runtime version **21.02.0-edge** (or later) must be installed on the cluster.
+- The Nextflow runtime version **21.02.0-edge** (or later) must be [installed on the cluster](https://nextflow.io/docs/latest/install.html).
 
 ## Credentials
 


### PR DESCRIPTION
I was setting up a new environment on a slurm cluster I'm building and I noticed that nextflow is set as a requirement but no pointers are set to the nextflow docs on how to set it up

I also noticed that some ancient docs were using a lighter tone for a requirement so I updated it, I don't know if that's something we do on docs for deprecated versions or whether they are considered in code freeze