### PR TITLE
[Fix] Change Algolia index name

### DIFF
--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           ALGOLIA_APP_ID: 5E8JEKSR3W
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
-          ALGOLIA_INDEX_NAME: "Docs Crawler (Staging)"
+          ALGOLIA_INDEX_NAME: "Docs Crawler"
         run: |
           node scripts/indexDocs.js
 


### PR DESCRIPTION
Changed index name in workflow from 'Docs Crawler (Staging)' to 'Docs Crawler' to see if it resolves issues with incorrect objectIDs which are not using the correct format. 