### PR TITLE
Add basic CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# More generic rules first, then more specific ones overwriting previous ones.
+*                                                                 @justinegeffen @llewellyn-sl
+
+/platform-enterprise_docs/enterprise/helm.md                      @justinegeffen @llewellyn-sl @seqeralabs/devops
+/platform-enterprise_docs/enterprise/kubernetes.md                @justinegeffen @llewellyn-sl @seqeralabs/devops
+/platform-enterprise_versioned_docs/*/enterprise/helm.md          @justinegeffen @llewellyn-sl @seqeralabs/devops
+/platform-enterprise_versioned_docs/*/enterprise/kubernetes.md    @justinegeffen @llewellyn-sl @seqeralabs/devops


### PR DESCRIPTION
The Devops team would like to get notified of future changes to the helm and k8s instructions in the future, so I'd like to propose to introduce a CODEOWNERS file.

I couldn't find a GH team for the Edu team so I added Justine and Llewellyn individually.

@gavinelder in case you're renaming files in the restructure PR #984