### PR TITLE
docs: document backend listening port NOTASK

### DIFF
--- a/platform-enterprise_docs/enterprise/configuration/configtables/generic_config_env.yml
+++ b/platform-enterprise_docs/enterprise/configuration/configtables/generic_config_env.yml
@@ -1,51 +1,56 @@
 ---
-- 
+-
   Environment variable:            '`TOWER_SERVER_URL`'
   Description: >
     Your Seqera instance hostname, IP address, DNS name, or full [reverse proxy path](https://docs.seqera.io/platform-enterprise/latest/enterprise/configuration/reverse_proxy) where the application is exposed. The `https://` protocol is required for instances that use an SSL certificate. As of version 22.1, HTTPS is used by default. To use HTTP, set `TOWER_ENABLE_UNSAFE_MODE=true`.
   Value:                "Default: `http://localhost:8000`"
 -
   Environment variable:            '`TOWER_LICENSE`'
-  Description: > 
-    Your Seqera Enterprise license key (**required**). [Contact us](mailto:sales@seqera.io) to obtain your license key. The key is base64-encoded by Seqera — paste this value exactly as received. 
+  Description: >
+    Your Seqera Enterprise license key (**required**). [Contact us](mailto:sales@seqera.io) to obtain your license key. The key is base64-encoded by Seqera — paste this value exactly as received.
   Value:                '`DT8G5F3...BBV90OW`'
-- 
+-
   Environment variable:            '`TOWER_APP_NAME`'
-  Description: > 
+  Description: >
     Application name. To run multiple instances of the same Seqera account, each instance must have a unique name, e.g., `tower-dev` and `tower-prod`.
   Value:                'Default: `tower`'
-- 
+-
   Environment variable:            '`TOWER_CONFIG_FILE`'
-  Description: > 
+  Description: >
     Custom path for the `tower.yml` file.
   Value:                '`path/to/tower/config`'
-- 
+-
   Environment variable:            '`TOWER_LANDING_URL`'
-  Description: > 
+  Description: >
     Custom landing page for the application (requires version 21.10.1 or later). This value doesn't change the `TOWER_SERVER_URL` used for inbound Seqera connections.
-  Value:                '`https://your.custom.landing.example.net`'               
-- 
+  Value:                '`https://your.custom.landing.example.net`'
+-
+  Environment variable:            '`TOWER_BACKEND_SERVER_PORT`'
+  Description: >
+    Define the HTTP port used by the Seqera backend service (requires version 25.3 or later).
+  Value:                '`8080`'
+-
   Environment variable:            '`TOWER_CRON_SERVER_PORT`'
-  Description: > 
+  Description: >
     Define the HTTP port used by the Seqera cron service (requires version 21.06.1 or later).
   Value:                '`8080`'
-- 
+-
   Environment variable:            '`TOWER_ROOT_USERS`'
-  Description: > 
+  Description: >
     Grant users access to the application admin panel.
   Value:                '`user1@your-company.com,user2@your-company.com`'
-- 
+-
   Environment variable:            '`TOWER_CONTACT_EMAIL`'
-  Description: > 
+  Description: >
     Your Seqera system administrator contact email.
   Value:                '`seqera@your-company.com`'
-- 
+-
   Environment variable:            '`TOWER_AUTH_DISABLE_EMAIL`'
-  Description: > 
+  Description: >
     Set to `true` to disable the email login. Ensure that you've configured an alternative authentication provider first.
-  Value:                'Default: `false`'  
+  Value:                'Default: `false`'
 -
   Environment variable:            '`TOWER_USER_WORKSPACE_ENABLED`'
-  Description: > 
+  Description: >
     Enable or disable user private workspaces (requires version 22.1.0 or later).
   Value:                'Default: `true`'


### PR DESCRIPTION
Similar to `TOWER_CRON_SERVER_PORT`.
I don't see v25.3 in the `platform-enterprise_versioned_docs` folder, I guess that's going to be cut at a later point.