### PR TITLE
Add all available seqera compute regions to Platform Cloud docs

### DIFF
--- a/platform-cloud/docs/compute-envs/seqera-compute.md
+++ b/platform-cloud/docs/compute-envs/seqera-compute.md
@@ -47,7 +47,7 @@ Seqera Compute has default workspace limits on compute environments, and organiz
 
     | Americas                             | Europe                            | Asia Pacific                        | Middle East & Africa       |
     |--------------------------------------|-----------------------------------|-------------------------------------|----------------------------|
-    | us-east-1 (Northern Virginia, USA)   | eu-central-1 (Frankfurt, Germany) | ap-east-1 (Hong Kong)               | af-south-1 (Cape Town, SA) |
+    | us-east-1 (Northern Virginia, USA)   | eu-central-1 (Frankfurt, Germany) | ap-east-1 (Hong Kong)               | af-south-1 (Cape Town, South Africa) |
     | us-east-2 (Ohio, USA)                | eu-north-1 (Stockholm, Sweden)    | ap-northeast-1 (Tokyo, Japan)       | me-south-1 (Bahrain)       |
     | us-west-1 (Northern California, USA) | eu-south-1 (Milan, Italy)         | ap-northeast-2 (Seoul, South Korea) |                            |
     | us-west-2 (Oregon, USA)              | eu-west-1 (Ireland)               | ap-northeast-3 (Osaka, Japan)       |                            |


### PR DESCRIPTION
slack thread: https://seqera.slack.com/archives/C097B208ZHR/p1767345744674569

Add all regions and add spaces to markdown table formatting for easier manipulation.

I thought I fixed this in November, but I edited the AWS Cloud CE pages instead somehow: https://github.com/seqeralabs/docs/pull/901. I'll fix those in a separate PR once engineering confirms the regions where that's available.