### PR TITLE
chore: streamline groundswell instructions

### DIFF
--- a/platform-enterprise_docs/enterprise/configuration/pipeline_optimization.md
+++ b/platform-enterprise_docs/enterprise/configuration/pipeline_optimization.md
@@ -75,10 +75,7 @@ To use the pipeline resource optimization service in an existing Docker Compose 
 
 Kubernetes deployments use an [initContainer](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that runs during pod initialization to set up the pipeline resource optimization service. To use the service in new or existing Kubernetes installations of Seqera Enterprise, do the following:
 
-1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml):
-
-    ```yaml file=../_templates/k8s/groundswell.yml
-    ```
+1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml).
 
 1. To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable in the `configmap.yml` file that you downloaded for your [Platform installation][platform-k8s]. A non-zero value for this environment variable activates the optimization service automatically, so `TOWER_ENABLE_GROUNDSWELL` does not need to be set when you declare a custom URL.
 

--- a/platform-enterprise_docs/enterprise/docker-compose.md
+++ b/platform-enterprise_docs/enterprise/docker-compose.md
@@ -73,6 +73,10 @@ If further customization of the config file is needed, mount a config map/secret
 
 ## Optional features
 
+### Pipeline optimization
+
+Seqera Platform offers a service that optimizes pipeline resource requests. Refer to [Pipeline optimization](./configuration/pipeline_optimization.md) for more information.
+
 ### Studios
 
 [Studios](../studios/overview) is an interactive analysis environment available in organizational workspaces. To enable Studios, see [Studios deployment](./studios).

--- a/platform-enterprise_docs/enterprise/kubernetes.md
+++ b/platform-enterprise_docs/enterprise/kubernetes.md
@@ -244,11 +244,7 @@ See [Test deployment](./testing).
 
 ### Pipeline optimization
 
-Seqera Platform offers a service that optimizes pipeline resource requests. Install the resource optimization service in your Kubernetes cluster with [this manifest](_templates/k8s/groundswell.yml).
-
-Define a set of credentials for the resource optimization database in the `tower-groundswell-cfg` ConfigMap. This can be the same database used for Seqera, but in a different schema.
-
-The initContainers will wait until both the Seqera and pipeline optimization service databases are ready before starting the migration in the Seqera database and finally starting the resource optimization container.
+Seqera Platform offers a service that optimizes pipeline resource requests. Refer to [Pipeline optimization](./configuration/pipeline_optimization.md) for more information.
 
 ### Studios
 

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/configuration/pipeline_optimization.md
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/configuration/pipeline_optimization.md
@@ -75,10 +75,7 @@ To use the pipeline resource optimization service in an existing Docker Compose 
 
 Kubernetes deployments use an [initContainer](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that runs during pod initialization to set up the pipeline resource optimization service. To use the service in new or existing Kubernetes installations of Seqera Enterprise, do the following:
 
-1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml):
-
-    ```yaml file=../_templates/k8s/groundswell.yml
-    ```
+1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml).
 
 1. To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable in the `configmap.yml` file that you downloaded for your [Platform installation][platform-k8s]. A non-zero value for this environment variable activates the optimization service automatically, so `TOWER_ENABLE_GROUNDSWELL` does not need to be set when you declare a custom URL.
 

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/docker-compose.md
@@ -43,6 +43,10 @@ For more information on configuration, see [Configuration options](./configurati
 
 ## Optional features
 
+### Pipeline optimization
+
+Seqera Platform offers a service that optimizes pipeline resource requests. Refer to [Pipeline optimization](./configuration/pipeline_optimization.md) for more information.
+
 ### Data Studios
 
 [Data Studios](../data_studios/overview) is an interactive analysis environment available in organizational workspaces. To enable Data Studios, see [Data Studios deployment](./data-studios).

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/kubernetes.mdx
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/kubernetes.mdx
@@ -244,11 +244,7 @@ See [Test deployment](./testing).
 
 ### Pipeline optimization
 
-Seqera Platform offers a service that optimizes pipeline resource requests. Install the resource optimization service in your Kubernetes cluster with [this manifest](_templates/k8s/groundswell.yml).
-
-Define a set of credentials for the resource optimization database in the `tower-groundswell-cfg` ConfigMap. This can be the same database used for Seqera, but in a different schema.
-
-The initContainers will wait until both the Seqera and pipeline optimization service databases are ready before starting the migration in the Seqera database and finally starting the resource optimization container.
+Seqera Platform offers a service that optimizes pipeline resource requests. Refer to [Pipeline optimization](./configuration/pipeline_optimization.md) for more information.
 
 ### Data Studios
 

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/configuration/pipeline_optimization.md
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/configuration/pipeline_optimization.md
@@ -75,10 +75,7 @@ To use the pipeline resource optimization service in an existing Docker Compose 
 
 Kubernetes deployments use an [initContainer](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that runs during pod initialization to set up the pipeline resource optimization service. To use the service in new or existing Kubernetes installations of Seqera Enterprise, do the following:
 
-1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml):
-
-    ```yaml file=../_templates/k8s/groundswell.yml
-    ```
+1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml).
 
 1. To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable in the `configmap.yml` file that you downloaded for your [Platform installation][platform-k8s]. A non-zero value for this environment variable activates the optimization service automatically, so `TOWER_ENABLE_GROUNDSWELL` does not need to be set when you declare a custom URL.
 

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/docker-compose.md
@@ -43,6 +43,10 @@ For more information on configuration, see [Configuration options](./configurati
 
 ## Optional features
 
+### Pipeline optimization
+
+Seqera Platform offers a service that optimizes pipeline resource requests. Refer to [Pipeline optimization](./configuration/pipeline_optimization.md) for more information.
+
 ### Studios
 
 [Studios](../data_studios/overview) is an interactive analysis environment available in organizational workspaces. To enable Studios, see [Studios deployment](../enterprise/studios).

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/kubernetes.mdx
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/kubernetes.mdx
@@ -244,11 +244,7 @@ See [Test deployment](./testing).
 
 ### Pipeline optimization
 
-Seqera Platform offers a service that optimizes pipeline resource requests. Install the resource optimization service in your Kubernetes cluster with [this manifest](_templates/k8s/groundswell.yml).
-
-Define a set of credentials for the resource optimization database in the `tower-groundswell-cfg` ConfigMap. This can be the same database used for Seqera, but in a different schema.
-
-The initContainers will wait until both the Seqera and pipeline optimization service databases are ready before starting the migration in the Seqera database and finally starting the resource optimization container.
+Seqera Platform offers a service that optimizes pipeline resource requests. Refer to [Pipeline optimization](./configuration/pipeline_optimization.md) for more information.
 
 ### Studios
 

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/configuration/pipeline_optimization.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/configuration/pipeline_optimization.md
@@ -75,10 +75,7 @@ To use the pipeline resource optimization service in an existing Docker Compose 
 
 Kubernetes deployments use an [initContainer](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that runs during pod initialization to set up the pipeline resource optimization service. To use the service in new or existing Kubernetes installations of Seqera Enterprise, do the following:
 
-1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml):
-
-    ```yaml file=../_templates/k8s/groundswell.yml
-    ```
+1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml).
 
 1. To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable in the `configmap.yml` file that you downloaded for your [Platform installation][platform-k8s]. A non-zero value for this environment variable activates the optimization service automatically, so `TOWER_ENABLE_GROUNDSWELL` does not need to be set when you declare a custom URL.
 

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/docker-compose.md
@@ -43,6 +43,10 @@ For more information on configuration, see [Configuration options](./configurati
 
 ## Optional features
 
+### Pipeline optimization
+
+Seqera Platform offers a service that optimizes pipeline resource requests. Refer to [Pipeline optimization](./configuration/pipeline_optimization.md) for more information.
+
 ### Studios
 
 [Studios](../studios/overview) is an interactive analysis environment available in organizational workspaces. To enable Studios, see [Studios deployment](./studios).

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/kubernetes.md
@@ -244,11 +244,7 @@ See [Test deployment](./testing).
 
 ### Pipeline optimization
 
-Seqera Platform offers a service that optimizes pipeline resource requests. Install the resource optimization service in your Kubernetes cluster with [this manifest](_templates/k8s/groundswell.yml).
-
-Define a set of credentials for the resource optimization database in the `tower-groundswell-cfg` ConfigMap. This can be the same database used for Seqera, but in a different schema.
-
-The initContainers will wait until both the Seqera and pipeline optimization service databases are ready before starting the migration in the Seqera database and finally starting the resource optimization container.
+Seqera Platform offers a service that optimizes pipeline resource requests. Refer to [Pipeline optimization](./configuration/pipeline_optimization.md) for more information.
 
 ### Studios
 

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/configuration/pipeline_optimization.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/configuration/pipeline_optimization.md
@@ -75,10 +75,7 @@ To use the pipeline resource optimization service in an existing Docker Compose 
 
 Kubernetes deployments use an [initContainer](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that runs during pod initialization to set up the pipeline resource optimization service. To use the service in new or existing Kubernetes installations of Seqera Enterprise, do the following:
 
-1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml):
-
-    ```yaml file=../_templates/k8s/groundswell.yml
-    ```
+1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml).
 
 1. To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable in the `configmap.yml` file that you downloaded for your [Platform installation][platform-k8s]. A non-zero value for this environment variable activates the optimization service automatically, so `TOWER_ENABLE_GROUNDSWELL` does not need to be set when you declare a custom URL.
 

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/docker-compose.md
@@ -43,6 +43,10 @@ For more information on configuration, see [Configuration options](./configurati
 
 ## Optional features
 
+### Pipeline optimization
+
+Seqera Platform offers a service that optimizes pipeline resource requests. Refer to [Pipeline optimization](./configuration/pipeline_optimization.md) for more information.
+
 ### Studios
 
 [Studios](../studios/overview) is an interactive analysis environment available in organizational workspaces. To enable Studios, see [Studios deployment](./studios).

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/kubernetes.md
@@ -244,11 +244,7 @@ See [Test deployment](./testing).
 
 ### Pipeline optimization
 
-Seqera Platform offers a service that optimizes pipeline resource requests. Install the resource optimization service in your Kubernetes cluster with [this manifest](_templates/k8s/groundswell.yml).
-
-Define a set of credentials for the resource optimization database in the `tower-groundswell-cfg` ConfigMap. This can be the same database used for Seqera, but in a different schema.
-
-The initContainers will wait until both the Seqera and pipeline optimization service databases are ready before starting the migration in the Seqera database and finally starting the resource optimization container.
+Seqera Platform offers a service that optimizes pipeline resource requests. Refer to [Pipeline optimization](./configuration/pipeline_optimization.md) for more information.
 
 ### Studios
 

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/configuration/pipeline_optimization.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/configuration/pipeline_optimization.md
@@ -75,10 +75,7 @@ To use the pipeline resource optimization service in an existing Docker Compose 
 
 Kubernetes deployments use an [initContainer](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that runs during pod initialization to set up the pipeline resource optimization service. To use the service in new or existing Kubernetes installations of Seqera Enterprise, do the following:
 
-1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml):
-
-    ```yaml file=../_templates/k8s/groundswell.yml
-    ```
+1. Download the [groundswell manifest](../_templates/k8s/groundswell.yml).
 
 1. To run the service from a custom URL, declare the URL with the `GROUNDSWELL_SERVER_URL` environment variable in the `configmap.yml` file that you downloaded for your [Platform installation][platform-k8s]. A non-zero value for this environment variable activates the optimization service automatically, so `TOWER_ENABLE_GROUNDSWELL` does not need to be set when you declare a custom URL.
 

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/docker-compose.md
@@ -73,6 +73,10 @@ If further customization of the config file is needed, mount a config map/secret
 
 ## Optional features
 
+### Pipeline optimization
+
+Seqera Platform offers a service that optimizes pipeline resource requests. Refer to [Pipeline optimization](./configuration/pipeline_optimization.md) for more information.
+
 ### Studios
 
 [Studios](../studios/overview) is an interactive analysis environment available in organizational workspaces. To enable Studios, see [Studios deployment](./studios).

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/kubernetes.md
@@ -244,11 +244,7 @@ See [Test deployment](./testing).
 
 ### Pipeline optimization
 
-Seqera Platform offers a service that optimizes pipeline resource requests. Install the resource optimization service in your Kubernetes cluster with [this manifest](_templates/k8s/groundswell.yml).
-
-Define a set of credentials for the resource optimization database in the `tower-groundswell-cfg` ConfigMap. This can be the same database used for Seqera, but in a different schema.
-
-The initContainers will wait until both the Seqera and pipeline optimization service databases are ready before starting the migration in the Seqera database and finally starting the resource optimization container.
+Seqera Platform offers a service that optimizes pipeline resource requests. Refer to [Pipeline optimization](./configuration/pipeline_optimization.md) for more information.
 
 ### Studios
 


### PR DESCRIPTION
Groundswell was being referenced in the kubernetes page with some minimal details, while we have a full page explaining it, so let's refer users to that, like we do for Studios.

Also notify compose users that groundswell is an optional feature.

All changes backported to v24.1+