### PR TITLE
fix: Add missing GH_TOKEN to use gh cli

### DIFF
--- a/.github/workflows/pre-commit-fix.yaml
+++ b/.github/workflows/pre-commit-fix.yaml
@@ -11,12 +11,18 @@ jobs:
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, 'fix formatting')
 
+    permissions:
+      contents: write
+      pull-requests: read
+
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # ratchet:actions/checkout@v6.0.0
 
       # Action runs on the issue comment, so we don't get the PR by default.
       # Use the GitHub CLI to check out the PR.
       - name: Checkout Pull Request
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: gh pr checkout ${{ github.event.issue.number }}
 
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # ratchet:actions/setup-python@v6.0.0


### PR DESCRIPTION
tested with trigger [here](https://github.com/seqeralabs/docs/pull/998#issuecomment-3729239048), failure [here](https://github.com/seqeralabs/docs/actions/runs/20855806605/job/59921995889?pr=998#step:3:5)