### PR TITLE
fix: Correctly point to helm release in link to github

### DIFF
--- a/platform-enterprise_docs/enterprise/helm.md
+++ b/platform-enterprise_docs/enterprise/helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/0.19.0/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.19.0/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 ## Prerequisites
 

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/helm.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/0.19.0/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.19.0/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 ## Prerequisites
 


### PR DESCRIPTION
Another follow-up of #938 and #939: I didn't check that the link was the correct one, but each new chart release creates a tag like `{chartName}-{chartVersion}`