### PR TITLE
fix: update docs to settle doubts about different bitbucket token types

### DIFF
--- a/platform-cloud/docs/git/overview.md
+++ b/platform-cloud/docs/git/overview.md
@@ -175,7 +175,7 @@ To connect to a private [Gitea](https://gitea.io/) repository, use your Gitea us
 To connect to a private BitBucket repository, see [API tokens](https://support.atlassian.com/bitbucket-cloud/docs/api-tokens/) to learn how to create a BitBucket API token (the API token must have at least `read:repository:bitbucket` scope). Then, create a new credential in Seqera with these steps:
 
 :::warning
-API tokens are tied to users and are different from Access tokens which are tied to resource. While API tokens are supported by Platform, Access tokens are not supported for accessing BitBucket repositories.
+API tokens are tied to users. This differs from access tokens, which are tied to a specific resource. While Seqera supports API tokens, access tokens are not supported for accessing BitBucket repositories.
 
 API tokens replace [app passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/), which can no longer be created after September 9, 2025 and will be phased out June 9, 2026. While app passwords are still supported, they are not recommended. See [Bitbucket Cloud transitions to API tokens](https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens-enhancing-security-with-app-password-deprecation) for more information.
 :::


### PR DESCRIPTION
Dispel confusion about different bitbucket token types
related customer ticker: https://seqera.atlassian.net/browse/ES-182