### PR TITLE
fix: Add custom css for markdown tables

### DIFF
--- a/src/custom.css
+++ b/src/custom.css
@@ -98,3 +98,10 @@ table th {
 :target {
   scroll-margin-top: 120px;
 }
+
+.markdown table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+}


### PR DESCRIPTION
- Add custom CSS to fix the table overflow while the architecture is updated.