### PR TITLE
Update URL generation for platform paths

### DIFF
--- a/scripts/indexDocs.js
+++ b/scripts/indexDocs.js
@@ -52,13 +52,12 @@ function extractTextContent(markdownContent) {
 
 function generateUrlFromPath(filePath) {
   // Convert file path to URL path - must match your actual site URLs
-  let url = filePath
-    .replace(/^platform-enterprise_docs\//, '/platform/')
-    .replace(/^platform-enterprise_versioned_docs\/version-([^\/]+)\//, '/platform/$1/')
+  let url = filePath    
+    .replace(/^platform-enterprise_versioned_docs\/version-([^\/]+)\//, '/platform-enterprise/$1/')
     .replace(/^fusion_docs\//, '/fusion/')
     .replace(/^wave_docs\//, '/wave/')
     .replace(/^multiqc_docs\//, '/multiqc/')
-    .replace(/^platform-cloud\/docs\//, '/cloud/')
+    .replace(/^platform-cloud\/docs\//, '/platform-cloud/')
     .replace(/^platform-api-docs\/docs\//, '/api/')
     .replace(/\.mdx?$/, '')
     .replace(/\/index$/, '');


### PR DESCRIPTION
- Removed `.replace(/^platform-enterprise_docs\//, '/platform/')` as we're not currently using that directory AFAIK. @gavinelder, can you confirm?
- Renamed references of platform to `platform-cloud` and `platform-enterprise` to fix broken links