### PR TITLE
Remove Pipeline outputs bullet from Outputs tab

### DIFF
--- a/platform-cloud/docs/monitoring/run-details.mdx
+++ b/platform-cloud/docs/monitoring/run-details.mdx
@@ -340,10 +340,9 @@ If the run was not launched with any input files or datasets, the table is empty
 </TabItem>
 <TabItem value="Outputs" label="Outputs" default>
 
-The **Outputs** tab links to every file the run published to its output directory. The tab has two sub-views:
+The **Outputs** tab links to every file the run published to its output directory:
 
 - **Reports** — The named report files configured for the run, such as the MultiQC report or any reports declared in `tower.yml`.
-- **Pipeline outputs** — If the `outDir` parameter is used, or the run executed with the `-output-dir` option, all outputs can be viewed in Data Explorer.
 
 #### Reports
 


### PR DESCRIPTION
Per robnewman's review feedback, the **Pipeline outputs** sub-view is not in this milestone, so this removes the bullet from the Outputs tab section in `platform-cloud/docs/monitoring/run-details.mdx`.

Also updates the intro sentence — since only the **Reports** sub-view remains, the "two sub-views" phrasing has been dropped.

## Test plan

- [ ] Confirm the Outputs tab section reads correctly with only the Reports bullet
- [ ] Verify no other references to "Pipeline outputs" need updating in this PR's scope


---
_Generated by [Claude Code](https://claude.ai/code/session_018hmHhZQvPrD4ktKUrx7tBu)_