### PR TITLE
Add ${userName} to inline dynamic resource label examples

### DIFF
--- a/platform-cloud/docs/resource-labels/overview.md
+++ b/platform-cloud/docs/resource-labels/overview.md
@@ -68,7 +68,7 @@ When a Studio starts with resource labels attached:
 1. Enter a **Name** such as `owner`, `team`, or `platform-run`.
 1. Enter a **Value**:
     - **Standard resource labels**: `<USERNAME>`, `TEAM_NAME`
-    - **[Dynamic resource labels](#dynamic-resource-labels)**: Use variable syntax — `${workflowId}` or `${sessionId}`
+    - **[Dynamic resource labels](#dynamic-resource-labels)**: Use variable syntax — `${workflowId}`, `${sessionId}`, or `${userName}`
 1. Optionally, enable **Use as default in compute environment form** to automatically apply this label to all new compute environments in this workspace.
 1. Select **Save**.
 

--- a/platform-cloud/docs/troubleshooting_and_faqs/resource-labels.md
+++ b/platform-cloud/docs/troubleshooting_and_faqs/resource-labels.md
@@ -20,4 +20,4 @@ Common issues experienced with resource labels in AWS, Azure, and GCP:
 **Missing tag values in cloud provider resources**: 
 - Verify that resource labels are applied to the correct compute environment
 - Check that workflows are using the tagged compute environment
-- For dynamic labels, ensure variables use correct syntax: `${workflowId}` and `${sessionId}`
+- For dynamic labels, ensure variables use correct syntax: `${workflowId}`, `${sessionId}`, and `${userName}`

--- a/platform-enterprise_docs/resource-labels/overview.md
+++ b/platform-enterprise_docs/resource-labels/overview.md
@@ -68,7 +68,7 @@ When a Studio starts with resource labels attached:
 1. Enter a **Name** such as `owner`, `team`, or `platform-run`.
 1. Enter a **Value**:
     - **Standard resource labels**: `<USERNAME>`, `TEAM_NAME`
-    - **[Dynamic resource labels](#dynamic-resource-labels)**: Use variable syntax — `${workflowId}` or `${sessionId}`
+    - **[Dynamic resource labels](#dynamic-resource-labels)**: Use variable syntax — `${workflowId}`, `${sessionId}`, or `${userName}`
 1. Optionally, enable **Use as default in compute environment form** to automatically apply this label to all new compute environments in this workspace.
 1. Select **Save**.
 

--- a/platform-enterprise_docs/troubleshooting_and_faqs/resource-labels.md
+++ b/platform-enterprise_docs/troubleshooting_and_faqs/resource-labels.md
@@ -20,4 +20,4 @@ Common issues experienced with resource labels in AWS, Azure, and GCP:
 **Missing tag values in cloud provider resources**:
 - Verify that resource labels are applied to the correct compute environment
 - Check that workflows are using the tagged compute environment
-- For dynamic labels, ensure variables use correct syntax: `${workflowId}` and `${sessionId}`
+- For dynamic labels, ensure variables use correct syntax: `${workflowId}`, `${sessionId}`, and `${userName}`

--- a/platform-enterprise_versioned_docs/version-25.3/resource-labels/overview.md
+++ b/platform-enterprise_versioned_docs/version-25.3/resource-labels/overview.md
@@ -68,7 +68,7 @@ When a Studio starts with resource labels attached:
 1. Enter a **Name** such as `owner`, `team`, or `platform-run`.
 1. Enter a **Value**:
     - **Standard resource labels**: `<USERNAME>`, `TEAM_NAME`
-    - **[Dynamic resource labels](#dynamic-resource-labels)**: Use variable syntax — `${workflowId}` or `${sessionId}`
+    - **[Dynamic resource labels](#dynamic-resource-labels)**: Use variable syntax — `${workflowId}`, `${sessionId}`, or `${userName}`
 1. Optionally, enable **Use as default in compute environment form** to automatically apply this label to all new compute environments in this workspace.
 1. Select **Save**.
 

--- a/platform-enterprise_versioned_docs/version-25.3/troubleshooting_and_faqs/resource-labels.md
+++ b/platform-enterprise_versioned_docs/version-25.3/troubleshooting_and_faqs/resource-labels.md
@@ -20,4 +20,4 @@ Common issues experienced with resource labels in AWS, Azure, and GCP:
 **Missing tag values in cloud provider resources**: 
 - Verify that resource labels are applied to the correct compute environment
 - Check that workflows are using the tagged compute environment
-- For dynamic labels, ensure variables use correct syntax: `${workflowId}` and `${sessionId}`
+- For dynamic labels, ensure variables use correct syntax: `${workflowId}`, `${sessionId}`, and `${userName}`


### PR DESCRIPTION
Follow-up to #1182: Add ${userName} to the inline variable syntax examples in overview and troubleshooting files for Cloud, Enterprise, and versioned docs (25.3).

https://claude.ai/code/session_01MsH1asZiExbK49KLbgAmxp