### PR TITLE
🔒 Improve AWS Cloud IAM policy security

### DIFF
--- a/platform-cloud/docs/compute-envs/aws-cloud.md
+++ b/platform-cloud/docs/compute-envs/aws-cloud.md
@@ -70,11 +70,21 @@ The following permissions are required to provision resources in the AWS account
                 "iam:CreateInstanceProfile",
                 "iam:AttachRolePolicy",
                 "iam:PutRolePolicy",
-                "iam:PassRole",
                 "iam:TagRole",
                 "iam:TagInstanceProfile"
             ],
-            "Resource": "*"
+            "Resource": [
+                "arn:aws:iam::*:role/TowerForge*",
+                "arn:aws:iam::*:instance-profile/TowerForge*"
+            ]
+        },
+        {
+            "Sid": "AwsCloudCreatePassRole",
+            "Effect": "Allow",
+            "Action": [
+                "iam:PassRole"
+            ],
+            "Resource": "arn:aws:iam::*:role/TowerForge*"
         }
     ]
 }
@@ -111,15 +121,49 @@ The following permissions are required to launch pipelines, run Studio sessions,
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "AwsCloudLaunch",
+            "Sid": "AwsCloudLaunchEC2",
             "Effect": "Allow",
             "Action": [
                 "ec2:RunInstances",
-                "ec2:DescribeInstances",
                 "ec2:CreateTags",
-                "ec2:TerminateInstances",
-                "ec2:DeleteTags",
-                "logs:GetLogEvents",
+                "ec2:DeleteTags"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:instance/*",
+                "arn:aws:ec2:*:*:volume/*",
+                "arn:aws:ec2:*:*:network-interface/*",
+                "arn:aws:ec2:*:*:subnet/*",
+                "arn:aws:ec2:*:*:security-group/*",
+                "arn:aws:ec2:*:*:key-pair/*",
+                "arn:aws:ec2:*:*:image/*"
+            ]
+        },
+        {
+            "Sid": "AwsCloudLaunchInstances",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeInstances",
+                "ec2:TerminateInstances"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "ec2:ResourceTag/Name": "TowerForge-*"
+                }
+            }
+        },
+        {
+            "Sid": "AwsCloudLaunchLogs",
+            "Effect": "Allow",
+            "Action": [
+                "logs:GetLogEvents"
+            ],
+            "Resource": "arn:aws:logs:*:*:log-group:*:log-stream:*"
+        },
+        {
+            "Sid": "AwsCloudLaunchS3",
+            "Effect": "Allow",
+            "Action": [
                 "s3:GetObject"
             ],
             "Resource": "*"
@@ -149,7 +193,10 @@ The following permissions are required to remove resources created by Seqera whe
                 "iam:DetachRolePolicy",
                 "iam:DeleteRolePolicy"
             ],
-            "Resource": "*"
+            "Resource": [
+                "arn:aws:iam::*:role/TowerForge*",
+                "arn:aws:iam::*:instance-profile/TowerForge*"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Summary
- Restricts IAM policy permissions to follow the principle of least privilege
- Scopes IAM roles and instance profiles to `TowerForge*` prefix instead of wildcard resources
- Adds resource-level restrictions for EC2 operations based on `TowerForge-*` instance naming
- Splits launch policy into granular statements with appropriate conditions

## Test plan
- [ ] Verify that AWS Cloud compute environments can still be created with the new scoped policies
- [ ] Test that only resources with the TowerForge prefix can be managed
- [ ] Confirm pipeline launches and Studio sessions work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)