### PR TITLE
fix: Bump helm release in link to github too

### DIFF
--- a/platform-enterprise_docs/enterprise/helm.md
+++ b/platform-enterprise_docs/enterprise/helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/0.17.1/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/0.19.0/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 ## Prerequisites
 

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/helm.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/0.17.1/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/0.19.0/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 ## Prerequisites
 


### PR DESCRIPTION
Follow up of #938, since I missed to update the link pointing to the helm chart repo on github.