### PR TITLE
[codex] Update Cloud permissions docs parity

### DIFF
--- a/platform-cloud/docs/orgs-and-teams/custom-roles.md
+++ b/platform-cloud/docs/orgs-and-teams/custom-roles.md
@@ -2,7 +2,7 @@
 title: "Custom roles"
 description: "Introduction to custom roles in Seqera Platform."
 date created: "2025-11-17"
-last updated: "2025-11-17"
+last updated: "2026-04-17"
 tags: [roles, user-roles, custom roles, rbac, permissions]
 ---
 
@@ -49,7 +49,7 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Validate credentials | _(Used by Platform)_ |
 |  | Validate credential name availability | `GET /credentials/validate` |
 | **credentials:delete** | Delete credentials | `DELETE /credentials/{credentialsId}` |
-| **credentials_encrypted:read** | Get encrypted credentials | _(Used by Platform)_ |
+| **credentials_encrypted:read** | Get encrypted credentials | `GET /credentials/{credentialsId}/keys` |
 | **pipeline_secrets:read** | List all pipeline secrets | `GET /pipeline-secrets` |
 |  | View pipeline secret details | `GET /pipeline-secrets/{secretId}` |
 | **pipeline_secrets:write** | Create a new pipeline secret | `POST /pipeline-secrets` |
@@ -68,6 +68,7 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Browse data-link contents | `GET /data-links/{dataLinkId}/browse` |
 |  | Browse data-link contents at the given path | `GET /data-links/{dataLinkId}/browse/{path}` |
 |  | View data-link details | `GET /data-links/{dataLinkId}` |
+|  | Resolve data-link cloud-scheme URLs | _(Used by Platform)_ |
 | **data_link:write** | Refresh data-link cache | `GET /data-links/cache/refresh` |
 |  | Browse data-link directory tree | `GET /data-links/{dataLinkId}/browse-tree` |
 |  | Download files from data-link | `GET /data-links/{dataLinkId}/download/{filePath}` |
@@ -79,6 +80,7 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Complete file upload to data-link at the given path | `POST /data-links/{dataLinkId}/upload/finish/{dirPath}` |
 |  | Create a custom data-link | `POST /data-links` |
 |  | Edit data-link metadata | `PUT /data-links/{dataLinkId}` |
+|  | Sign data-link URLs for batch access | _(Used by Platform)_ |
 | **data_link:delete** | Delete files from data-link | `DELETE /data-links/{dataLinkId}/content` |
 |  | Remove a data-link from workspace | `DELETE /data-links/{dataLinkId}` |
 | **data_link:admin** | Hide data-links | _(Used by Platform)_ |
@@ -87,19 +89,23 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | List workspace dataset versions (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/versions` |
 |  | List dataset versions (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/{datasetId}/versions` |
 |  | View dataset metadata (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/{datasetId}/metadata` |
-|  | Download dataset | `GET /workspaces/{workspaceId}/datasets/{datasetId}/v/{version}/n/{fileName}` |
+|  | Download dataset | _(Used by Platform)_ |
 |  | List all datasets | `GET /datasets` |
 |  | List latest dataset versions | `GET /datasets/versions` |
 |  | List versions for a specific dataset | `GET /datasets/{datasetId}/versions` |
 |  | List datasets used in a pipeline launch | `GET /launch/{launchId}/datasets` |
 |  | View dataset metadata | `GET /datasets/{datasetId}/metadata` |
 |  | Download dataset files | `GET /datasets/{datasetId}/v/{version}/n/{fileName}` |
+|  | Fetch preview content for a URL without persisting | `POST /datasets/preview-url` |
+|  | Preview linked dataset content | `GET /datasets/{datasetId}/v/{version}/preview` |
 | **dataset:write** | Create dataset (legacy endpoint) | `POST /workspaces/{workspaceId}/datasets` |
 |  | Edit dataset (legacy endpoint) | `PUT /workspaces/{workspaceId}/datasets/{datasetId}` |
 |  | Upload dataset (legacy endpoint) | `POST /workspaces/{workspaceId}/datasets/{datasetId}/upload` |
 |  | Create a new dataset | `POST /datasets` |
 |  | Edit dataset metadata | `PUT /datasets/{datasetId}` |
 |  | Upload files to dataset | `POST /datasets/{datasetId}/upload` |
+|  | Link external URL as dataset version | `POST /datasets/{datasetId}/link` |
+|  | Validate URL for dataset linking | `POST /datasets/validate-url` |
 | **dataset:delete** | Delete dataset (legacy endpoint) | `DELETE /workspaces/{workspaceId}/datasets/{datasetId}` |
 |  | Delete a single dataset | `DELETE /datasets/{datasetId}` |
 |  | Delete multiple datasets | `DELETE /datasets` |
@@ -130,7 +136,6 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Remove labels from actions | `POST /actions/labels/remove` |
 |  | Apply label sets to actions | `POST /actions/labels/apply` |
 | **container:read** | View container details | _(Used by Platform)_ |
-|  | List containers | _(Used by Platform)_ |
 |  | List workflow containers | _(Used by Platform)_ |
 | **launch:read** | View launch details | `GET /launch/{launchId}` |
 | **pipeline:read** | View pipeline repository information | `GET /pipelines/info` |
@@ -140,20 +145,23 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | List available pipeline repositories | `GET /pipelines/repositories` |
 |  | List all pipelines in workspace | `GET /pipelines` |
 |  | View pipeline details | `GET /pipelines/{pipelineId}` |
+|  | List pipeline versions | `GET /pipelines/{pipelineId}/versions` |
 |  | Fetch pipeline optimization | _(Used by Platform)_ |
-|  | List pipeline versions | _(Used by Platform)_ |
 | **pipeline:write** | Modify pipeline details when launching a pipeline run | Sub-operation on `POST /workflow/launch` |
 |  | Add a new pipeline to workspace | `POST /pipelines` |
-|  | Edit pipeline configuration | `PUT /pipelines/{pipelineId}` |
+|  | Edit pipeline (default version) configuration | `PUT /pipelines/{pipelineId}` |
 |  | Configure pipeline | _(Used by Platform)_ |
 |  | Validate pipeline name availability | `GET /pipelines/validate` |
-|  | Validate pipeline version name availability | _(Used by Platform)_ |
-|  | Manage pipeline version | _(Used by Platform)_ |
+|  | Create a pipeline schema | `POST /pipeline-schemas` |
+|  | Validate pipeline version name availability | `GET /pipelines/{pipelineId}/versions/validate` |
+|  | Manage pipeline version | `PUT /pipelines/{pipelineId}/versions/{versionId}/manage` |
+|  | Edit pipeline version configuration | `POST /pipelines/{pipelineId}/versions/{versionId}` |
 | **pipeline:delete** | Delete a pipeline | `DELETE /pipelines/{pipelineId}` |
 | **pipeline_label:write** | Apply resource labels when launching a pipeline run | Sub-operation on `POST /workflow/launch` |
 |  | Add labels to pipelines | `POST /pipelines/labels/add` |
 |  | Apply resource labels when adding a pipeline | Sub-operation on `POST /pipelines` |
-|  | Apply resource labels when editing a pipeline | Sub-operation on `PUT /pipelines/{pipelineId}` |
+|  | Apply resource labels when editing a pipeline (default version) | Sub-operation on `PUT /pipelines/{pipelineId}` |
+|  | Apply resource labels when editing a pipeline version | Sub-operation on `POST /pipelines/{pipelineId}/versions/{versionId}` |
 |  | Remove labels from pipelines | `POST /pipelines/labels/remove` |
 |  | Apply label sets to pipelines | `POST /pipelines/labels/apply` |
 | **workflow:read** | View run details | `GET /workflow/{workflowId}` |
@@ -231,15 +239,18 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Stop a studio session | `PUT /studios/{sessionId}/stop` |
 | **studio:write** | Create a new studio | `POST /studios` |
 |  | Edit checkpoint name | `PUT /studios/{sessionId}/checkpoints/{checkpointId}` |
+|  | Update a studio | `PUT /studios/{sessionId}` |
 |  | Validate studio name availability | `GET /studios/validate` |
 | **studio:delete** | Delete a studio | `DELETE /studios/{sessionId}` |
 | **studio:admin** | Delete another user's private studio | Sub-operation on `DELETE /studios/{sessionId}` |
 |  | Start another user's private studio | Sub-operation on `PUT /studios/{sessionId}/start` |
+|  | Update another user's private studio | Sub-operation on `PUT /studios/{sessionId}` |
 |  | Stop another user's private studio | Sub-operation on `PUT /studios/{sessionId}/stop` |
 |  | Extend another user's private studio session lifespan (iframe) | _(Used by Platform)_ |
 |  | Extend another user's private studio session lifespan | Sub-operation on `POST /studios/{sessionId}/lifespan` |
 |  | Administer another user's private studio | _(Used by Platform)_ |
 | **studio_label:write** | Apply resource labels when starting a studio | Sub-operation on `PUT /studios/{sessionId}/start` |
+|  | Apply resource labels when updating a studio | Sub-operation on `PUT /studios/{sessionId}` |
 | **studio_session:read** | Open a studio | _(Used by Platform)_ |
 | **studio_session:execute** | Extend studio session lifespan (iframe) | _(Used by Platform)_ |
 |  | Extend studio session lifespan | `POST /studios/{sessionId}/lifespan` |

--- a/platform-cloud/docs/orgs-and-teams/roles.md
+++ b/platform-cloud/docs/orgs-and-teams/roles.md
@@ -2,7 +2,7 @@
 title: "User roles"
 description: "Understand the various roles in Seqera Platform."
 date created: "2024-06-10"
-last updated: "2025-07-03"
+last updated: "2026-04-17"
 tags: [roles, user-roles]
 ---
 
@@ -31,7 +31,7 @@ As a best practice, use teams as the primary vehicle for assigning rights within
 
 ## Workspace participant roles
 
-- **Owner**: The user who created the workspace is its first owner. Owners have full administrative privileges over a workspace and its resources, including permission to delete the workspace. Regular participants can also be promoted to workspace owners. 
+- **Owner**: The user who created the workspace is its first owner. Owners have full administrative privileges over a workspace and its resources, including permission to delete the workspace. Regular participants can also be promoted to workspace owners.
 - **Admin**: Workspace admins share most of the administrative privileges of workspace owners, but admins cannot delete a workspace.
 - **Maintain**: Workspace maintainers can use and manage all workspace resources, but cannot create workspace credentials or compute environments.
 - **Launch**: Launch users can use existing workspace resources and launch pipelines, but they cannot modify workspace resources.
@@ -83,7 +83,7 @@ The following table shows which operations are available to the default workspac
 | **pipeline_secrets:delete**    | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **platform:read**              | ✅     | ✅     | ✅        | ✅      | ✅       | ✅      |
 | **studio:read**                | ✅     | ✅     | ✅        | ✅      | ✅       | ✅      |
-| **studio:execute**             | ✅     | ✅     | ✅        | ✅      | ❌       | ❌      |
+| **studio:execute**             | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **studio:write**               | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **studio:delete**              | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **studio:admin**               | ✅     | ✅     | ❌        | ❌      | ❌       | ❌      |

--- a/platform-enterprise_docs/orgs-and-teams/custom-roles.md
+++ b/platform-enterprise_docs/orgs-and-teams/custom-roles.md
@@ -2,11 +2,11 @@
 title: "Custom roles"
 description: "Introduction to custom roles in Seqera Platform."
 date created: "2025-11-17"
-last updated: "2025-11-17"
+last updated: "2026-04-17"
 tags: [roles, user-roles, custom roles, rbac, permissions]
 ---
 
-Seqera Platform supports custom roles to define permissions-based access control at a more granular level than the six default [workspace participant roles](./roles.md#workspace-participant-roles). 
+Seqera Platform supports custom roles to define permissions-based access control at a more granular level than the six default [workspace participant roles](./roles.md#workspace-participant-roles).
 
 ### Create custom roles
 
@@ -15,15 +15,15 @@ Organization owners can add custom roles and assign read, write, execute, admin,
 1. Select your organization name from the organization and workspace switcher in the top navigation.
 1. Select **Access control** to view the list of default and custom roles available in your organization.
 1. Select **Add role**.
-1. Enter a role **Name** and optional **Description**. 
-1. From the **Permissions** list, select the **Read**, **Write**, **Execute**, **Admin**, and **Delete** permissions your custom role requires for each resource type. 
-1. Select **Add** to create the custom role and return to the **Access control** roles list. 
+1. Enter a role **Name** and optional **Description**.
+1. From the **Permissions** list, select the **Read**, **Write**, **Execute**, **Admin**, and **Delete** permissions your custom role requires for each resource type.
+1. Select **Add** to create the custom role and return to the **Access control** roles list.
 
-Select **Edit** or **Delete** to manage existing custom roles in the list. 
+Select **Edit** or **Delete** to manage existing custom roles in the list.
 
 ### Permissions
 
-Individual permissions grant read, write, execute, admin, or delete access for each Seqera entity. Individual read and write permissions may grant access for multiple operations via the Platform UI, API, and other programmatic tools such as Platform CLI. For example, the `action:read` permission allows a user to view the list of actions in a workspace, view the details of a specific action, and view available action types. 
+Individual permissions grant read, write, execute, admin, or delete access for each Seqera entity. Individual read and write permissions may grant access for multiple operations via the Platform UI, API, and other programmatic tools such as Platform CLI. For example, the `action:read` permission allows a user to view the list of actions in a workspace, view the details of a specific action, and view available action types.
 
 #### Compute
 
@@ -45,7 +45,7 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Validate credentials | _(Used by Platform)_ |
 |  | Validate credential name availability | `GET /credentials/validate` |
 | **credentials:delete** | Delete credentials | `DELETE /credentials/{credentialsId}` |
-| **credentials_encrypted:read** | Get encrypted credentials | _(Used by Platform)_ |
+| **credentials_encrypted:read** | Get encrypted credentials | `GET /credentials/{credentialsId}/keys` |
 | **pipeline_secrets:read** | List all pipeline secrets | `GET /pipeline-secrets` |
 |  | View pipeline secret details | `GET /pipeline-secrets/{secretId}` |
 | **pipeline_secrets:write** | Create a new pipeline secret | `POST /pipeline-secrets` |
@@ -64,6 +64,7 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Browse data-link contents | `GET /data-links/{dataLinkId}/browse` |
 |  | Browse data-link contents at the given path | `GET /data-links/{dataLinkId}/browse/{path}` |
 |  | View data-link details | `GET /data-links/{dataLinkId}` |
+|  | Resolve data-link cloud-scheme URLs | _(Used by Platform)_ |
 | **data_link:write** | Refresh data-link cache | `GET /data-links/cache/refresh` |
 |  | Browse data-link directory tree | `GET /data-links/{dataLinkId}/browse-tree` |
 |  | Download files from data-link | `GET /data-links/{dataLinkId}/download/{filePath}` |
@@ -75,6 +76,7 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Complete file upload to data-link at the given path | `POST /data-links/{dataLinkId}/upload/finish/{dirPath}` |
 |  | Create a custom data-link | `POST /data-links` |
 |  | Edit data-link metadata | `PUT /data-links/{dataLinkId}` |
+|  | Sign data-link URLs for batch access | _(Used by Platform)_ |
 | **data_link:delete** | Delete files from data-link | `DELETE /data-links/{dataLinkId}/content` |
 |  | Remove a data-link from workspace | `DELETE /data-links/{dataLinkId}` |
 | **data_link:admin** | Hide data-links | _(Used by Platform)_ |
@@ -83,19 +85,23 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | List workspace dataset versions (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/versions` |
 |  | List dataset versions (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/{datasetId}/versions` |
 |  | View dataset metadata (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/{datasetId}/metadata` |
-|  | Download dataset | `GET /workspaces/{workspaceId}/datasets/{datasetId}/v/{version}/n/{fileName}` |
+|  | Download dataset | _(Used by Platform)_ |
 |  | List all datasets | `GET /datasets` |
 |  | List latest dataset versions | `GET /datasets/versions` |
 |  | List versions for a specific dataset | `GET /datasets/{datasetId}/versions` |
 |  | List datasets used in a pipeline launch | `GET /launch/{launchId}/datasets` |
 |  | View dataset metadata | `GET /datasets/{datasetId}/metadata` |
 |  | Download dataset files | `GET /datasets/{datasetId}/v/{version}/n/{fileName}` |
+|  | Fetch preview content for a URL without persisting | `POST /datasets/preview-url` |
+|  | Preview linked dataset content | `GET /datasets/{datasetId}/v/{version}/preview` |
 | **dataset:write** | Create dataset (legacy endpoint) | `POST /workspaces/{workspaceId}/datasets` |
 |  | Edit dataset (legacy endpoint) | `PUT /workspaces/{workspaceId}/datasets/{datasetId}` |
 |  | Upload dataset (legacy endpoint) | `POST /workspaces/{workspaceId}/datasets/{datasetId}/upload` |
 |  | Create a new dataset | `POST /datasets` |
 |  | Edit dataset metadata | `PUT /datasets/{datasetId}` |
 |  | Upload files to dataset | `POST /datasets/{datasetId}/upload` |
+|  | Link external URL as dataset version | `POST /datasets/{datasetId}/link` |
+|  | Validate URL for dataset linking | `POST /datasets/validate-url` |
 | **dataset:delete** | Delete dataset (legacy endpoint) | `DELETE /workspaces/{workspaceId}/datasets/{datasetId}` |
 |  | Delete a single dataset | `DELETE /datasets/{datasetId}` |
 |  | Delete multiple datasets | `DELETE /datasets` |
@@ -126,7 +132,6 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Remove labels from actions | `POST /actions/labels/remove` |
 |  | Apply label sets to actions | `POST /actions/labels/apply` |
 | **container:read** | View container details | _(Used by Platform)_ |
-|  | List containers | _(Used by Platform)_ |
 |  | List workflow containers | _(Used by Platform)_ |
 | **launch:read** | View launch details | `GET /launch/{launchId}` |
 | **pipeline:read** | View pipeline repository information | `GET /pipelines/info` |
@@ -136,20 +141,23 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | List available pipeline repositories | `GET /pipelines/repositories` |
 |  | List all pipelines in workspace | `GET /pipelines` |
 |  | View pipeline details | `GET /pipelines/{pipelineId}` |
+|  | List pipeline versions | `GET /pipelines/{pipelineId}/versions` |
 |  | Fetch pipeline optimization | _(Used by Platform)_ |
-|  | List pipeline versions | _(Used by Platform)_ |
 | **pipeline:write** | Modify pipeline details when launching a pipeline run | Sub-operation on `POST /workflow/launch` |
 |  | Add a new pipeline to workspace | `POST /pipelines` |
-|  | Edit pipeline configuration | `PUT /pipelines/{pipelineId}` |
+|  | Edit pipeline (default version) configuration | `PUT /pipelines/{pipelineId}` |
 |  | Configure pipeline | _(Used by Platform)_ |
 |  | Validate pipeline name availability | `GET /pipelines/validate` |
-|  | Validate pipeline version name availability | _(Used by Platform)_ |
-|  | Manage pipeline version | _(Used by Platform)_ |
+|  | Create a pipeline schema | `POST /pipeline-schemas` |
+|  | Validate pipeline version name availability | `GET /pipelines/{pipelineId}/versions/validate` |
+|  | Manage pipeline version | `PUT /pipelines/{pipelineId}/versions/{versionId}/manage` |
+|  | Edit pipeline version configuration | `POST /pipelines/{pipelineId}/versions/{versionId}` |
 | **pipeline:delete** | Delete a pipeline | `DELETE /pipelines/{pipelineId}` |
 | **pipeline_label:write** | Apply resource labels when launching a pipeline run | Sub-operation on `POST /workflow/launch` |
 |  | Add labels to pipelines | `POST /pipelines/labels/add` |
 |  | Apply resource labels when adding a pipeline | Sub-operation on `POST /pipelines` |
-|  | Apply resource labels when editing a pipeline | Sub-operation on `PUT /pipelines/{pipelineId}` |
+|  | Apply resource labels when editing a pipeline (default version) | Sub-operation on `PUT /pipelines/{pipelineId}` |
+|  | Apply resource labels when editing a pipeline version | Sub-operation on `POST /pipelines/{pipelineId}/versions/{versionId}` |
 |  | Remove labels from pipelines | `POST /pipelines/labels/remove` |
 |  | Apply label sets to pipelines | `POST /pipelines/labels/apply` |
 | **workflow:read** | View run details | `GET /workflow/{workflowId}` |
@@ -227,15 +235,18 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Stop a studio session | `PUT /studios/{sessionId}/stop` |
 | **studio:write** | Create a new studio | `POST /studios` |
 |  | Edit checkpoint name | `PUT /studios/{sessionId}/checkpoints/{checkpointId}` |
+|  | Update a studio | `PUT /studios/{sessionId}` |
 |  | Validate studio name availability | `GET /studios/validate` |
 | **studio:delete** | Delete a studio | `DELETE /studios/{sessionId}` |
 | **studio:admin** | Delete another user's private studio | Sub-operation on `DELETE /studios/{sessionId}` |
 |  | Start another user's private studio | Sub-operation on `PUT /studios/{sessionId}/start` |
+|  | Update another user's private studio | Sub-operation on `PUT /studios/{sessionId}` |
 |  | Stop another user's private studio | Sub-operation on `PUT /studios/{sessionId}/stop` |
 |  | Extend another user's private studio session lifespan (iframe) | _(Used by Platform)_ |
 |  | Extend another user's private studio session lifespan | Sub-operation on `POST /studios/{sessionId}/lifespan` |
 |  | Administer another user's private studio | _(Used by Platform)_ |
 | **studio_label:write** | Apply resource labels when starting a studio | Sub-operation on `PUT /studios/{sessionId}/start` |
+|  | Apply resource labels when updating a studio | Sub-operation on `PUT /studios/{sessionId}` |
 | **studio_session:read** | Open a studio | _(Used by Platform)_ |
 | **studio_session:execute** | Extend studio session lifespan (iframe) | _(Used by Platform)_ |
 |  | Extend studio session lifespan | `POST /studios/{sessionId}/lifespan` |

--- a/platform-enterprise_docs/orgs-and-teams/custom-roles.md
+++ b/platform-enterprise_docs/orgs-and-teams/custom-roles.md
@@ -34,8 +34,6 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 | **compute_environment:write** | Create a new compute environment | `POST /compute-envs` |
 |  | Edit an existing compute environment | `PUT /compute-envs/{computeEnvId}` |
 |  | Set a compute environment as primary | `POST /compute-envs/{computeEnvId}/primary` |
-|  | Disable compute environment | `POST /compute-envs/{computeEnvId}/disable` |
-|  | Enable compute environment | `POST /compute-envs/{computeEnvId}/enable` |
 |  | Validate compute environment name availability | `GET /compute-envs/validate` |
 | **compute_environment:delete** | Delete a compute environment | `DELETE /compute-envs/{computeEnvId}` |
 | **credentials:read** | List all credentials in workspace | `GET /credentials` |
@@ -45,7 +43,7 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Validate credentials | _(Used by Platform)_ |
 |  | Validate credential name availability | `GET /credentials/validate` |
 | **credentials:delete** | Delete credentials | `DELETE /credentials/{credentialsId}` |
-| **credentials_encrypted:read** | Get encrypted credentials | `GET /credentials/{credentialsId}/keys` |
+| **credentials_encrypted:read** | Get encrypted credentials | _(Used by Platform)_ |
 | **pipeline_secrets:read** | List all pipeline secrets | `GET /pipeline-secrets` |
 |  | View pipeline secret details | `GET /pipeline-secrets/{secretId}` |
 | **pipeline_secrets:write** | Create a new pipeline secret | `POST /pipeline-secrets` |
@@ -62,21 +60,16 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |------------|-------------|--------------|
 | **data_link:read** | List all data-links (cloud buckets) | `GET /data-links` |
 |  | Browse data-link contents | `GET /data-links/{dataLinkId}/browse` |
-|  | Browse data-link contents at the given path | `GET /data-links/{dataLinkId}/browse/{path}` |
 |  | View data-link details | `GET /data-links/{dataLinkId}` |
-|  | Resolve data-link cloud-scheme URLs | _(Used by Platform)_ |
 | **data_link:write** | Refresh data-link cache | `GET /data-links/cache/refresh` |
 |  | Browse data-link directory tree | `GET /data-links/{dataLinkId}/browse-tree` |
-|  | Download files from data-link | `GET /data-links/{dataLinkId}/download/{filePath}` |
+|  | Download files from data-link | `GET /data-links/{dataLinkId}/download` |
 |  | Generate download URL for data-link files | `GET /data-links/{dataLinkId}/generate-download-url` |
 |  | Generate download script | `GET /data-links/{dataLinkId}/script/download` |
 |  | Upload files to data-link | `POST /data-links/{dataLinkId}/upload` |
-|  | Upload files to data-link at the given path | `POST /data-links/{dataLinkId}/upload/{dirPath}` |
 |  | Complete file upload to data-link | `POST /data-links/{dataLinkId}/upload/finish` |
-|  | Complete file upload to data-link at the given path | `POST /data-links/{dataLinkId}/upload/finish/{dirPath}` |
 |  | Create a custom data-link | `POST /data-links` |
 |  | Edit data-link metadata | `PUT /data-links/{dataLinkId}` |
-|  | Sign data-link URLs for batch access | _(Used by Platform)_ |
 | **data_link:delete** | Delete files from data-link | `DELETE /data-links/{dataLinkId}/content` |
 |  | Remove a data-link from workspace | `DELETE /data-links/{dataLinkId}` |
 | **data_link:admin** | Hide data-links | _(Used by Platform)_ |
@@ -85,23 +78,19 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | List workspace dataset versions (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/versions` |
 |  | List dataset versions (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/{datasetId}/versions` |
 |  | View dataset metadata (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/{datasetId}/metadata` |
-|  | Download dataset | _(Used by Platform)_ |
+|  | Download dataset | `GET /workspaces/{workspaceId}/datasets/{datasetId}/v/{version}/n/{fileName}` |
 |  | List all datasets | `GET /datasets` |
 |  | List latest dataset versions | `GET /datasets/versions` |
 |  | List versions for a specific dataset | `GET /datasets/{datasetId}/versions` |
 |  | List datasets used in a pipeline launch | `GET /launch/{launchId}/datasets` |
 |  | View dataset metadata | `GET /datasets/{datasetId}/metadata` |
 |  | Download dataset files | `GET /datasets/{datasetId}/v/{version}/n/{fileName}` |
-|  | Fetch preview content for a URL without persisting | `POST /datasets/preview-url` |
-|  | Preview linked dataset content | `GET /datasets/{datasetId}/v/{version}/preview` |
 | **dataset:write** | Create dataset (legacy endpoint) | `POST /workspaces/{workspaceId}/datasets` |
 |  | Edit dataset (legacy endpoint) | `PUT /workspaces/{workspaceId}/datasets/{datasetId}` |
 |  | Upload dataset (legacy endpoint) | `POST /workspaces/{workspaceId}/datasets/{datasetId}/upload` |
 |  | Create a new dataset | `POST /datasets` |
 |  | Edit dataset metadata | `PUT /datasets/{datasetId}` |
 |  | Upload files to dataset | `POST /datasets/{datasetId}/upload` |
-|  | Link external URL as dataset version | `POST /datasets/{datasetId}/link` |
-|  | Validate URL for dataset linking | `POST /datasets/validate-url` |
 | **dataset:delete** | Delete dataset (legacy endpoint) | `DELETE /workspaces/{workspaceId}/datasets/{datasetId}` |
 |  | Delete a single dataset | `DELETE /datasets/{datasetId}` |
 |  | Delete multiple datasets | `DELETE /datasets` |
@@ -132,6 +121,7 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Remove labels from actions | `POST /actions/labels/remove` |
 |  | Apply label sets to actions | `POST /actions/labels/apply` |
 | **container:read** | View container details | _(Used by Platform)_ |
+|  | List containers | _(Used by Platform)_ |
 |  | List workflow containers | _(Used by Platform)_ |
 | **launch:read** | View launch details | `GET /launch/{launchId}` |
 | **pipeline:read** | View pipeline repository information | `GET /pipelines/info` |
@@ -235,19 +225,15 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Stop a studio session | `PUT /studios/{sessionId}/stop` |
 | **studio:write** | Create a new studio | `POST /studios` |
 |  | Edit checkpoint name | `PUT /studios/{sessionId}/checkpoints/{checkpointId}` |
-|  | Update a studio | `PUT /studios/{sessionId}` |
 |  | Validate studio name availability | `GET /studios/validate` |
 | **studio:delete** | Delete a studio | `DELETE /studios/{sessionId}` |
 | **studio:admin** | Delete another user's private studio | Sub-operation on `DELETE /studios/{sessionId}` |
 |  | Start another user's private studio | Sub-operation on `PUT /studios/{sessionId}/start` |
-|  | Update another user's private studio | Sub-operation on `PUT /studios/{sessionId}` |
 |  | Stop another user's private studio | Sub-operation on `PUT /studios/{sessionId}/stop` |
 |  | Extend another user's private studio session lifespan (iframe) | _(Used by Platform)_ |
 |  | Extend another user's private studio session lifespan | Sub-operation on `POST /studios/{sessionId}/lifespan` |
 |  | Administer another user's private studio | _(Used by Platform)_ |
 | **studio_label:write** | Apply resource labels when starting a studio | Sub-operation on `PUT /studios/{sessionId}/start` |
-|  | Apply resource labels when updating a studio | Sub-operation on `PUT /studios/{sessionId}` |
 | **studio_session:read** | Open a studio | _(Used by Platform)_ |
 | **studio_session:execute** | Extend studio session lifespan (iframe) | _(Used by Platform)_ |
 |  | Extend studio session lifespan | `POST /studios/{sessionId}/lifespan` |
-| | Extend studio session lifespan | `POST /studios/{sessionId}/lifespan` |

--- a/platform-enterprise_docs/orgs-and-teams/roles.md
+++ b/platform-enterprise_docs/orgs-and-teams/roles.md
@@ -86,7 +86,7 @@ The following table shows which operations are available to the default workspac
 | **pipeline_secrets:delete**    | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **platform:read**              | ✅     | ✅     | ✅        | ✅      | ✅       | ✅      |
 | **studio:read**                | ✅     | ✅     | ✅        | ✅      | ✅       | ✅      |
-| **studio:execute**             | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
+| **studio:execute**             | ✅     | ✅     | ✅        | ✅      | ❌       | ❌      |
 | **studio:write**               | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **studio:delete**              | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **studio:admin**               | ✅     | ✅     | ❌        | ❌      | ❌       | ❌      |

--- a/platform-enterprise_docs/orgs-and-teams/roles.md
+++ b/platform-enterprise_docs/orgs-and-teams/roles.md
@@ -2,7 +2,7 @@
 title: "User roles"
 description: "Understand the various roles in Seqera Platform."
 date created: "2024-06-10"
-last updated: "2025-11-18"
+last updated: "2026-04-17"
 tags: [roles, user-roles]
 ---
 
@@ -32,7 +32,7 @@ As a best practice, use teams as the primary vehicle for assigning rights within
 ## Workspace participant roles
 
 The default workspace participant roles are:
-- **Owner**: The user who created the workspace is its first owner. Owners have full administrative privileges over a workspace and its resources, including permission to delete the workspace. Regular participants can also be promoted to workspace owners. 
+- **Owner**: The user who created the workspace is its first owner. Owners have full administrative privileges over a workspace and its resources, including permission to delete the workspace. Regular participants can also be promoted to workspace owners.
 - **Admin**: Workspace admins share most of the administrative privileges of workspace owners, but admins cannot delete a workspace.
 - **Maintain**: Workspace maintainers can use and manage all workspace resources, but cannot create workspace credentials, compute environments, or Studios
 - **Launch**: Launch users can use existing workspace resources and launch pipelines, but they cannot modify workspace resources.
@@ -86,7 +86,7 @@ The following table shows which operations are available to the default workspac
 | **pipeline_secrets:delete**    | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **platform:read**              | ✅     | ✅     | ✅        | ✅      | ✅       | ✅      |
 | **studio:read**                | ✅     | ✅     | ✅        | ✅      | ✅       | ✅      |
-| **studio:execute**             | ✅     | ✅     | ✅        | ✅      | ❌       | ❌      |
+| **studio:execute**             | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **studio:write**               | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **studio:delete**              | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **studio:admin**               | ✅     | ✅     | ❌        | ❌      | ❌       | ❌      |

--- a/platform-enterprise_versioned_docs/version-25.3/orgs-and-teams/custom-roles.md
+++ b/platform-enterprise_versioned_docs/version-25.3/orgs-and-teams/custom-roles.md
@@ -2,7 +2,7 @@
 title: "Custom roles"
 description: "Introduction to custom roles in Seqera Platform."
 date created: "2025-11-17"
-last updated: "2025-11-17"
+last updated: "2026-04-17"
 tags: [roles, user-roles, custom roles, rbac, permissions]
 ---
 
@@ -45,7 +45,7 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Validate credentials | _(Used by Platform)_ |
 |  | Validate credential name availability | `GET /credentials/validate` |
 | **credentials:delete** | Delete credentials | `DELETE /credentials/{credentialsId}` |
-| **credentials_encrypted:read** | Get encrypted credentials | _(Used by Platform)_ |
+| **credentials_encrypted:read** | Get encrypted credentials | `GET /credentials/{credentialsId}/keys` |
 | **pipeline_secrets:read** | List all pipeline secrets | `GET /pipeline-secrets` |
 |  | View pipeline secret details | `GET /pipeline-secrets/{secretId}` |
 | **pipeline_secrets:write** | Create a new pipeline secret | `POST /pipeline-secrets` |
@@ -64,6 +64,7 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Browse data-link contents | `GET /data-links/{dataLinkId}/browse` |
 |  | Browse data-link contents at the given path | `GET /data-links/{dataLinkId}/browse/{path}` |
 |  | View data-link details | `GET /data-links/{dataLinkId}` |
+|  | Resolve data-link cloud-scheme URLs | _(Used by Platform)_ |
 | **data_link:write** | Refresh data-link cache | `GET /data-links/cache/refresh` |
 |  | Browse data-link directory tree | `GET /data-links/{dataLinkId}/browse-tree` |
 |  | Download files from data-link | `GET /data-links/{dataLinkId}/download/{filePath}` |
@@ -75,6 +76,7 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Complete file upload to data-link at the given path | `POST /data-links/{dataLinkId}/upload/finish/{dirPath}` |
 |  | Create a custom data-link | `POST /data-links` |
 |  | Edit data-link metadata | `PUT /data-links/{dataLinkId}` |
+|  | Sign data-link URLs for batch access | _(Used by Platform)_ |
 | **data_link:delete** | Delete files from data-link | `DELETE /data-links/{dataLinkId}/content` |
 |  | Remove a data-link from workspace | `DELETE /data-links/{dataLinkId}` |
 | **data_link:admin** | Hide data-links | _(Used by Platform)_ |
@@ -83,19 +85,23 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | List workspace dataset versions (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/versions` |
 |  | List dataset versions (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/{datasetId}/versions` |
 |  | View dataset metadata (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/{datasetId}/metadata` |
-|  | Download dataset | `GET /workspaces/{workspaceId}/datasets/{datasetId}/v/{version}/n/{fileName}` |
+|  | Download dataset | _(Used by Platform)_ |
 |  | List all datasets | `GET /datasets` |
 |  | List latest dataset versions | `GET /datasets/versions` |
 |  | List versions for a specific dataset | `GET /datasets/{datasetId}/versions` |
 |  | List datasets used in a pipeline launch | `GET /launch/{launchId}/datasets` |
 |  | View dataset metadata | `GET /datasets/{datasetId}/metadata` |
 |  | Download dataset files | `GET /datasets/{datasetId}/v/{version}/n/{fileName}` |
+|  | Fetch preview content for a URL without persisting | `POST /datasets/preview-url` |
+|  | Preview linked dataset content | `GET /datasets/{datasetId}/v/{version}/preview` |
 | **dataset:write** | Create dataset (legacy endpoint) | `POST /workspaces/{workspaceId}/datasets` |
 |  | Edit dataset (legacy endpoint) | `PUT /workspaces/{workspaceId}/datasets/{datasetId}` |
 |  | Upload dataset (legacy endpoint) | `POST /workspaces/{workspaceId}/datasets/{datasetId}/upload` |
 |  | Create a new dataset | `POST /datasets` |
 |  | Edit dataset metadata | `PUT /datasets/{datasetId}` |
 |  | Upload files to dataset | `POST /datasets/{datasetId}/upload` |
+|  | Link external URL as dataset version | `POST /datasets/{datasetId}/link` |
+|  | Validate URL for dataset linking | `POST /datasets/validate-url` |
 | **dataset:delete** | Delete dataset (legacy endpoint) | `DELETE /workspaces/{workspaceId}/datasets/{datasetId}` |
 |  | Delete a single dataset | `DELETE /datasets/{datasetId}` |
 |  | Delete multiple datasets | `DELETE /datasets` |
@@ -126,7 +132,6 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Remove labels from actions | `POST /actions/labels/remove` |
 |  | Apply label sets to actions | `POST /actions/labels/apply` |
 | **container:read** | View container details | _(Used by Platform)_ |
-|  | List containers | _(Used by Platform)_ |
 |  | List workflow containers | _(Used by Platform)_ |
 | **launch:read** | View launch details | `GET /launch/{launchId}` |
 | **pipeline:read** | View pipeline repository information | `GET /pipelines/info` |
@@ -136,20 +141,23 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | List available pipeline repositories | `GET /pipelines/repositories` |
 |  | List all pipelines in workspace | `GET /pipelines` |
 |  | View pipeline details | `GET /pipelines/{pipelineId}` |
+|  | List pipeline versions | `GET /pipelines/{pipelineId}/versions` |
 |  | Fetch pipeline optimization | _(Used by Platform)_ |
-|  | List pipeline versions | _(Used by Platform)_ |
 | **pipeline:write** | Modify pipeline details when launching a pipeline run | Sub-operation on `POST /workflow/launch` |
 |  | Add a new pipeline to workspace | `POST /pipelines` |
-|  | Edit pipeline configuration | `PUT /pipelines/{pipelineId}` |
+|  | Edit pipeline (default version) configuration | `PUT /pipelines/{pipelineId}` |
 |  | Configure pipeline | _(Used by Platform)_ |
 |  | Validate pipeline name availability | `GET /pipelines/validate` |
-|  | Validate pipeline version name availability | _(Used by Platform)_ |
-|  | Manage pipeline version | _(Used by Platform)_ |
+|  | Create a pipeline schema | `POST /pipeline-schemas` |
+|  | Validate pipeline version name availability | `GET /pipelines/{pipelineId}/versions/validate` |
+|  | Manage pipeline version | `PUT /pipelines/{pipelineId}/versions/{versionId}/manage` |
+|  | Edit pipeline version configuration | `POST /pipelines/{pipelineId}/versions/{versionId}` |
 | **pipeline:delete** | Delete a pipeline | `DELETE /pipelines/{pipelineId}` |
 | **pipeline_label:write** | Apply resource labels when launching a pipeline run | Sub-operation on `POST /workflow/launch` |
 |  | Add labels to pipelines | `POST /pipelines/labels/add` |
 |  | Apply resource labels when adding a pipeline | Sub-operation on `POST /pipelines` |
-|  | Apply resource labels when editing a pipeline | Sub-operation on `PUT /pipelines/{pipelineId}` |
+|  | Apply resource labels when editing a pipeline (default version) | Sub-operation on `PUT /pipelines/{pipelineId}` |
+|  | Apply resource labels when editing a pipeline version | Sub-operation on `POST /pipelines/{pipelineId}/versions/{versionId}` |
 |  | Remove labels from pipelines | `POST /pipelines/labels/remove` |
 |  | Apply label sets to pipelines | `POST /pipelines/labels/apply` |
 | **workflow:read** | View run details | `GET /workflow/{workflowId}` |
@@ -227,15 +235,18 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Stop a studio session | `PUT /studios/{sessionId}/stop` |
 | **studio:write** | Create a new studio | `POST /studios` |
 |  | Edit checkpoint name | `PUT /studios/{sessionId}/checkpoints/{checkpointId}` |
+|  | Update a studio | `PUT /studios/{sessionId}` |
 |  | Validate studio name availability | `GET /studios/validate` |
 | **studio:delete** | Delete a studio | `DELETE /studios/{sessionId}` |
 | **studio:admin** | Delete another user's private studio | Sub-operation on `DELETE /studios/{sessionId}` |
 |  | Start another user's private studio | Sub-operation on `PUT /studios/{sessionId}/start` |
+|  | Update another user's private studio | Sub-operation on `PUT /studios/{sessionId}` |
 |  | Stop another user's private studio | Sub-operation on `PUT /studios/{sessionId}/stop` |
 |  | Extend another user's private studio session lifespan (iframe) | _(Used by Platform)_ |
 |  | Extend another user's private studio session lifespan | Sub-operation on `POST /studios/{sessionId}/lifespan` |
 |  | Administer another user's private studio | _(Used by Platform)_ |
 | **studio_label:write** | Apply resource labels when starting a studio | Sub-operation on `PUT /studios/{sessionId}/start` |
+|  | Apply resource labels when updating a studio | Sub-operation on `PUT /studios/{sessionId}` |
 | **studio_session:read** | Open a studio | _(Used by Platform)_ |
 | **studio_session:execute** | Extend studio session lifespan (iframe) | _(Used by Platform)_ |
 |  | Extend studio session lifespan | `POST /studios/{sessionId}/lifespan` |

--- a/platform-enterprise_versioned_docs/version-25.3/orgs-and-teams/custom-roles.md
+++ b/platform-enterprise_versioned_docs/version-25.3/orgs-and-teams/custom-roles.md
@@ -34,8 +34,6 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 | **compute_environment:write** | Create a new compute environment | `POST /compute-envs` |
 |  | Edit an existing compute environment | `PUT /compute-envs/{computeEnvId}` |
 |  | Set a compute environment as primary | `POST /compute-envs/{computeEnvId}/primary` |
-|  | Disable compute environment | `POST /compute-envs/{computeEnvId}/disable` |
-|  | Enable compute environment | `POST /compute-envs/{computeEnvId}/enable` |
 |  | Validate compute environment name availability | `GET /compute-envs/validate` |
 | **compute_environment:delete** | Delete a compute environment | `DELETE /compute-envs/{computeEnvId}` |
 | **credentials:read** | List all credentials in workspace | `GET /credentials` |
@@ -45,7 +43,7 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Validate credentials | _(Used by Platform)_ |
 |  | Validate credential name availability | `GET /credentials/validate` |
 | **credentials:delete** | Delete credentials | `DELETE /credentials/{credentialsId}` |
-| **credentials_encrypted:read** | Get encrypted credentials | `GET /credentials/{credentialsId}/keys` |
+| **credentials_encrypted:read** | Get encrypted credentials | _(Used by Platform)_ |
 | **pipeline_secrets:read** | List all pipeline secrets | `GET /pipeline-secrets` |
 |  | View pipeline secret details | `GET /pipeline-secrets/{secretId}` |
 | **pipeline_secrets:write** | Create a new pipeline secret | `POST /pipeline-secrets` |
@@ -62,21 +60,16 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |------------|-------------|--------------|
 | **data_link:read** | List all data-links (cloud buckets) | `GET /data-links` |
 |  | Browse data-link contents | `GET /data-links/{dataLinkId}/browse` |
-|  | Browse data-link contents at the given path | `GET /data-links/{dataLinkId}/browse/{path}` |
 |  | View data-link details | `GET /data-links/{dataLinkId}` |
-|  | Resolve data-link cloud-scheme URLs | _(Used by Platform)_ |
 | **data_link:write** | Refresh data-link cache | `GET /data-links/cache/refresh` |
 |  | Browse data-link directory tree | `GET /data-links/{dataLinkId}/browse-tree` |
-|  | Download files from data-link | `GET /data-links/{dataLinkId}/download/{filePath}` |
+|  | Download files from data-link | `GET /data-links/{dataLinkId}/download` |
 |  | Generate download URL for data-link files | `GET /data-links/{dataLinkId}/generate-download-url` |
 |  | Generate download script | `GET /data-links/{dataLinkId}/script/download` |
 |  | Upload files to data-link | `POST /data-links/{dataLinkId}/upload` |
-|  | Upload files to data-link at the given path | `POST /data-links/{dataLinkId}/upload/{dirPath}` |
 |  | Complete file upload to data-link | `POST /data-links/{dataLinkId}/upload/finish` |
-|  | Complete file upload to data-link at the given path | `POST /data-links/{dataLinkId}/upload/finish/{dirPath}` |
 |  | Create a custom data-link | `POST /data-links` |
 |  | Edit data-link metadata | `PUT /data-links/{dataLinkId}` |
-|  | Sign data-link URLs for batch access | _(Used by Platform)_ |
 | **data_link:delete** | Delete files from data-link | `DELETE /data-links/{dataLinkId}/content` |
 |  | Remove a data-link from workspace | `DELETE /data-links/{dataLinkId}` |
 | **data_link:admin** | Hide data-links | _(Used by Platform)_ |
@@ -85,23 +78,19 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | List workspace dataset versions (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/versions` |
 |  | List dataset versions (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/{datasetId}/versions` |
 |  | View dataset metadata (legacy endpoint) | `GET /workspaces/{workspaceId}/datasets/{datasetId}/metadata` |
-|  | Download dataset | _(Used by Platform)_ |
+|  | Download dataset | `GET /workspaces/{workspaceId}/datasets/{datasetId}/v/{version}/n/{fileName}` |
 |  | List all datasets | `GET /datasets` |
 |  | List latest dataset versions | `GET /datasets/versions` |
 |  | List versions for a specific dataset | `GET /datasets/{datasetId}/versions` |
 |  | List datasets used in a pipeline launch | `GET /launch/{launchId}/datasets` |
 |  | View dataset metadata | `GET /datasets/{datasetId}/metadata` |
 |  | Download dataset files | `GET /datasets/{datasetId}/v/{version}/n/{fileName}` |
-|  | Fetch preview content for a URL without persisting | `POST /datasets/preview-url` |
-|  | Preview linked dataset content | `GET /datasets/{datasetId}/v/{version}/preview` |
 | **dataset:write** | Create dataset (legacy endpoint) | `POST /workspaces/{workspaceId}/datasets` |
 |  | Edit dataset (legacy endpoint) | `PUT /workspaces/{workspaceId}/datasets/{datasetId}` |
 |  | Upload dataset (legacy endpoint) | `POST /workspaces/{workspaceId}/datasets/{datasetId}/upload` |
 |  | Create a new dataset | `POST /datasets` |
 |  | Edit dataset metadata | `PUT /datasets/{datasetId}` |
 |  | Upload files to dataset | `POST /datasets/{datasetId}/upload` |
-|  | Link external URL as dataset version | `POST /datasets/{datasetId}/link` |
-|  | Validate URL for dataset linking | `POST /datasets/validate-url` |
 | **dataset:delete** | Delete dataset (legacy endpoint) | `DELETE /workspaces/{workspaceId}/datasets/{datasetId}` |
 |  | Delete a single dataset | `DELETE /datasets/{datasetId}` |
 |  | Delete multiple datasets | `DELETE /datasets` |
@@ -132,6 +121,7 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Remove labels from actions | `POST /actions/labels/remove` |
 |  | Apply label sets to actions | `POST /actions/labels/apply` |
 | **container:read** | View container details | _(Used by Platform)_ |
+|  | List containers | _(Used by Platform)_ |
 |  | List workflow containers | _(Used by Platform)_ |
 | **launch:read** | View launch details | `GET /launch/{launchId}` |
 | **pipeline:read** | View pipeline repository information | `GET /pipelines/info` |
@@ -235,19 +225,15 @@ Individual permissions grant read, write, execute, admin, or delete access for e
 |  | Stop a studio session | `PUT /studios/{sessionId}/stop` |
 | **studio:write** | Create a new studio | `POST /studios` |
 |  | Edit checkpoint name | `PUT /studios/{sessionId}/checkpoints/{checkpointId}` |
-|  | Update a studio | `PUT /studios/{sessionId}` |
 |  | Validate studio name availability | `GET /studios/validate` |
 | **studio:delete** | Delete a studio | `DELETE /studios/{sessionId}` |
 | **studio:admin** | Delete another user's private studio | Sub-operation on `DELETE /studios/{sessionId}` |
 |  | Start another user's private studio | Sub-operation on `PUT /studios/{sessionId}/start` |
-|  | Update another user's private studio | Sub-operation on `PUT /studios/{sessionId}` |
 |  | Stop another user's private studio | Sub-operation on `PUT /studios/{sessionId}/stop` |
 |  | Extend another user's private studio session lifespan (iframe) | _(Used by Platform)_ |
 |  | Extend another user's private studio session lifespan | Sub-operation on `POST /studios/{sessionId}/lifespan` |
 |  | Administer another user's private studio | _(Used by Platform)_ |
 | **studio_label:write** | Apply resource labels when starting a studio | Sub-operation on `PUT /studios/{sessionId}/start` |
-|  | Apply resource labels when updating a studio | Sub-operation on `PUT /studios/{sessionId}` |
 | **studio_session:read** | Open a studio | _(Used by Platform)_ |
 | **studio_session:execute** | Extend studio session lifespan (iframe) | _(Used by Platform)_ |
 |  | Extend studio session lifespan | `POST /studios/{sessionId}/lifespan` |
-| | Extend studio session lifespan | `POST /studios/{sessionId}/lifespan` |

--- a/platform-enterprise_versioned_docs/version-25.3/orgs-and-teams/roles.md
+++ b/platform-enterprise_versioned_docs/version-25.3/orgs-and-teams/roles.md
@@ -86,7 +86,7 @@ The following table shows which operations are available to the default workspac
 | **pipeline_secrets:delete**    | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **platform:read**              | ✅     | ✅     | ✅        | ✅      | ✅       | ✅      |
 | **studio:read**                | ✅     | ✅     | ✅        | ✅      | ✅       | ✅      |
-| **studio:execute**             | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
+| **studio:execute**             | ✅     | ✅     | ✅        | ✅      | ❌       | ❌      |
 | **studio:write**               | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **studio:delete**              | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **studio:admin**               | ✅     | ✅     | ❌        | ❌      | ❌       | ❌      |

--- a/platform-enterprise_versioned_docs/version-25.3/orgs-and-teams/roles.md
+++ b/platform-enterprise_versioned_docs/version-25.3/orgs-and-teams/roles.md
@@ -2,7 +2,7 @@
 title: "User roles"
 description: "Understand the various roles in Seqera Platform."
 date created: "2024-06-10"
-last updated: "2025-11-18"
+last updated: "2026-04-17"
 tags: [roles, user-roles]
 ---
 
@@ -32,7 +32,7 @@ As a best practice, use teams as the primary vehicle for assigning rights within
 ## Workspace participant roles
 
 The default workspace participant roles are:
-- **Owner**: The user who created the workspace is its first owner. Owners have full administrative privileges over a workspace and its resources, including permission to delete the workspace. Regular participants can also be promoted to workspace owners. 
+- **Owner**: The user who created the workspace is its first owner. Owners have full administrative privileges over a workspace and its resources, including permission to delete the workspace. Regular participants can also be promoted to workspace owners.
 - **Admin**: Workspace admins share most of the administrative privileges of workspace owners, but admins cannot delete a workspace.
 - **Maintain**: Workspace maintainers can use and manage all workspace resources, but cannot create workspace credentials, compute environments, or Studios
 - **Launch**: Launch users can use existing workspace resources and launch pipelines, but they cannot modify workspace resources.
@@ -86,7 +86,7 @@ The following table shows which operations are available to the default workspac
 | **pipeline_secrets:delete**    | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **platform:read**              | ✅     | ✅     | ✅        | ✅      | ✅       | ✅      |
 | **studio:read**                | ✅     | ✅     | ✅        | ✅      | ✅       | ✅      |
-| **studio:execute**             | ✅     | ✅     | ✅        | ✅      | ❌       | ❌      |
+| **studio:execute**             | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **studio:write**               | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **studio:delete**              | ✅     | ✅     | ✅        | ❌      | ❌       | ❌      |
 | **studio:admin**               | ✅     | ✅     | ❌        | ❌      | ❌       | ❌      |


### PR DESCRIPTION
## Summary
This updates the Platform Cloud permissions docs to match the source permissions data in `seqeralabs/platform` tag `v26.1.0-cycle50_8fce0da`.

## What changed
- corrected the default role matrix in `roles.md` so `Launch` no longer has `studio:execute`
- added the missing custom-role operations and endpoint updates in `custom-roles.md`
- refreshed the page `last updated` metadata on both docs pages

## Why
The automated permissions docs workflow is being handled separately, and this manual update gets the public Cloud docs back to parity with what is in production now.

## Validation
- diffed both docs pages against `docs/grants_roles.md` and `docs/grants_operations.md` from `seqeralabs/platform` tag `v26.1.0-cycle50_8fce0da`
- diffed the Enterprise unversioned and `version-25.3` docs pages against `docs/grants_roles.md` and `docs/grants_operations.md` from `seqeralabs/platform` tag `v25.3.5-enterprise`
- passed local pre-commit hooks during commit