### PR TITLE
feat: Update seqera compute supported regions

### DIFF
--- a/platform-cloud/docs/compute-envs/aws-cloud.md
+++ b/platform-cloud/docs/compute-envs/aws-cloud.md
@@ -35,15 +35,28 @@ This type of compute environment is best suited to run Studios and small to medi
 
 The following regions are currently supported:
 
-- `eu-west-1`
-- `us-east-1`
-- `us-west-2`
-- `eu-west-2`
-- `us-east-2`
-- `eu-central-1`
-- `us-west-1`
-- `eu-west-3`
+- `af-south-1`
+- `ap-east-1`
+- `ap-northeast-1`
+- `ap-northeast-2`
+- `ap-northeast-3`
+- `ap-south-1`
 - `ap-southeast-1`
+- `ap-southeast-2`
+- `ap-southeast-3`
+- `ca-central-1`
+- `eu-central-1`
+- `eu-north-1`
+- `eu-south-1`
+- `eu-west-1`
+- `eu-west-2`
+- `eu-west-3`
+- `me-south-1`
+- `sa-east-1`
+- `us-east-1`
+- `us-east-2`
+- `us-west-1`
+- `us-west-2`
 
 ## Requirements
 

--- a/platform-enterprise_docs/compute-envs/aws-cloud.md
+++ b/platform-enterprise_docs/compute-envs/aws-cloud.md
@@ -35,15 +35,28 @@ This type of compute environment is best suited to run Studios and small to medi
 
 The following regions are currently supported:
 
-- `eu-west-1`
-- `us-east-1`
-- `us-west-2`
-- `eu-west-2`
-- `us-east-2`
-- `eu-central-1`
-- `us-west-1`
-- `eu-west-3`
+- `af-south-1`
+- `ap-east-1`
+- `ap-northeast-1`
+- `ap-northeast-2`
+- `ap-northeast-3`
+- `ap-south-1`
 - `ap-southeast-1`
+- `ap-southeast-2`
+- `ap-southeast-3`
+- `ca-central-1`
+- `eu-central-1`
+- `eu-north-1`
+- `eu-south-1`
+- `eu-west-1`
+- `eu-west-2`
+- `eu-west-3`
+- `me-south-1`
+- `sa-east-1`
+- `us-east-1`
+- `us-east-2`
+- `us-west-1`
+- `us-west-2`
 
 ## Requirements
 

--- a/platform-enterprise_versioned_docs/version-25.2/compute-envs/aws-cloud.md
+++ b/platform-enterprise_versioned_docs/version-25.2/compute-envs/aws-cloud.md
@@ -9,7 +9,7 @@ tags: [cloud, vm, amazon, aws, compute-environment]
 
 :::note
 This compute environment type is currently in public preview. Please consult this guide for the latest information on recommended configuration and limitations. This guide assumes you already have an AWS account with a valid AWS subscription.
-::: 
+:::
 
 The current implementation of compute environments for cloud providers all rely on the use of batch services such as AWS Batch, Azure Batch, and Google Batch for the execution and management of submitted jobs, including pipelines and Studio session environments. Batch services are suitable for large-scale workloads, but they add management complexity. In practical terms, the currently used batch services result in some limitations:
 
@@ -32,17 +32,30 @@ This type of compute environment is best suited to run Studios and small to medi
 
 ## Supported regions
 
-The following regions are currently supported: 
+The following regions are currently supported:
 
-- `eu-west-1`
-- `us-east-1`
-- `us-west-2`
-- `eu-west-2`
-- `us-east-2`
-- `eu-central-1`
-- `us-west-1`
-- `eu-west-3`
+- `af-south-1`
+- `ap-east-1`
+- `ap-northeast-1`
+- `ap-northeast-2`
+- `ap-northeast-3`
+- `ap-south-1`
 - `ap-southeast-1`
+- `ap-southeast-2`
+- `ap-southeast-3`
+- `ca-central-1`
+- `eu-central-1`
+- `eu-north-1`
+- `eu-south-1`
+- `eu-west-1`
+- `eu-west-2`
+- `eu-west-3`
+- `me-south-1`
+- `sa-east-1`
+- `us-east-1`
+- `us-east-2`
+- `us-west-1`
+- `us-west-2`
 
 ## Requirements
 
@@ -180,7 +193,7 @@ The following permissions enable Seqera to populate values for dropdown fields. 
 }
 ```
 
-## Managed Amazon Machine Image (AMI) 
+## Managed Amazon Machine Image (AMI)
 
 The AWS Cloud compute environment uses an AMI maintained by Seqera, and the pipeline launch procedure assumes that some basic tooling is already present in the image itself. If you want to provide your own AMI, it must include at least the following:
 


### PR DESCRIPTION
slack: https://seqera.slack.com/archives/C097B208ZHR/p1762427402723729

I noticed the following line in the `v25.2.0_cycle16` changelog, shall we retroactively update the changelogs?
```
- Added `ap-southeast-2` to supported regions in Platform.
```
in the slack thread above Cristian pointed out the source code where regions are enabled, maybe we can trace when the different regions were added