### PR TITLE
Add path-based routing to Enterprise docs

### DIFF
--- a/platform-enterprise_versioned_docs/version-25.2/studios/overview.md
+++ b/platform-enterprise_versioned_docs/version-25.2/studios/overview.md
@@ -22,7 +22,7 @@ Before you get started, you need the following:
 - [Data Explorer](../data/data-explorer) is enabled.
 
 :::note
-Currently, Studios supports [AWS Cloud][aws-cloud], [Google Cloud(https://docs.seqera.io/platform-cloud/compute-envs/google-cloud), and [AWS Batch][aws-batch] compute environments that **do not** have Fargate enabled.
+Currently, Studios supports [AWS Cloud][aws-cloud], [Google Cloud][google-cloud], and [AWS Batch][aws-batch] compute environments that **do not** have Fargate enabled.
 :::
 
 ## Container image templates
@@ -239,6 +239,7 @@ In Connect proxy/server:
 [contact]: https://support.seqera.io/
 [aws-cloud]: ../compute-envs/aws-cloud
 [aws-batch]: ../compute-envs/aws-batch
+[google-cloud]: ../compute-envs/google-cloud
 [custom-envs]: ./custom-envs
 [build-status]: ./custom-envs#build-status
 [cloud-bucket-subdirectory]: ./managing#cloud-bucket-subdirectory


### PR DESCRIPTION
Content preview: **https://deploy-preview-735--seqera-docs.netlify.app/platform-enterprise/25.2/studios/overview#path-based-routingnon-wildcard-ssltls-certificates**

Env vars have been added in a separate PR. 