### PR TITLE
fix: added the connect proxy socket requirement for docker-compose

### DIFF
--- a/platform-enterprise_docs/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_docs/enterprise/_templates/docker/docker-compose.yml
@@ -127,6 +127,8 @@ services:
 #    restart: always
 #    depends_on:
 #      - redis
+#   volumes:
+#     - $HOME/.tower/connect:/data
 #
 #  connect-server:
 #    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.8.0

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/docker/docker-compose.yml
@@ -127,6 +127,8 @@ services:
 #    restart: always
 #    depends_on:
 #      - redis
+#   volumes:
+#     - $HOME/.tower/connect:/data
 #
 #  connect-server:
 #    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.8.3


### PR DESCRIPTION
## Summary
The connect-proxy:0.8.3 image requires a socket mount to function properly. This PR adds the missing volume mount configuration to the Docker Compose file.

## Details
The socket mount is already defined in the Kubernetes proxy manifest.
This update ensures consistency between the Docker Compose setup and the Kubernetes deployment.

## Changes
Added volume mount:
```
volumes:
  - $HOME/.tower/connect:/data
```

##Impact
Aligns local and Kubernetes environments, ensuring the proxy connects correctly in both.