### PR TITLE
chore: Align Platform memory requirement to 4 GB, set requests=limits

### DIFF
--- a/platform-enterprise_docs/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/tower-svc.yml
@@ -51,9 +51,9 @@ spec:
           resources:
             requests:
               cpu: "1"
-              memory: "1200Mi"
+              memory: "4000Mi"
             limits:
-              memory: "4200Mi"
+              memory: "4000Mi"
           readinessProbe:
             httpGet:
               path: /health

--- a/platform-enterprise_docs/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_docs/enterprise/platform-kubernetes.md
@@ -17,7 +17,7 @@ Other than the basic requirements [already listed in the Platform installation o
 
 | Component | CPU | Memory |
 | :-------- | :-- | :----- |
-| Backend pod | 1 core | 4200 Mi limit |
+| Backend pod | 1 core | 4000 Mi request and limit |
 
 ## Container images
 

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/k8s/tower-svc.yml
@@ -54,9 +54,9 @@ spec:
           resources:
             requests:
               cpu: "1"
-              memory: "4Gi"
+              memory: "4000Mi"
             limits:
-              memory: "4Gi"
+              memory: "4000Mi"
           readinessProbe:
             httpGet:
               path: /health

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/platform-kubernetes.md
@@ -17,7 +17,7 @@ Other than the basic requirements [already listed in the Platform installation o
 
 | Component | CPU | Memory |
 | :-------- | :-- | :----- |
-| Backend pod | 1 core | 1200 Mi request, 4200 Mi limit |
+| Backend pod | 1 core | 4000 Mi request and limit |
 
 ## Container images
 

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/k8s/tower-svc.yml
@@ -54,9 +54,9 @@ spec:
           resources:
             requests:
               cpu: "1"
-              memory: "4Gi"
+              memory: "4000Mi"
             limits:
-              memory: "4Gi"
+              memory: "4000Mi"
           readinessProbe:
             httpGet:
               path: /health

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/platform-kubernetes.md
@@ -17,7 +17,7 @@ Other than the basic requirements [already listed in the Platform installation o
 
 | Component | CPU | Memory |
 | :-------- | :-- | :----- |
-| Backend pod | 1 core | 1200 Mi request, 4200 Mi limit |
+| Backend pod | 1 core | 4000 Mi request and limit |
 
 ## Container images
 

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/tower-svc.yml
@@ -54,9 +54,9 @@ spec:
           resources:
             requests:
               cpu: "1"
-              memory: "4Gi"
+              memory: "4000Mi"
             limits:
-              memory: "4Gi"
+              memory: "4000Mi"
           readinessProbe:
             httpGet:
               path: /health

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/platform-kubernetes.md
@@ -17,7 +17,7 @@ Other than the basic requirements [already listed in the Platform installation o
 
 | Component | CPU | Memory |
 | :-------- | :-- | :----- |
-| Backend pod | 1 core | 1200 Mi request, 4200 Mi limit |
+| Backend pod | 1 core | 4000 Mi request and limit |
 
 ## Container images
 


### PR DESCRIPTION
I noticed we were recommending 4200 MB in the markdown, but setting 4 GB as default in the k8s files, so let's align on 4000 MB.