### PR TITLE
[codex] Clarify OIDC AWS Parameter Store configuration

### DIFF
--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/configuration/authentication/overview.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/configuration/authentication/overview.md
@@ -35,6 +35,20 @@ For OIDC providers, configure authentication with these environment variables:
 | `TOWER_OIDC_SECRET` | The client secret provided by your authentication service                                   |
 | `TOWER_OIDC_ISSUER` | The authentication service URL to which Seqera connects to authenticate the sign-in request |
 
+:::warning
+If you store OIDC values in AWS Parameter Store, keep the issuer, client ID, and client secret in the same configuration source. Do not split them across `tower.env`, `tower.yml`, and AWS Parameter Store. Mixed-source OIDC configuration can prevent Platform from resolving the full set of values during startup.
+:::
+
+When you use AWS Parameter Store for OIDC configuration, create these parameters with the same application name prefix:
+
+| OIDC value | AWS Parameter Store path |
+| :--------- | :----------------------- |
+| Client ID | `/config/<application_name>/micronaut/security/oauth2/clients/oidc/client-id` |
+| Client secret | `/config/<application_name>/micronaut/security/oauth2/clients/oidc/client-secret` |
+| Issuer URL | `/config/<application_name>/micronaut/security/oauth2/clients/oidc/openid/issuer` |
+
+Store the client secret as a `SecureString` parameter. See [AWS Parameter Store](../aws_parameter_store) for more information.
+
 Some providers require the full authentication service URL while others require only the SSO root domain (without the trailing sub-directories).
 
 In your OpenID provider settings, specify the following URL as a callback address or authorized redirect:

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/configuration/aws_parameter_store.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/configuration/aws_parameter_store.md
@@ -53,6 +53,8 @@ We recommend storing sensitive values, such as database passwords, as SecureStri
 
 Seqera does not support StringList parameters. Configuration parameters with multiple values can be created as comma-separated lists of String type.
 
+OIDC client secrets should also be stored as `SecureString` parameters. If you use AWS Parameter Store for OIDC, keep the issuer, client ID, and client secret together in Parameter Store instead of splitting them across different configuration sources.
+
 To create Seqera configuration parameters in AWS Parameter Store, do the following:
 
 1. Navigate to the **Parameter Store** from the **AWS Systems Manager Service** console.
@@ -66,3 +68,13 @@ To create Seqera configuration parameters in AWS Parameter Store, do the followi
 | **Type** | Use **SecureString** for sensitive values like passwords and tokens. Use **String** for everything else. |
 | **Data type** | Select **text**. |
 | **Value** | Enter a plain text value (this is the configuration value used in Seqera). |
+
+For OIDC values, the corresponding parameter paths are:
+
+| OIDC value | Parameter path |
+| :--------- | :------------- |
+| Client ID | `/config/<application_name>/micronaut/security/oauth2/clients/oidc/client-id` |
+| Client secret | `/config/<application_name>/micronaut/security/oauth2/clients/oidc/client-secret` |
+| Issuer URL | `/config/<application_name>/micronaut/security/oauth2/clients/oidc/openid/issuer` |
+
+If you template these values into Terraform user data or manifest generation, use Terraform interpolation syntax such as `${...}` rather than shell command substitution syntax such as `$()`.


### PR DESCRIPTION
## Summary
This draft clarifies how to configure OIDC values from AWS Parameter Store for current versioned Platform docs.

## Source context
- Slack source: https://seqera.slack.com/archives/C0APYR2A3A8/p1775513396564269
- Jira: https://seqera.atlassian.net/browse/EDU-1120
- Report: https://github.com/seqeralabs/agent-education-feedback-automation/blob/cursor/prompt-file-execution-4398/2026-03-30/2026-04-06.md

## Repo and doc targets
- Repo: `seqeralabs/docs`
- Docset: `platform-enterprise_versioned_docs`
- Pages:
  - `version-25.3/enterprise/configuration/authentication/overview.md`
  - `version-25.3/enterprise/configuration/aws_parameter_store.md`

## Rationale
The ticket described repeated startup failures caused by incorrect OIDC Parameter Store paths and by splitting the issuer, client ID, and client secret across multiple configuration sources. The current docs already covered OIDC and AWS Parameter Store separately, so this patch updates those existing pages instead of creating new docs.

## What changed
- Added a warning that OIDC issuer, client ID, and client secret must stay in the same configuration source.
- Added the AWS Parameter Store keys for OIDC client ID, client secret, and issuer.
- Clarified that the OIDC client secret should be stored as `SecureString`.
- Added a Terraform interpolation note for generated user-data or manifest templates.

## Validation
- Ran `npx markdownlint-cli2` on the two touched files.
- The command reported pre-existing style issues already present in these files; no new automated build was run.

## Follow-up
Please confirm the exact OIDC Parameter Store paths match product expectations in production deployments.
