### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
 # More generic rules first, then more specific ones overwriting previous ones.
 
+/platform-enterprise_docs/enterprise/advanced-topics/firewall-configuration.md                            @justinegeffen @llewellyn-sl @seqeralabs/devops
+/platform-enterprise_docs/_versioned_docs/version-*/enterprise/advanced-topics/firewall-configuration.md  @justinegeffen @llewellyn-sl @seqeralabs/devops
 /platform-enterprise_docs/enterprise/helm.md                      @justinegeffen @llewellyn-sl @seqeralabs/devops
 /platform-enterprise_docs/enterprise/kubernetes.md                @justinegeffen @llewellyn-sl @seqeralabs/devops
 /platform-enterprise_versioned_docs/*/enterprise/helm.md          @justinegeffen @llewellyn-sl @seqeralabs/devops


### PR DESCRIPTION
Removed the need for codeowner approval on all PRs to ensure our workflow for merging PRs isn't negatively affected.

The previous setting required codeowner approval on all PRs. This change limits the requirement to devops-related PRs.