### PR TITLE
[Wave] Make overview page landing page

### DIFF
--- a/wave_docs/sidebar.json
+++ b/wave_docs/sidebar.json
@@ -39,9 +39,9 @@
         {
           "type": "category",
           "label": "CLI",
+          "link": {"type": "doc", "id": "cli/index"},
           "collapsed": true,
           "items": [
-            "cli/index",
             "cli/installation",
             "cli/use-cases"
           ]


### PR DESCRIPTION
- Complements this PR https://github.com/seqeralabs/wave/pull/941
- Removing overview headings
- Overview page becomes the index page for the section