### PR TITLE
chore: Move groundswell db setup instructions to install-groundswell page

### DIFF
--- a/platform-enterprise_docs/enterprise/groundswell-docker-compose.md
+++ b/platform-enterprise_docs/enterprise/groundswell-docker-compose.md
@@ -1,7 +1,7 @@
 ---
 title: "Pipeline optimization: Docker Compose"
 description: Deploy pipeline optimization with Docker Compose
-date: "12 Apr 2023"
+date: "2026-02-09"
 tags: [docker, compose, groundswell, pipeline optimization, deployment]
 ---
 

--- a/platform-enterprise_docs/enterprise/groundswell-kubernetes.md
+++ b/platform-enterprise_docs/enterprise/groundswell-kubernetes.md
@@ -1,7 +1,7 @@
 ---
 title: "Pipeline optimization: Kubernetes"
 description: Deploy pipeline optimization on Kubernetes
-date: "12 Apr 2023"
+date: "2026-02-09"
 tags: [kubernetes, groundswell, pipeline optimization, deployment]
 ---
 

--- a/platform-enterprise_docs/enterprise/install-groundswell.md
+++ b/platform-enterprise_docs/enterprise/install-groundswell.md
@@ -1,7 +1,7 @@
 ---
 title: "Pipeline optimization"
 description: Install pipeline optimization for Seqera Platform Enterprise
-date: "12 Apr 2023"
+date: "2026-02-09"
 tags: [groundswell, pipeline, optimization, installation, deployment]
 ---
 

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/groundswell-docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/groundswell-docker-compose.md
@@ -1,7 +1,7 @@
 ---
 title: "Pipeline optimization: Docker Compose"
 description: Deploy pipeline optimization with Docker Compose
-date: "12 Apr 2023"
+date: "2026-02-09"
 tags: [docker, compose, groundswell, pipeline optimization, deployment]
 ---
 

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/groundswell-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/groundswell-kubernetes.md
@@ -1,7 +1,7 @@
 ---
 title: "Pipeline optimization: Kubernetes"
 description: Deploy pipeline optimization on Kubernetes
-date: "12 Apr 2023"
+date: "2026-02-09"
 tags: [kubernetes, groundswell, pipeline optimization, deployment]
 ---
 

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/install-groundswell.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/install-groundswell.md
@@ -1,7 +1,7 @@
 ---
 title: "Pipeline optimization"
 description: Install pipeline optimization for Seqera Platform Enterprise
-date: "12 Apr 2023"
+date: "2026-02-09"
 tags: [groundswell, pipeline, optimization, installation, deployment]
 ---
 

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/groundswell-docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/groundswell-docker-compose.md
@@ -1,7 +1,7 @@
 ---
 title: "Pipeline optimization: Docker Compose"
 description: Deploy pipeline optimization with Docker Compose
-date: "12 Apr 2023"
+date: "2026-02-09"
 tags: [docker, compose, groundswell, pipeline optimization, deployment]
 ---
 

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/groundswell-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/groundswell-kubernetes.md
@@ -1,7 +1,7 @@
 ---
 title: "Pipeline optimization: Kubernetes"
 description: Deploy pipeline optimization on Kubernetes
-date: "12 Apr 2023"
+date: "2026-02-09"
 tags: [kubernetes, groundswell, pipeline optimization, deployment]
 ---
 

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/install-groundswell.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/install-groundswell.md
@@ -1,7 +1,7 @@
 ---
 title: "Pipeline optimization"
 description: Install pipeline optimization for Seqera Platform Enterprise
-date: "12 Apr 2023"
+date: "2026-02-09"
 tags: [groundswell, pipeline, optimization, installation, deployment]
 ---
 

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/groundswell-docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/groundswell-docker-compose.md
@@ -1,7 +1,7 @@
 ---
 title: "Pipeline optimization: Docker Compose"
 description: Deploy pipeline optimization with Docker Compose
-date: "12 Apr 2023"
+date: "2026-02-09"
 tags: [docker, compose, groundswell, pipeline optimization, deployment]
 ---
 

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/groundswell-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/groundswell-kubernetes.md
@@ -1,7 +1,7 @@
 ---
 title: "Pipeline optimization: Kubernetes"
 description: Deploy pipeline optimization on Kubernetes
-date: "12 Apr 2023"
+date: "2026-02-09"
 tags: [kubernetes, groundswell, pipeline optimization, deployment]
 ---
 

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/install-groundswell.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/install-groundswell.md
@@ -1,7 +1,7 @@
 ---
 title: "Pipeline optimization"
 description: Install pipeline optimization for Seqera Platform Enterprise
-date: "12 Apr 2023"
+date: "2026-02-09"
 tags: [groundswell, pipeline, optimization, installation, deployment]
 ---
 


### PR DESCRIPTION
This PR moves groundswell DB instructions to the requirements section of install-groundswell docs page, removing the duplication from the compose and k8s pages

This also realigns install-groundswell pages, since v25.3 was different from vNext and other v25.x