### PR TITLE
docs: add logsViewer to SA permissions list

### DIFF
--- a/platform-cloud/docs/compute-envs/google-cloud-batch.md
+++ b/platform-cloud/docs/compute-envs/google-cloud-batch.md
@@ -61,6 +61,7 @@ By default, Google Cloud Batch uses the default Compute Engine service account t
 - Batch Agent Reporter (`roles/batch.agentReporter`) on the project
 - Batch Job Editor (`roles/batch.jobsEditor`) on the project
 - Logs Writer (`roles/logging.logWriter`) on the project (to let jobs generate logs in Cloud Logging)
+- Logs Viewer (`roles/logging.logViewer`) on the project (to view and retrieve logs from Cloud Logging)
 - Service Account User (`roles/iam.serviceAccountUser`)
 
 If your Google Cloud project does not require access restrictions on any of its Cloud Storage buckets, you can grant project Storage Admin (`roles/storage.admin`) permissions to your service account to simplify setup. To grant access only to specific buckets, add the service account as a principal on each bucket individually. See [Cloud Storage bucket](#cloud-storage-bucket) below.


### PR DESCRIPTION
Adds `roles/logging.logViewer` to the list of required IAM permissions for a custom service account. I think without this, users are unable to see the execution log in the console logs for a run on the Platform (see related JIRA issue [here](https://seqera.atlassian.net/browse/PLAT-2753?atlOrigin=eyJpIjoiNTM0NDcyZWFiYzNhNDdjMTg4M2Y3MmU4YWZmYjRkOTgiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)). 