### PR TITLE
Replace Bitbucket app passwords with API tokens

### DIFF
--- a/platform-cloud/docs/git/overview.md
+++ b/platform-cloud/docs/git/overview.md
@@ -165,7 +165,7 @@ To connect to a private [Gitea](https://gitea.io/) repository, use your Gitea us
 
 ### Bitbucket
 
-To connect to a private BitBucket repository, see [API tokens](https://support.atlassian.com/bitbucket-cloud/docs/api-tokens/) to learn how to create a BitBucket API token. Then, create a new credential in Seqera with these steps:
+To connect to a private BitBucket repository, see [API tokens](https://support.atlassian.com/bitbucket-cloud/docs/api-tokens/) to learn how to create a BitBucket API token (the API token must have at least `read:repository:bitbucket` scope). Then, create a new credential in Seqera with these steps:
 
 :::warning
 API tokens replace [app passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/), which can no longer be created after September 9, 2025 and will be phased out June 9, 2026. While app passwords are still supported, they are not recommended. See [Bitbucket Cloud transitions to API tokens](https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens-enhancing-security-with-app-password-deprecation) for more information.


### PR DESCRIPTION
Closes [PLAT-2939](https://seqera.atlassian.net/browse/PLAT-2939).

- Bitbucket app passwords are deprecated in favour of API tokens: update documentation to reflect that.

[PLAT-2939]: https://seqera.atlassian.net/browse/PLAT-2939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ