### PR TITLE
Remove reference to env vars in Cloud docs

### DIFF
--- a/platform-cloud/docs/studios/overview.md
+++ b/platform-cloud/docs/studios/overview.md
@@ -206,14 +206,6 @@ To mount an EFS volume in a Studio session (for example, if your organization ha
 
 For more information on AWS Batch configuration, see [AWS Batch][aws-batch].
 
-### Custom subdomains/non-wildcard SSL/TLS certificates
-
-Connect, the Studios webserver, uses dynamic subdomains to manage session routing of requests. This requires a wildcard SSL/TLS certificate. For Enterprise deployments that cannot use a wildcard SSL/TLS certificate or that require custom subdomains, an optional configuration environment variable can be added (`TOWER_DATA_STUDIO_ENABLE_PATH_ROUTING = True`). Setting this configures Studios requests to use path-based routing, which does not require a wildcard SSL/TLS certificate and allows custom subdomains.
-
-:::warning
-Path-based routing is only supported for the Seqera-provided JupyterLab, R-IDE Server, and Visual Studio Code container template images (and custom environments built from each). Xpra and user-defined [custom container template images](./custom-envs.md#custom-containers) are not supported.
-:::
-
 {/* links */}
 [contact]: https://support.seqera.io/
 [aws-cloud]: ../compute-envs/aws-cloud


### PR DESCRIPTION
Closes https://seqera.atlassian.net/browse/EDU-846

@bebosudo, I removed the content completely as it shouldn't be in the Cloud docs. When we have our new search live, it'll be easier for customers to find the information they need in the docs so we don't need to shoe-horn in this sort of cross-reference. :) 