### PR TITLE
feat: Define redis as requirement for azure/gcp/on-prem

### DIFF
--- a/platform-enterprise_versioned_docs/version-23.3/enterprise/prerequisites/azure.md
+++ b/platform-enterprise_versioned_docs/version-23.3/enterprise/prerequisites/azure.md
@@ -12,6 +12,7 @@ Run the Seqera container with [Docker](../docker-compose) on an Azure VM instanc
 - A resource group and a storage account are required to use Azure. See [Azure setup](#azure-setup) below to provision these resources.
 - **SMTP server**: If you don't have an email server, see [Azure's recommended method of sending email][azure-sendmail]. Microsoft recommends [Microsoft 365][msft-365] or the third party service [SendGrid][sendgrid].
 - **MySQL database**: An external database such as [Azure Database for MySQL][azure-db-create-portal] is highly recommended for production deployments.
+- **Redis-compatible cache**: An external Redis-compatible cache, such as [Azure Cache for Redis](https://azure.microsoft.com/en-gb/products/cache/), is highly recommended for production deployments.
 - **SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
   :::caution

--- a/platform-enterprise_versioned_docs/version-23.3/enterprise/prerequisites/gcp.mdx
+++ b/platform-enterprise_versioned_docs/version-23.3/enterprise/prerequisites/gcp.mdx
@@ -14,6 +14,7 @@ Run the Seqera container with [Docker](../docker-compose) on a GCP VM instance o
 
 - **SMTP server**: If you don't have an email server, Google Cloud provides several ways to send emails, such as [SendGrid][sendgrid], [Mailgun][mailgun], and [Mailjet][mailjet]. Work with your IT team to select the best solution for your organization.
 - **MySQL database**: An external database such as [Google CloudSQL][gcloudsql] is highly recommended for production environments.
+- **Redis-compatible cache**: An external Redis-compatible cache, such as [Google Memorystore] (https://cloud.google.com/memorystore/docs/redis/), is highly recommended for production deployments.
 - **SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
   :::caution

--- a/platform-enterprise_versioned_docs/version-23.4/enterprise/prerequisites/azure.md
+++ b/platform-enterprise_versioned_docs/version-23.4/enterprise/prerequisites/azure.md
@@ -12,6 +12,7 @@ Run the Seqera container with [Docker](../docker-compose) on an Azure VM instanc
 - A resource group and a storage account are required to use Azure. See [Azure setup](#azure-setup) below to provision these resources.
 - **SMTP server**: If you don't have an email server, see [Azure's recommended method of sending email][azure-sendmail]. Microsoft recommends [Microsoft 365][msft-365] or the third party service [SendGrid][sendgrid].
 - **MySQL database**: An external database such as [Azure Database for MySQL][azure-db-create-portal] is highly recommended for production deployments.
+- **Redis-compatible cache**: An external Redis-compatible cache, such as [Azure Cache for Redis](https://azure.microsoft.com/en-gb/products/cache/), is highly recommended for production deployments.
 - **SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
   :::caution

--- a/platform-enterprise_versioned_docs/version-23.4/enterprise/prerequisites/gcp.mdx
+++ b/platform-enterprise_versioned_docs/version-23.4/enterprise/prerequisites/gcp.mdx
@@ -14,6 +14,7 @@ Run the Seqera container with [Docker](../docker-compose) on a GCP VM instance o
 
 - **SMTP server**: If you don't have an email server, Google Cloud provides several ways to send emails, such as [SendGrid][sendgrid], [Mailgun][mailgun], and [Mailjet][mailjet]. Work with your IT team to select the best solution for your organization.
 - **MySQL database**: An external database such as [Google CloudSQL][gcloudsql] is highly recommended for production environments.
+- **Redis-compatible cache**: An external Redis-compatible cache, such as [Google Memorystore] (https://cloud.google.com/memorystore/docs/redis/), is highly recommended for production deployments.
 - **SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
   :::caution

--- a/platform-enterprise_versioned_docs/version-23.4/enterprise/prerequisites/on-prem.md
+++ b/platform-enterprise_versioned_docs/version-23.4/enterprise/prerequisites/on-prem.md
@@ -25,6 +25,12 @@ You must satisfy the requirements for your installation:
 
   To use an external database, you must create a MySQL user and database manually. See [Configuration](../configuration/overview#seqera-and-redis-databases) for more details.
 
+- **Redis cache**: A Redis-compatible cache external to your Docker Compose or Kubernetes environment is highly recommended for production deployments.
+
+  If you don't have your own redis service, use an external service from a cloud provider. Visit the provider's corresponding **Prerequisites** page for more information and consult your IT team to select the most suitable solution for your organization.
+
+  See [Configuration](../configuration/overview#seqera-and-redis-databases) for more details.
+
 - **(Optional) SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
 :::caution

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/prerequisites/azure.md
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/prerequisites/azure.md
@@ -12,6 +12,7 @@ Run the Seqera container with [Docker](../docker-compose) on an Azure VM instanc
 - A resource group and a storage account are required to use Azure. See [Azure setup](#azure-setup) below to provision these resources.
 - **SMTP server**: If you don't have an email server, see [Azure's recommended method of sending email][azure-sendmail]. Microsoft recommends [Microsoft 365][msft-365] or the third party service [SendGrid][sendgrid].
 - **MySQL database**: An external database such as [Azure Database for MySQL][azure-db-create-portal] is highly recommended for production deployments.
+- **Redis-compatible cache**: An external Redis-compatible cache, such as [Azure Cache for Redis](https://azure.microsoft.com/en-gb/products/cache/), is highly recommended for production deployments.
 - **SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
   :::caution

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/prerequisites/gcp.mdx
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/prerequisites/gcp.mdx
@@ -14,6 +14,7 @@ Run the Seqera container with [Docker](../docker-compose) on a GCP VM instance o
 
 - **SMTP server**: If you don't have an email server, Google Cloud provides several ways to send emails, such as [SendGrid][sendgrid], [Mailgun][mailgun], and [Mailjet][mailjet]. Work with your IT team to select the best solution for your organization.
 - **MySQL database**: An external database such as [Google CloudSQL][gcloudsql] is highly recommended for production environments.
+- **Redis-compatible cache**: An external Redis-compatible cache, such as [Google Memorystore] (https://cloud.google.com/memorystore/docs/redis/), is highly recommended for production deployments.
 - **SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
   :::caution

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/prerequisites/on-prem.md
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/prerequisites/on-prem.md
@@ -25,6 +25,12 @@ You must satisfy the requirements for your installation:
 
   To use an external database, you must create a MySQL user and database manually. See [Configuration](../configuration/overview#seqera-and-redis-databases) for more details.
 
+- **Redis cache**: A Redis-compatible cache external to your Docker Compose or Kubernetes environment is highly recommended for production deployments.
+
+  If you don't have your own redis service, use an external service from a cloud provider. Visit the provider's corresponding **Prerequisites** page for more information and consult your IT team to select the most suitable solution for your organization.
+
+  See [Configuration](../configuration/overview#seqera-and-redis-databases) for more details.
+
 - **(Optional) SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
 :::caution

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/prerequisites/azure.md
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/prerequisites/azure.md
@@ -12,6 +12,7 @@ Run the Seqera container with [Docker](../docker-compose) on an Azure VM instanc
 - A resource group and a storage account are required to use Azure. See [Azure setup](#azure-setup) below to provision these resources.
 - **SMTP server**: If you don't have an email server, see [Azure's recommended method of sending email][azure-sendmail]. Microsoft recommends [Microsoft 365][msft-365] or the third party service [SendGrid][sendgrid].
 - **MySQL database**: An external database such as [Azure Database for MySQL][azure-db-create-portal] is highly recommended for production deployments.
+- **Redis-compatible cache**: An external Redis-compatible cache, such as [Azure Cache for Redis](https://azure.microsoft.com/en-gb/products/cache/), is highly recommended for production deployments.
 - **SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
   :::caution

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/prerequisites/gcp.mdx
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/prerequisites/gcp.mdx
@@ -14,6 +14,7 @@ Run the Seqera container with [Docker](../docker-compose) on a GCP VM instance o
 
 - **SMTP server**: If you don't have an email server, Google Cloud provides several ways to send emails, such as [SendGrid][sendgrid], [Mailgun][mailgun], and [Mailjet][mailjet]. Work with your IT team to select the best solution for your organization.
 - **MySQL database**: An external database such as [Google CloudSQL][gcloudsql] is highly recommended for production environments.
+- **Redis-compatible cache**: An external Redis-compatible cache, such as [Google Memorystore] (https://cloud.google.com/memorystore/docs/redis/), is highly recommended for production deployments.
 - **SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
   :::caution

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/prerequisites/on-prem.md
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/prerequisites/on-prem.md
@@ -25,6 +25,12 @@ You must satisfy the requirements for your installation:
 
   To use an external database, you must create a MySQL user and database manually. See [Configuration](../configuration/overview#seqera-and-redis-databases) for more details.
 
+- **Redis cache**: A Redis-compatible cache external to your Docker Compose or Kubernetes environment is highly recommended for production deployments.
+
+  If you don't have your own redis service, use an external service from a cloud provider. Visit the provider's corresponding **Prerequisites** page for more information and consult your IT team to select the most suitable solution for your organization.
+
+  See [Configuration](../configuration/overview#seqera-and-redis-databases) for more details.
+
 - **(Optional) SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
 :::caution

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/prerequisites/azure.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/prerequisites/azure.md
@@ -12,6 +12,7 @@ Run the Seqera container with [Docker](../docker-compose) on an Azure VM instanc
 - A resource group and a storage account are required to use Azure. See [Azure setup](#azure-setup) below to provision these resources.
 - **SMTP server**: If you don't have an email server, see [Azure's recommended method of sending email][azure-sendmail]. Microsoft recommends [Microsoft 365][msft-365] or the third party service [SendGrid][sendgrid].
 - **MySQL database**: An external database such as [Azure Database for MySQL][azure-db-create-portal] is highly recommended for production deployments.
+- **Redis-compatible cache**: An external Redis-compatible cache, such as [Azure Cache for Redis](https://azure.microsoft.com/en-gb/products/cache/), is highly recommended for production deployments.
 - **SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
   :::caution

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/prerequisites/gcp.mdx
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/prerequisites/gcp.mdx
@@ -14,6 +14,7 @@ Run the Seqera container with [Docker](../docker-compose) on a GCP VM instance o
 
 - **SMTP server**: If you don't have an email server, Google Cloud provides several ways to send emails, such as [SendGrid][sendgrid], [Mailgun][mailgun], and [Mailjet][mailjet]. Work with your IT team to select the best solution for your organization.
 - **MySQL database**: An external database such as [Google CloudSQL][gcloudsql] is highly recommended for production environments.
+- **Redis-compatible cache**: An external Redis-compatible cache, such as [Google Memorystore] (https://cloud.google.com/memorystore/docs/redis/), is highly recommended for production deployments.
 - **SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
   :::caution

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/prerequisites/on-prem.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/prerequisites/on-prem.md
@@ -25,6 +25,12 @@ You must satisfy the requirements for your installation:
 
   To use an external database, you must create a MySQL user and database manually. See [Configuration](../configuration/overview#seqera-and-redis-databases) for more details.
 
+- **Redis cache**: A Redis-compatible cache external to your Docker Compose or Kubernetes environment is highly recommended for production deployments.
+
+  If you don't have your own redis service, use an external service from a cloud provider. Visit the provider's corresponding **Prerequisites** page for more information and consult your IT team to select the most suitable solution for your organization.
+
+  See [Configuration](../configuration/overview#seqera-and-redis-databases) for more details.
+
 - **(Optional) SSL certificate**: An SSL certificate is required for your Seqera instance to handle HTTPS traffic.
 
 :::caution


### PR DESCRIPTION
Follow up of https://github.com/seqeralabs/docs/pull/728 since I realized we don't mention redis as a requirement for gcp/azure/on-prem either.