### PR TITLE
docs(seqera-ai): add Projects page for Enterprise

### DIFF
--- a/platform-enterprise_docs/enterprise-sidebar.json
+++ b/platform-enterprise_docs/enterprise-sidebar.json
@@ -230,7 +230,8 @@
         "seqera-ai/installation",
         "seqera-ai/authentication",
         "seqera-ai/command-approval",
-        "seqera-ai/use-cases"
+        "seqera-ai/use-cases",
+        "seqera-ai/projects"
       ]
     },
        {

--- a/platform-enterprise_docs/seqera-ai/index.md
+++ b/platform-enterprise_docs/seqera-ai/index.md
@@ -65,7 +65,7 @@ Full access to Platform capabilities including compute environments, datasets, d
 
 ### Projects
 
-Organize a workspace into projects by applying Seqera Platform labels prefixed with `project_`. Each project scopes the pipelines, datasets, workflow runs, and chat context the AI sees — without needing a separate CRUD surface in Seqera AI.
+Organize a workspace into projects by applying Seqera Platform labels prefixed with `project_`. Each project scopes the pipelines, datasets, workflow runs, and chat context the AI sees, without needing a separate CRUD surface in Seqera AI.
 
 ## Learn more
 

--- a/platform-enterprise_docs/seqera-ai/index.md
+++ b/platform-enterprise_docs/seqera-ai/index.md
@@ -63,10 +63,15 @@ Resume previous sessions to continue your work. Use `seqera ai -c` to continue y
 
 Full access to Platform capabilities including compute environments, datasets, data links, and workspace management.
 
+### Projects
+
+Organize a workspace into projects by applying Seqera Platform labels prefixed with `project_`. Each project scopes the pipelines, datasets, workflow runs, and chat context the AI sees — without needing a separate CRUD surface in Seqera AI.
+
 ## Learn more
 
 - [Installation](./installation.mdx): Detailed installation instructions
 - [Authentication](./authentication.md): Log in, log out, and session management
 - [Command approval](./command-approval.md): Control which commands run automatically
 - [Use cases](./use-cases.md): Seqera AI CLI use cases
+- [Projects](./projects.md): Organize workspace resources into projects using Platform labels
 - [Troubleshooting](../troubleshooting_and_faqs/seqera-ai.md): Troubleshoot common errors

--- a/platform-enterprise_docs/seqera-ai/projects.md
+++ b/platform-enterprise_docs/seqera-ai/projects.md
@@ -23,7 +23,7 @@ When you open a workspace in the Seqera AI portal web interface:
 
 1. Seqera AI reads the list of workspace labels from the Seqera Platform API.
 2. Any label whose name starts with `project_` becomes a project.
-3. An **Entire workspace** view is always included alongside your projects so you can see every resource in the workspace.
+3. An **Entire workspace** view is included alongside your projects. You can see every resource in the workspace.
 4. Pipelines, datasets, and workflow runs are scoped to a project by matching on its `project_*` label.
 
 Because membership lives on the Platform label, adding or removing a resource from a project is the same action as applying or removing the label in Platform.

--- a/platform-enterprise_docs/seqera-ai/projects.md
+++ b/platform-enterprise_docs/seqera-ai/projects.md
@@ -14,7 +14,7 @@ Projects in Seqera AI group the pipelines, datasets, and workflow runs that belo
 Projects are not created inside Seqera AI. They are derived from **workspace labels in Seqera Platform** whose names start with `project_`. Each matching label surfaces in Seqera AI as a separate project scope, with the Platform label acting as the source of truth for membership.
 
 :::note
-Projects are part of the Seqera AI **portal web interface**. The portal must be deployed alongside Seqera AI in your Enterprise installation — see [Install Seqera AI](../enterprise/install-seqera-ai.md).
+Projects are part of the Seqera AI **portal web interface**. The portal must be deployed alongside Seqera AI in your Enterprise installation. See [Install Seqera AI](../enterprise/install-seqera-ai.md) for more information.
 :::
 
 ## How projects are derived

--- a/platform-enterprise_docs/seqera-ai/projects.md
+++ b/platform-enterprise_docs/seqera-ai/projects.md
@@ -1,0 +1,90 @@
+---
+title: "Projects"
+description: "Organize workspace resources into projects using Seqera Platform labels"
+date: "2026-04-22"
+tags: [seqera-ai, projects, labels]
+---
+
+:::caution Seqera AI is in beta
+Seqera AI is currently in beta. Features and behavior may change as we continue to improve the product.
+:::
+
+Projects in Seqera AI group the pipelines, datasets, and workflow runs that belong to a single piece of work, so you can view and chat about them without the noise of the rest of the workspace.
+
+Projects are not created inside Seqera AI. They are derived from **workspace labels in Seqera Platform** whose names start with `project_`. Each matching label surfaces in Seqera AI as a separate project scope, with the Platform label acting as the source of truth for membership.
+
+:::note
+Projects are part of the Seqera AI **portal web interface**. The portal must be deployed alongside Seqera AI in your Enterprise installation — see [Install Seqera AI](../enterprise/install-seqera-ai.md).
+:::
+
+## How projects are derived
+
+When you open a workspace in the Seqera AI portal web interface:
+
+1. Seqera AI reads the list of workspace labels from the Seqera Platform API.
+2. Any label whose name starts with `project_` becomes a project.
+3. An **Entire workspace** view is always included alongside your projects so you can see every resource in the workspace.
+4. Pipelines, datasets, and workflow runs are scoped to a project by matching on its `project_*` label.
+
+Because membership lives on the Platform label, adding or removing a resource from a project is the same action as applying or removing the label in Platform.
+
+## Create a project
+
+1. In **Seqera Platform**, open the workspace where the project should live.
+2. Go to **Labels** in workspace settings and create a new label with the `project_` prefix. For example:
+    - `project_rnaseq`
+    - `project_variant_calling`
+    - `project_chip_seq`
+3. Apply the label to the pipelines and datasets that belong to the project.
+4. Open Seqera AI. The new project appears on the **Projects** page and in the chat project selector on the next page load.
+
+:::tip
+Create the label in workspace settings **before** applying it to resources. This ensures the label has a Platform-assigned ID, which Seqera AI needs to auto-attach the label when you upload new datasets into the project.
+:::
+
+## Display names
+
+Seqera AI strips the `project_` prefix to produce the display name shown in the portal:
+
+| Platform label        | Seqera AI display name  |
+|-----------------------|-------------------------|
+| `project_rnaseq`      | Project rnaseq          |
+| `project_wgs`         | Project wgs             |
+| `project_single_cell` | Project single_cell     |
+
+Choose descriptive names after the prefix so projects are easy to identify.
+
+## Where projects appear
+
+Once a `project_*` label exists in the workspace and is applied to at least one resource, the project is used in the following places:
+
+- **Projects page**: one row per project, plus the **Entire workspace** row.
+- **Project details page**: the pipelines, datasets, and workflow runs filtered to that project's label.
+- **Chat project selector**: scopes the resources the AI can see and act on during a chat session.
+- **Dataset upload**: when you upload a dataset from inside a project, the project's label is auto-attached.
+
+## Edge cases
+
+### A resource carries a `project_*` label that isn't in the workspace label list
+
+If a pipeline has a `project_*` label but the label has not been created in workspace settings, Seqera AI still surfaces the project, inferred from the pipeline. In this case:
+
+- The project has no Platform-assigned label ID.
+- Dataset uploads into the project cannot auto-attach the label.
+
+To avoid this, always create `project_*` labels in workspace settings first, then apply them.
+
+### No `project_*` labels in the workspace
+
+When a workspace has no `project_*` labels:
+
+- The **Projects** page shows a **No projects configured yet** empty state.
+- The project selector is hidden in the chat header.
+- The workspace view shows a header-only empty state.
+
+Ask a workspace admin to create the first `project_*` label to enable projects for the workspace.
+
+## Learn more
+
+- [Install Seqera AI](../enterprise/install-seqera-ai.md): Deploy Seqera AI and the portal web interface in Enterprise
+- [Get started with Seqera AI](./get-started.md): Install and authenticate the Seqera AI CLI

--- a/platform-enterprise_docs/seqera-ai/projects.md
+++ b/platform-enterprise_docs/seqera-ai/projects.md
@@ -9,7 +9,7 @@ tags: [seqera-ai, projects, labels]
 Seqera AI is currently in beta. Features and behavior may change as we continue to improve the product.
 :::
 
-Projects in Seqera AI group the pipelines, datasets, and workflow runs that belong to a single piece of work, so you can view and chat about them without the noise of the rest of the workspace.
+Projects in Seqera AI group the pipelines, datasets, and workflow runs that belong to a single piece of work. You can view and chat about them without the noise of the rest of the workspace.
 
 Projects are not created inside Seqera AI. They are derived from **workspace labels in Seqera Platform** whose names start with `project_`. Each matching label surfaces in Seqera AI as a separate project scope, with the Platform label acting as the source of truth for membership.
 

--- a/platform-enterprise_docs/seqera-ai/projects.md
+++ b/platform-enterprise_docs/seqera-ai/projects.md
@@ -30,6 +30,8 @@ Because membership lives on the Platform label, adding or removing a resource fr
 
 ## Create a project
 
+To create a project:
+
 1. In **Seqera Platform**, open the workspace where the project should live.
 2. Go to **Labels** in workspace settings and create a new label with the `project_` prefix. For example:
     - `project_rnaseq`


### PR DESCRIPTION
## Summary

- Add new `platform-enterprise_docs/seqera-ai/projects.md` page documenting how Seqera AI derives projects from Seqera Platform workspace labels prefixed with `project_`
- Surface the page in the Enterprise Seqera AI CLI landing page (index.md) with a feature card and Learn more link
- Register the page in the Enterprise sidebar under the Seqera AI CLI category

## Source

Content adapted from internal engineering docs in https://github.com/seqeralabs/portal/pull/865 for public-docs audience.

## Cloud counterpart

Cloud PR: https://github.com/seqeralabs/docs/pull/1345 (`docs(seqera-ai): add Projects page for Cloud`). No overlapping files between the two PRs.

## Enterprise-specific differences

The Enterprise page differs from the Cloud page in three ways:

1. A `:::caution Seqera AI is in beta` admonition at the top, matching the Enterprise `index.md` beta banner convention.
2. A `:::note` block below the intro linking to the Install Seqera AI guide (`../enterprise/install-seqera-ai.md`), since Enterprise admins need to deploy the portal web interface explicitly.
3. The Learn more section points to `../enterprise/install-seqera-ai.md` and `./get-started.md` rather than the Cloud Platform labels page.

## Base branch

This PR targets **`enterprise-26.1-documentation`** because this content ships with the 26.1 release cycle.

## Test plan

- [x] `npm run build` passes (pre-existing broken-link warnings in enterprise docs are unrelated)
- [ ] Verify the new page renders correctly on the Netlify deploy preview
- [ ] Verify the sidebar entry appears under Seqera AI CLI
- [ ] Verify the feature card and Learn more link on the index page
- [ ] Cross-check parity with the Cloud PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)