### PR TITLE
docs(release-notes): add Enterprise release notes for v25.3.6 [NOTASK]

### DIFF
--- a/changelog/seqera-enterprise/v25.3.6.md
+++ b/changelog/seqera-enterprise/v25.3.6.md
@@ -1,0 +1,28 @@
+---
+title: Seqera Enterprise v25.3.6
+date: 2026-04-24
+tags: [seqera enterprise]
+---
+
+## Feature updates and improvements
+
+### Access control
+
+- Added PKCE and consent flow support to OIDC, enabling Seqera Platform to act as an identity provider for OIDC/OAuth2 clients such as the Seqera AI CLI.
+- Added the `oauth-client.seqera-ai-portal-url` config property (exposed via the `TOWER_ENTERPRISE_AI_PORTAL_URL` environment variable) for enterprise-specific Seqera AI OAuth redirect registration, removing the need for manual `tower.yml` patches or `oauth-development` redirect-validation bypasses.
+
+## Bug fixes
+
+### Pipelines
+
+- Fixed Nextflow timeline config generation to resolve `NXF_TML_FILE` via `System.getenv` instead of relying on shell variable expansion.
+- Fixed the **Browse** button in the pipeline launch form being hidden for users with **Launch**, **Connect**, or **View** workspace roles by gating it on the correct permission instead of the Data Studios `studio:execute` grant.
+
+### Security
+
+- Addressed CVE-2025-67735 (CRLF injection in `HttpRequestEncoder`) by upgrading Netty from v4.1.127.Final to v4.1.129.Final.
+- Prevented denial-of-service via form-url-encoded payloads by backporting the Micronaut `JsonBeanPropertyBinder` fix that corrects an infinite loop in `expandArrayToThreshold`.
+
+## Upgrade notes
+
+No breaking changes. Standard upgrade procedure applies.


### PR DESCRIPTION
## Enterprise Release Notes

Adds release notes for **Seqera Enterprise v25.3.6**, covering all changes in the v25.3.4 → v25.3.6 range. v25.3.5 was skipped as a public release, so its commits are included here as well.

**Mode**: version_to_version (`v25.3.4-enterprise` → `v25.3.6-enterprise`)

### Coverage

12 PRs in range, condensed to 6 user-facing entries:

- **Access control** (2 features): OIDC PKCE/consent, Seqera AI OAuth client config
- **Pipelines** (2 bug fixes): `NXF_TML_FILE` resolution, Browse button permission
- **Security** (2 fixes): CVE-2025-67735 (Netty), Micronaut `JsonBeanPropertyBinder` DoS

Excluded as internal-only: test pin (#10598), Renovate Docker digest (#10698), CI action update (#10811), Storybook build fix (#10913). Two cherry-pick pairs deduplicated: #10336↔#10677, #10837↔#10956.

### Review Checklist
- [x] Files generated and validated locally (`quick-validation.sh`: 0 errors, 0 warnings)
- [x] Upgrade notes reviewed (no breaking changes)
- [ ] Final review of release notes
- [ ] Confirm v25.3.5 commits should be folded into v25.3.6 (vs. separate file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)