### PR TITLE
fix: Fix all container image tags in Docker Compose and Kubernetes YAMLs to use full release version

### DIFF
--- a/platform-enterprise_docs/enterprise/_templates/cloudformation/aws-ecs-cloudformation.json
+++ b/platform-enterprise_docs/enterprise/_templates/cloudformation/aws-ecs-cloudformation.json
@@ -80,7 +80,7 @@
                     },
                     {
                     "Name": "cron",
-                    "Image": "cr.seqera.io/private/nf-tower-enterprise/backend:v25.3",
+                    "Image": "cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.0",
                     "Memory": 2000,
                     "Cpu": 0,
                     "Links": [
@@ -192,7 +192,7 @@
                     },
                     {
                     "Name": "frontend",
-                    "Image": "cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3",
+                    "Image": "cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.0",
                     "Memory": 2000,
                     "Cpu": 0,
                     "Essential": false,
@@ -215,7 +215,7 @@
                     "Hostname": "backend",
                     "Memory": 2000,
                     "Cpu": 0,
-                    "Image": "cr.seqera.io/private/nf-tower-enterprise/backend:v25.3",
+                    "Image": "cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.0",
                     "PortMappings": [{
                         "ContainerPort": 8080,
                         "HostPort": 8080

--- a/platform-enterprise_docs/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_docs/enterprise/_templates/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.3
+    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.3.0
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -57,7 +57,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3
+    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.0
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -78,7 +78,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3
+    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.0
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -103,7 +103,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3
+    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.0
     platform: linux/amd64
     networks:
       - frontend

--- a/platform-enterprise_docs/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/tower-cron.yml
@@ -21,7 +21,7 @@ spec:
             name: tower-yml
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.3
+          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.3.0
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -32,7 +32,7 @@ spec:
               subPath: tower.yml
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3
+          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.0
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform-enterprise_docs/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/tower-svc.yml
@@ -29,7 +29,7 @@ spec:
         #    secretName: platform-oidc-certs
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3
+          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.0
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -88,7 +88,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3
+          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.0
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform-enterprise_docs/enterprise/kubernetes.md
+++ b/platform-enterprise_docs/enterprise/kubernetes.md
@@ -178,7 +178,7 @@ spec:
   ...
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3-unprivileged
+          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.0-unprivileged
           env:
             - name: NGINX_LISTEN_PORT  # If not defined, defaults to 8000.
               value: 8000

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/cloudformation/aws-ecs-cloudformation.json
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/cloudformation/aws-ecs-cloudformation.json
@@ -80,7 +80,7 @@
                     },
                     {
                     "Name": "cron",
-                    "Image": "cr.seqera.io/private/nf-tower-enterprise/backend:v25.3",
+                    "Image": "cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.0",
                     "Memory": 2000,
                     "Cpu": 0,
                     "Links": [
@@ -192,7 +192,7 @@
                     },
                     {
                     "Name": "frontend",
-                    "Image": "cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3",
+                    "Image": "cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.0",
                     "Memory": 2000,
                     "Cpu": 0,
                     "Essential": false,
@@ -215,7 +215,7 @@
                     "Hostname": "backend",
                     "Memory": 2000,
                     "Cpu": 0,
-                    "Image": "cr.seqera.io/private/nf-tower-enterprise/backend:v25.3",
+                    "Image": "cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.0",
                     "PortMappings": [{
                         "ContainerPort": 8080,
                         "HostPort": 8080

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.3
+    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.3.0
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -57,7 +57,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3
+    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.0
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -78,7 +78,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3
+    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.0
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -103,7 +103,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3
+    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.0
     platform: linux/amd64
     networks:
       - frontend

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/tower-cron.yml
@@ -21,7 +21,7 @@ spec:
             name: tower-yml
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.3
+          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.3.0
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -32,7 +32,7 @@ spec:
               subPath: tower.yml
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3
+          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.0
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/tower-svc.yml
@@ -29,7 +29,7 @@ spec:
         #    secretName: platform-oidc-certs
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3
+          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.0
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -91,7 +91,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3
+          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.0
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/kubernetes.md
@@ -178,7 +178,7 @@ spec:
   ...
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3-unprivileged
+          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.0-unprivileged
           env:
             - name: NGINX_LISTEN_PORT  # If not defined, defaults to 8000.
               value: 8000


### PR DESCRIPTION
This PR updates several image references in the Docker Compose and Kubernetes installation YAML files to use the full release version tag `v25.3.0` instead of the truncated `v25.3`.