### PR TITLE
chore: Deprecate legacy distribution endpoint cr.seqera.io/private

### DIFF
--- a/changelog/seqera-enterprise/v24.1.md
+++ b/changelog/seqera-enterprise/v24.1.md
@@ -6,6 +6,10 @@ tags: [seqera enterprise]
 
 Seqera Platform Enterprise version 24.1 introduces three new features: Data Studios (in public preview), Data Explorer, and managed identities. A number of bug fixes and performance enhancements are included in this major release.
 
+:::info
+The legacy distribution endpoint at `cr.seqera.io/private` is deprecated. Only bug fixes for existing major releases will continue to be published there. New major releases of Seqera Platform are available from `cr.seqera.io/enterprise`. Seqera will provide updated credentials for the new endpoint — [contact your Seqera representative](https://support.seqera.io) if you need access.
+:::
+
 ## Feature updates and improvements
 
 ### Data Studios

--- a/changelog/seqera-enterprise/v24.2.md
+++ b/changelog/seqera-enterprise/v24.2.md
@@ -6,6 +6,10 @@ tags: [seqera enterprise]
 
 Seqera Enterprise version 24.2 introduces new Data Studios features, global Nextflow configuration at the compute environment level, Azure service principal and managed identity authentication support, and a number of bug fixes and performance enhancements.
 
+:::info
+The legacy distribution endpoint at `cr.seqera.io/private` is deprecated. Only bug fixes for existing major releases will continue to be published there. New major releases of Seqera Platform are available from `cr.seqera.io/enterprise`. Seqera will provide updated credentials for the new endpoint — [contact your Seqera representative](https://support.seqera.io) if you need access.
+:::
+
 ## Feature updates and improvements
 
 ### Data Studios

--- a/changelog/seqera-enterprise/v25.1.md
+++ b/changelog/seqera-enterprise/v25.1.md
@@ -8,6 +8,10 @@ Seqera Platform Enterprise version 25.1 introduces Studios GA and a number of bu
 
 Studios is Seqera's in-platform tool for secure, on-demand, interactive data analysis using containers created from Seqera-managed container template images or your own organization-managed custom environments. You only pay for the compute your Studio sessions consume, and the compute is adjacent to your data, significantly reducing data transfer costs and wasted time copying data from storage to analysis. This significantly reduces infrastructure management requirements, removes data silos, adheres to strict in-platform role-based access control, and lowers your operational costs. [Learn more about Studios](https://docs.seqera.io/platform-enterprise/25.1/studios/overview).
 
+:::info
+The legacy distribution endpoint at `cr.seqera.io/private` is deprecated. Only bug fixes for existing major releases will continue to be published there. New major releases of Seqera Platform are available from `cr.seqera.io/enterprise`. Seqera will provide updated credentials for the new endpoint — [contact your Seqera representative](https://support.seqera.io) if you need access.
+:::
+
 ## Feature updates and improvements
 
 ### Studios

--- a/changelog/seqera-enterprise/v25.2.md
+++ b/changelog/seqera-enterprise/v25.2.md
@@ -6,6 +6,10 @@ tags: [seqera enterprise]
 
 Seqera Platform Enterprise version 25.2 introduces a series of enhancements to improve security, observability, and flexibility.
 
+:::info
+The legacy distribution endpoint at `cr.seqera.io/private` is deprecated. Only bug fixes for existing major releases will continue to be published there. New major releases of Seqera Platform are available from `cr.seqera.io/enterprise`. Seqera will provide updated credentials for the new endpoint — [contact your Seqera representative](https://support.seqera.io) if you need access.
+:::
+
 ## Feature updates and improvements
 
 ### Single instance cloud compute environments

--- a/changelog/seqera-enterprise/v25.3.md
+++ b/changelog/seqera-enterprise/v25.3.md
@@ -6,6 +6,10 @@ tags: [seqera enterprise]
 
 Seqera Platform Enterprise version 25.3 introduces a series of new features and enhancements, including custom user roles, Studios integration with Git providers, and pipeline versioning.
 
+:::info
+The legacy distribution endpoint at `cr.seqera.io/private` is deprecated. Only bug fixes for existing major releases will continue to be published there. New major releases of Seqera Platform are available from `cr.seqera.io/enterprise`. Seqera will provide updated credentials for the new endpoint — [contact your Seqera representative](https://support.seqera.io) if you need access.
+:::
+
 ## Feature updates and improvements
 
 ### Custom roles and fine-grained authorization (RBAC)

--- a/changelog/seqera-enterprise/v26.1.md
+++ b/changelog/seqera-enterprise/v26.1.md
@@ -4,6 +4,10 @@ date: 2026-04-07
 tags: [enterprise]
 ---
 
+:::info
+The legacy distribution endpoint at `cr.seqera.io/private` is deprecated. Only bug fixes for existing major releases will continue to be published there. New major releases of Seqera Platform are available from `cr.seqera.io/enterprise`. Seqera will provide updated credentials for the new endpoint — [contact your Seqera representative](https://support.seqera.io) if you need access.
+:::
+
 ## Feature updates and improvements
 
 ### Studios

--- a/platform-enterprise_docs/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_docs/enterprise/_templates/docker/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v26.1
+    image: cr.seqera.io/enterprise/platform/migrate-db:v26.1
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -64,7 +64,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v26.1
+    image: cr.seqera.io/enterprise/platform/backend:v26.1
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -85,7 +85,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v26.1
+    image: cr.seqera.io/enterprise/platform/backend:v26.1
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -110,7 +110,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v26.1
+    image: cr.seqera.io/enterprise/platform/frontend:v26.1
     platform: linux/amd64
     networks:
       - frontend
@@ -122,7 +122,7 @@ services:
 
 # Uncomment the following section to enable Studios functionality. See [Studios configuration](../../../studios/overview) for more information.
 #  connect-proxy:
-#    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-proxy:0.11.0
+#    image: cr.seqera.io/enterprise/studios/proxy:0.11.0
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env
@@ -138,7 +138,7 @@ services:
 #     - $HOME/.tower/connect:/data
 #
 #  connect-server:
-#    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.11.0
+#    image: cr.seqera.io/enterprise/studios/server:0.11.0
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env
@@ -151,7 +151,7 @@ services:
   # Uncomment the following section to enable the pipeline optimization service. Add TOWER_ENABLE_GROUNDSWELL
   # or GROUNDSWELL_SERVER_URL to tower.env environment variables
   # groundswell:
-  #   image: cr.seqera.io/private/nf-tower-enterprise/groundswell:0.3.3
+  #   image: cr.seqera.io/enterprise/platform/pipeline-optimization:0.3.3
   #   command: bash -c 'bin/wait-for-it.sh db:3306 -t 60; bin/migrate-db.sh; bin/serve.sh'
   #   networks:
   #     - backend

--- a/platform-enterprise_docs/enterprise/_templates/k8s/data_studios/proxy.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/data_studios/proxy.yml
@@ -19,7 +19,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: proxy
-          image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-proxy:0.10.0
+          image: cr.seqera.io/enterprise/studios/proxy:0.10.0
           env:
             - name: CONNECT_HTTP_PORT
               value: "8081"

--- a/platform-enterprise_docs/enterprise/_templates/k8s/data_studios/server.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/data_studios/server.yml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: server
-          image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.10.0
+          image: cr.seqera.io/enterprise/studios/server:0.10.0
           ports:
             - containerPort: 7070
               name: server

--- a/platform-enterprise_docs/enterprise/_templates/k8s/groundswell.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/groundswell.yml
@@ -96,7 +96,7 @@ spec:
                 name: tower-groundswell-cfg
 
         - name: migrate-db
-          image: "cr.seqera.io/private/nf-tower-enterprise/groundswell:0.4.7"
+          image: "cr.seqera.io/enterprise/platform/pipeline-optimization:0.4.7"
           command: ['/opt/groundswell/bin/migrate-db.sh']
           envFrom:
             - configMapRef:
@@ -106,7 +106,7 @@ spec:
 
       containers:
         - name: groundswell
-          image: "cr.seqera.io/private/nf-tower-enterprise/groundswell:0.4.7"
+          image: "cr.seqera.io/enterprise/platform/pipeline-optimization:0.4.7"
           env:
             - name: MPLCONFIGDIR
               value: "/tmp"

--- a/platform-enterprise_docs/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/tower-cron.yml
@@ -21,7 +21,7 @@ spec:
             name: tower-yml
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.3.4
+          image: cr.seqera.io/enterprise/platform/migrate-db:v25.3.4
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -32,7 +32,7 @@ spec:
               subPath: tower.yml
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.4
+          image: cr.seqera.io/enterprise/platform/backend:v25.3.4
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform-enterprise_docs/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/tower-svc.yml
@@ -29,7 +29,7 @@ spec:
         #    secretName: platform-oidc-certs
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.4
+          image: cr.seqera.io/enterprise/platform/backend:v25.3.4
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -88,7 +88,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.4
+          image: cr.seqera.io/enterprise/platform/frontend:v25.3.4
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform-enterprise_docs/enterprise/configuration/mirroring.md
+++ b/platform-enterprise_docs/enterprise/configuration/mirroring.md
@@ -30,9 +30,9 @@ Create a YAML file (`seqera-images.yaml`) to specify which images to sync:
 ```yaml
 cr.seqera.io:
     images-by-semver:
-        private/nf-tower-enterprise/backend: ">= v25.3.4"
-        private/nf-tower-enterprise/frontend: ">= v25.3.4"
-        private/nf-tower-enterprise/migrate-db: ">= v25.3.4"
+        enterprise/platform/backend: ">= v25.3.4"
+        enterprise/platform/frontend: ">= v25.3.4"
+        enterprise/platform/migrate-db: ">= v25.3.4"
 ```
 
 Run the sync:

--- a/platform-enterprise_docs/enterprise/install-seqera-ai.md
+++ b/platform-enterprise_docs/enterprise/install-seqera-ai.md
@@ -194,7 +194,7 @@ For the full list of configuration options, see the [agent-backend chart documen
 |-------|-------------|---------|
 | `agentBackend.replicaCount` | Number of replicas | `1` |
 | `agentBackend.image.registry` | Image registry | `cr.seqera.io` |
-| `agentBackend.image.repository` | Image repository | `private/nf-tower-enterprise/agent-backend` |
+| `agentBackend.image.repository` | Image repository | `ai/agent-backend/backend` |
 | `anthropicApiKeyExistingSecretName` | Existing secret containing `ANTHROPIC_API_KEY` | `""` |
 | `tokenEncryptionKeyExistingSecretName` | Existing secret containing `TOKEN_ENCRYPTION_KEY` | `""` |
 

--- a/platform-enterprise_docs/enterprise/platform-docker-compose.md
+++ b/platform-enterprise_docs/enterprise/platform-docker-compose.md
@@ -80,11 +80,11 @@ For more information on configuration, see [Configuration options](./configurati
 
 An unprivileged version of the Seqera frontend image is also available. This image listens on an unprivileged port and therefore doesn't need to be run as the root user.
 
-Replace the tag of the frontend image `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x` with `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged`. Then update the `frontend` section of the `docker-compose.yml` file as follows, replacing the port mappings as needed:
+Replace the tag of the frontend image `cr.seqera.io/enterprise/platform/frontend:v24.x.x` with `cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged`. Then update the `frontend` section of the `docker-compose.yml` file as follows, replacing the port mappings as needed:
 
 ```yaml
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged
+    image: cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged
     platform: linux/amd64
     environment:
       NGINX_LISTEN_PORT: 8001  # If not defined, defaults to 8000

--- a/platform-enterprise_docs/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_docs/enterprise/platform-kubernetes.md
@@ -107,7 +107,7 @@ kubectl apply -f tower-svc.yml
 
 An unprivileged version of the Seqera frontend image is also available. This image listens on an unprivileged port and therefore doesn't need to be run as the root user.
 
-Replace the tag of the frontend image `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x` with `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged`. In the `frontend` service below, specify the `targetPort` to match the environment variable `NGINX_LISTEN_PORT` (see below):
+Replace the tag of the frontend image `cr.seqera.io/enterprise/platform/frontend:v24.x.x` with `cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged`. In the `frontend` service below, specify the `targetPort` to match the environment variable `NGINX_LISTEN_PORT` (see below):
 
 ```yaml
 ---
@@ -121,7 +121,7 @@ spec:
   ...
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.0-unprivileged
+          image: cr.seqera.io/enterprise/platform/frontend:v25.3.0-unprivileged
           env:
             - name: NGINX_LISTEN_PORT  # If not defined, defaults to 8000.
               value: 8000

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/cloudformation/aws-ecs-cloudformation.json
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/cloudformation/aws-ecs-cloudformation.json
@@ -82,7 +82,7 @@
           },
           {
             "Name": "cron",
-            "Image": "cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.8",
+            "Image": "cr.seqera.io/enterprise/platform/backend:v24.1.8",
             "Memory": 2000,
             "Cpu": 0,
             "Links": ["redis"],
@@ -188,7 +188,7 @@
           },
           {
             "Name": "frontend",
-            "Image": "cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.8",
+            "Image": "cr.seqera.io/enterprise/platform/frontend:v24.1.8",
             "Memory": 2000,
             "Cpu": 0,
             "Essential": false,
@@ -211,7 +211,7 @@
             "Hostname": "backend",
             "Memory": 2000,
             "Cpu": 0,
-            "Image": "cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.8",
+            "Image": "cr.seqera.io/enterprise/platform/backend:v24.1.8",
             "PortMappings": [
               {
                 "ContainerPort": 8080,

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.1.8
+    image: cr.seqera.io/enterprise/platform/migrate-db:v24.1.8
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -57,7 +57,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.8
+    image: cr.seqera.io/enterprise/platform/backend:v24.1.8
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -77,7 +77,7 @@ services:
         condition: service_completed_successfully
 
   backend:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.8
+    image: cr.seqera.io/enterprise/platform/backend:v24.1.8
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -102,7 +102,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.8
+    image: cr.seqera.io/enterprise/platform/frontend:v24.1.8
     platform: linux/amd64
     networks:
       - frontend
@@ -113,7 +113,7 @@ services:
       - backend
   # Uncomment the following section to enable Data Studios functionality. See [Data Studios configuration](../../data-studios.mdx) for more information.
   #  connect-proxy:
-  #    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-proxy:0.7.2
+  #    image: cr.seqera.io/enterprise/studios/proxy:0.7.2
   #    platform: linux/amd64
   #    env_file:
   #      - data-studios.env
@@ -127,7 +127,7 @@ services:
   #      - redis
   #
   #  connect-server:
-  #    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.7.2
+  #    image: cr.seqera.io/enterprise/studios/server:0.7.2
   #    platform: linux/amd64
   #    env_file:
   #      - data-studios.env
@@ -140,7 +140,7 @@ services:
   # Uncomment the following section to enable the pipeline resource optimization service. Add TOWER_ENABLE_GROUNDSWELL
   # or GROUNDSWELL_SERVER_URL to tower.env environment variables
   # groundswell:
-  #   image: cr.seqera.io/private/nf-tower-enterprise/groundswell:0.3.3
+  #   image: cr.seqera.io/enterprise/platform/pipeline-optimization:0.3.3
   #   command: bash -c 'bin/wait-for-it.sh db:3306 -t 60; bin/migrate-db.sh; bin/serve.sh'
   #   networks:
   #     - backend

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/k8s/data_studios/proxy.yml
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/k8s/data_studios/proxy.yml
@@ -19,7 +19,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: proxy
-          image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-proxy:0.7.2
+          image: cr.seqera.io/enterprise/studios/proxy:0.7.2
           command:
             - caddy
             - serve

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/k8s/data_studios/server.yml
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/k8s/data_studios/server.yml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: server
-          image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.7.2
+          image: cr.seqera.io/enterprise/studios/server:0.7.2
           ports:
             - containerPort: 7070
               name: server

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/k8s/groundswell.yml
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/k8s/groundswell.yml
@@ -96,7 +96,7 @@ spec:
                 name: tower-groundswell-cfg
 
         - name: migrate-db
-          image: "cr.seqera.io/private/nf-tower-enterprise/groundswell:0.4.7"
+          image: "cr.seqera.io/enterprise/platform/pipeline-optimization:0.4.7"
           command: ['/opt/groundswell/bin/migrate-db.sh']
           envFrom:
             - configMapRef:
@@ -106,7 +106,7 @@ spec:
 
       containers:
         - name: groundswell
-          image: "cr.seqera.io/private/nf-tower-enterprise/groundswell:0.4.7"
+          image: "cr.seqera.io/enterprise/platform/pipeline-optimization:0.4.7"
           env:
             - name: MPLCONFIGDIR
               value: "/tmp"

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-cron.yml
@@ -21,7 +21,7 @@ spec:
             name: tower-yml
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.1.8
+          image: cr.seqera.io/enterprise/platform/migrate-db:v24.1.8
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -32,7 +32,7 @@ spec:
               subPath: tower.yml
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.8
+          image: cr.seqera.io/enterprise/platform/backend:v24.1.8
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/_templates/k8s/tower-svc.yml
@@ -29,7 +29,7 @@ spec:
         #    secretName: platform-oidc-certs
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.8
+          image: cr.seqera.io/enterprise/platform/backend:v24.1.8
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -91,7 +91,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.8
+          image: cr.seqera.io/enterprise/platform/frontend:v24.1.8
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/kubernetes.md
@@ -168,7 +168,7 @@ kubectl apply -f tower-svc.yml
 
 An unprivileged version of the Seqera frontend image is also available. This image listens on an unprivileged port and therefore doesn't need to be run as the root user.
 
-Replace the tag of the frontend image `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x` with `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged`. In the `frontend` service below, specify the `targetPort` to match the environment variable `NGINX_LISTEN_PORT` (see below):
+Replace the tag of the frontend image `cr.seqera.io/enterprise/platform/frontend:v24.x.x` with `cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged`. In the `frontend` service below, specify the `targetPort` to match the environment variable `NGINX_LISTEN_PORT` (see below):
 
 ```yaml
 ---
@@ -182,7 +182,7 @@ spec:
   ...
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.8-unprivileged
+          image: cr.seqera.io/enterprise/platform/frontend:v24.1.8-unprivileged
           env:
             - name: NGINX_LISTEN_PORT  # If not defined, defaults to 8000.
               value: 8000

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/overview.md
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/overview.md
@@ -80,9 +80,9 @@ Seqera Enterprise is distributed as a collection of Docker containers available 
 3. Pull the application container images:
 
    ```bash
-   docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v24.1.8
+   docker pull cr.seqera.io/enterprise/platform/backend:v24.1.8
 
-   docker pull cr.seqera.io/private/nf-tower-enterprise/frontend:v24.1.8
+   docker pull cr.seqera.io/enterprise/platform/frontend:v24.1.8
    ```
 
 ## Support

--- a/platform-enterprise_versioned_docs/version-24.1/enterprise/prerequisites/common.md
+++ b/platform-enterprise_versioned_docs/version-24.1/enterprise/prerequisites/common.md
@@ -39,16 +39,16 @@ We recommend installing the latest version of Skopeo (or at least v1.15+ to work
 1. Listing the available tags for a given image can be done with the `list-tags` command:
 
    ```console
-   skopeo list-tags docker://cr.seqera.io/private/nf-tower-enterprise
+   skopeo list-tags docker://cr.seqera.io/enterprise/platform
    ```
 
-1. Syncing images can be done with the `sync` command. For example, to sync all images stored in the `cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server` repository to your internal registry, run:
+1. Syncing images can be done with the `sync` command. For example, to sync all images stored in the `cr.seqera.io/enterprise/studios/server` repository to your internal registry, run:
 
    ```console
-   skopeo sync --scoped --src docker --dest docker cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server YOUR_INTERNAL_REGISTRY
+   skopeo sync --scoped --src docker --dest docker cr.seqera.io/enterprise/studios/server YOUR_INTERNAL_REGISTRY
    ```
 
-   Note that `--scoped` will populate your internal registry with images like `YOUR_INTERNAL_REGISTRY/cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server`.
+   Note that `--scoped` will populate your internal registry with images like `YOUR_INTERNAL_REGISTRY/cr.seqera.io/enterprise/studios/server`.
    More advanced usage examples are available in the Skopeo documentation: https://github.com/containers/skopeo/blob/main/docs/skopeo-sync.1.md#examples
 
 To avoid duplicating several years of Seqera images, we recommend using the `images-by-semver` option in the `sync` command. This option allows you to specify semantic versioning constraints for each image to be synced. For example, to sync all images with tags greater than or equal to a certain version, create a YAML file (for example, `seqera-container-registry.yaml`) with content similar to the following (adapt it to the versions you want to sync and the images you need):
@@ -56,13 +56,13 @@ To avoid duplicating several years of Seqera images, we recommend using the `ima
 ```yaml
 cr.seqera.io:
     images-by-semver:
-        private/nf-tower-enterprise/backend: ">= v25.2.0"
-        private/nf-tower-enterprise/frontend: ">= v25.2.0"
-        private/nf-tower-enterprise/migrate-db: ">= v25.2.0"
-        private/nf-tower-enterprise/data-studio/connect-server: ">= 0.8.0"
-        private/nf-tower-enterprise/data-studio/connect-proxy: ">= 0.8.0"
-        private/nf-tower-enterprise/wave: ">= v1.23.0"
-        private/nf-tower-enterprise/groundswell: ">= 0.4.0"
+        enterprise/platform/backend: ">= v25.2.0"
+        enterprise/platform/frontend: ">= v25.2.0"
+        enterprise/platform/migrate-db: ">= v25.2.0"
+        enterprise/studios/server: ">= 0.8.0"
+        enterprise/studios/proxy: ">= 0.8.0"
+        enterprise/wave/server: ">= v1.23.0"
+        enterprise/platform/pipeline-optimization: ">= 0.4.0"
 ```
 
 Note that some image tags are prefixed with `v` while others are not.
@@ -91,13 +91,13 @@ The general process to manually replicate images involves:
 1. Downloading the image from the Seqera container registry.
 
    ```console
-   docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v25.2.3
+   docker pull cr.seqera.io/enterprise/platform/backend:v25.2.3
    ```
 
 1. Re-tagging the image.
 
    ```console
-   docker tag cr.seqera.io/private/nf-tower-enterprise/backend:v25.2.3 YOUR_INTERNAL_REGISTRY/your-repo/backend:v25.2.3
+   docker tag cr.seqera.io/enterprise/platform/backend:v25.2.3 YOUR_INTERNAL_REGISTRY/your-repo/backend:v25.2.3
    ```
 
 1. Pushing the image to your preferred container registry (for example, ECR, GCR, Docker Hub).

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/cloudformation/aws-ecs-cloudformation.json
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/cloudformation/aws-ecs-cloudformation.json
@@ -80,7 +80,7 @@
                     },
                     {
                     "Name": "cron",
-                    "Image": "cr.seqera.io/private/nf-tower-enterprise/backend:v24.2.4",
+                    "Image": "cr.seqera.io/enterprise/platform/backend:v24.2.4",
                     "Memory": 2000,
                     "Cpu": 0,
                     "Links": [
@@ -188,7 +188,7 @@
                     },
                     {
                     "Name": "frontend",
-                    "Image": "cr.seqera.io/private/nf-tower-enterprise/frontend:v24.2.4",
+                    "Image": "cr.seqera.io/enterprise/platform/frontend:v24.2.4",
                     "Memory": 2000,
                     "Cpu": 0,
                     "Essential": false,
@@ -211,7 +211,7 @@
                     "Hostname": "backend",
                     "Memory": 2000,
                     "Cpu": 0,
-                    "Image": "cr.seqera.io/private/nf-tower-enterprise/backend:v24.2.4",
+                    "Image": "cr.seqera.io/enterprise/platform/backend:v24.2.4",
                     "PortMappings": [{
                         "ContainerPort": 8080,
                         "HostPort": 8080

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/docker/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.2.4
+    image: cr.seqera.io/enterprise/platform/migrate-db:v24.2.4
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -64,7 +64,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.2.4
+    image: cr.seqera.io/enterprise/platform/backend:v24.2.4
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -85,7 +85,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.2.4
+    image: cr.seqera.io/enterprise/platform/backend:v24.2.4
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -110,7 +110,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.2.4
+    image: cr.seqera.io/enterprise/platform/frontend:v24.2.4
     platform: linux/amd64
     networks:
       - frontend
@@ -122,7 +122,7 @@ services:
 
 # Uncomment the following section to enable Data Studios functionality. See [Data Studios configuration](../../data-studios.mdx) for more information.
 #  connect-proxy:
-#    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-proxy:0.7.2
+#    image: cr.seqera.io/enterprise/studios/proxy:0.7.2
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env
@@ -136,7 +136,7 @@ services:
 #      - redis
 #
 #  connect-server:
-#    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.7.2
+#    image: cr.seqera.io/enterprise/studios/server:0.7.2
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env
@@ -149,7 +149,7 @@ services:
   # Uncomment the following section to enable the pipeline resource optimization service. Add TOWER_ENABLE_GROUNDSWELL
   # or GROUNDSWELL_SERVER_URL to tower.env environment variables
   # groundswell:
-  #   image: cr.seqera.io/private/nf-tower-enterprise/groundswell:0.3.3
+  #   image: cr.seqera.io/enterprise/platform/pipeline-optimization:0.3.3
   #   command: bash -c 'bin/wait-for-it.sh db:3306 -t 60; bin/migrate-db.sh; bin/serve.sh'
   #   networks:
   #     - backend

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/k8s/data_studios/proxy.yml
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/k8s/data_studios/proxy.yml
@@ -19,7 +19,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: proxy
-          image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-proxy:0.7.2
+          image: cr.seqera.io/enterprise/studios/proxy:0.7.2
           command:
             - caddy
             - serve

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/k8s/data_studios/server.yml
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/k8s/data_studios/server.yml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: server
-          image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.7.2
+          image: cr.seqera.io/enterprise/studios/server:0.7.2
           ports:
             - containerPort: 7070
               name: server

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/k8s/groundswell.yml
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/k8s/groundswell.yml
@@ -96,7 +96,7 @@ spec:
                 name: tower-groundswell-cfg
 
         - name: migrate-db
-          image: "cr.seqera.io/private/nf-tower-enterprise/groundswell:0.4.7"
+          image: "cr.seqera.io/enterprise/platform/pipeline-optimization:0.4.7"
           command: ['/opt/groundswell/bin/migrate-db.sh']
           envFrom:
             - configMapRef:
@@ -106,7 +106,7 @@ spec:
 
       containers:
         - name: groundswell
-          image: "cr.seqera.io/private/nf-tower-enterprise/groundswell:0.4.7"
+          image: "cr.seqera.io/enterprise/platform/pipeline-optimization:0.4.7"
           env:
             - name: MPLCONFIGDIR
               value: "/tmp"

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/k8s/tower-cron.yml
@@ -21,7 +21,7 @@ spec:
             name: tower-yml
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v24.2.4
+          image: cr.seqera.io/enterprise/platform/migrate-db:v24.2.4
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -32,7 +32,7 @@ spec:
               subPath: tower.yml
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.2.4
+          image: cr.seqera.io/enterprise/platform/backend:v24.2.4
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/_templates/k8s/tower-svc.yml
@@ -29,7 +29,7 @@ spec:
         #    secretName: platform-oidc-certs
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v24.2.4
+          image: cr.seqera.io/enterprise/platform/backend:v24.2.4
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -91,7 +91,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.2.4
+          image: cr.seqera.io/enterprise/platform/frontend:v24.2.4
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/kubernetes.mdx
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/kubernetes.mdx
@@ -168,7 +168,7 @@ To deploy the manifest to your cluster, run the following:
 
 An unprivileged version of the Seqera frontend image is also available. This image listens on an unprivileged port and therefore doesn't need to be run as the root user.
 
-Replace the tag of the frontend image `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x` with `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged`. In the `frontend` service below, specify the `targetPort` to match the environment variable `NGINX_LISTEN_PORT` (see below):
+Replace the tag of the frontend image `cr.seqera.io/enterprise/platform/frontend:v24.x.x` with `cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged`. In the `frontend` service below, specify the `targetPort` to match the environment variable `NGINX_LISTEN_PORT` (see below):
 
 ```yaml
 ---
@@ -182,7 +182,7 @@ spec:
   ...
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.2.4-unprivileged
+          image: cr.seqera.io/enterprise/platform/frontend:v24.2.4-unprivileged
           env:
             - name: NGINX_LISTEN_PORT  # If not defined, defaults to 8000.
               value: 8000

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/overview.md
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/overview.md
@@ -80,9 +80,9 @@ Seqera Enterprise is distributed as a collection of Docker containers available 
 3. Pull the application container images:
 
    ```bash
-   docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v24.2.4
+   docker pull cr.seqera.io/enterprise/platform/backend:v24.2.4
 
-   docker pull cr.seqera.io/private/nf-tower-enterprise/frontend:v24.2.4
+   docker pull cr.seqera.io/enterprise/platform/frontend:v24.2.4
    ```
 
 ## Support

--- a/platform-enterprise_versioned_docs/version-24.2/enterprise/prerequisites/common.md
+++ b/platform-enterprise_versioned_docs/version-24.2/enterprise/prerequisites/common.md
@@ -39,16 +39,16 @@ We recommend installing the latest version of Skopeo (or at least v1.15+ to work
 1. Listing the available tags for a given image can be done with the `list-tags` command:
 
    ```console
-   skopeo list-tags docker://cr.seqera.io/private/nf-tower-enterprise
+   skopeo list-tags docker://cr.seqera.io/enterprise/platform
    ```
 
-1. Syncing images can be done with the `sync` command. For example, to sync all images stored in the `cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server` repository to your internal registry, run:
+1. Syncing images can be done with the `sync` command. For example, to sync all images stored in the `cr.seqera.io/enterprise/studios/server` repository to your internal registry, run:
 
    ```console
-   skopeo sync --scoped --src docker --dest docker cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server YOUR_INTERNAL_REGISTRY
+   skopeo sync --scoped --src docker --dest docker cr.seqera.io/enterprise/studios/server YOUR_INTERNAL_REGISTRY
    ```
 
-   Note that `--scoped` will populate your internal registry with images like `YOUR_INTERNAL_REGISTRY/cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server`.
+   Note that `--scoped` will populate your internal registry with images like `YOUR_INTERNAL_REGISTRY/cr.seqera.io/enterprise/studios/server`.
    More advanced usage examples are available in the Skopeo documentation: https://github.com/containers/skopeo/blob/main/docs/skopeo-sync.1.md#examples
 
 To avoid duplicating several years of Seqera images, we recommend using the `images-by-semver` option in the `sync` command. This option allows you to specify semantic versioning constraints for each image to be synced. For example, to sync all images with tags greater than or equal to a certain version, create a YAML file (for example, `seqera-container-registry.yaml`) with content similar to the following (adapt it to the versions you want to sync and the images you need):
@@ -56,13 +56,13 @@ To avoid duplicating several years of Seqera images, we recommend using the `ima
 ```yaml
 cr.seqera.io:
     images-by-semver:
-        private/nf-tower-enterprise/backend: ">= v25.2.0"
-        private/nf-tower-enterprise/frontend: ">= v25.2.0"
-        private/nf-tower-enterprise/migrate-db: ">= v25.2.0"
-        private/nf-tower-enterprise/data-studio/connect-server: ">= 0.8.0"
-        private/nf-tower-enterprise/data-studio/connect-proxy: ">= 0.8.0"
-        private/nf-tower-enterprise/wave: ">= v1.23.0"
-        private/nf-tower-enterprise/groundswell: ">= 0.4.0"
+        enterprise/platform/backend: ">= v25.2.0"
+        enterprise/platform/frontend: ">= v25.2.0"
+        enterprise/platform/migrate-db: ">= v25.2.0"
+        enterprise/studios/server: ">= 0.8.0"
+        enterprise/studios/proxy: ">= 0.8.0"
+        enterprise/wave/server: ">= v1.23.0"
+        enterprise/platform/pipeline-optimization: ">= 0.4.0"
 ```
 
 Note that some image tags are prefixed with `v` while others are not.
@@ -91,13 +91,13 @@ The general process to manually replicate images involves:
 1. Downloading the image from the Seqera container registry.
 
    ```console
-   docker pull cr.seqera.io/private/nf-tower-enterprise/backend:v25.2.3
+   docker pull cr.seqera.io/enterprise/platform/backend:v25.2.3
    ```
 
 1. Re-tagging the image.
 
    ```console
-   docker tag cr.seqera.io/private/nf-tower-enterprise/backend:v25.2.3 YOUR_INTERNAL_REGISTRY/your-repo/backend:v25.2.3
+   docker tag cr.seqera.io/enterprise/platform/backend:v25.2.3 YOUR_INTERNAL_REGISTRY/your-repo/backend:v25.2.3
    ```
 
 1. Pushing the image to your preferred container registry (for example, ECR, GCR, Docker Hub).

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.1.1
+    image: cr.seqera.io/enterprise/platform/migrate-db:v25.1.1
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -57,7 +57,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.1.1
+    image: cr.seqera.io/enterprise/platform/backend:v25.1.1
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -78,7 +78,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.1.1
+    image: cr.seqera.io/enterprise/platform/backend:v25.1.1
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -103,7 +103,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.1.1
+    image: cr.seqera.io/enterprise/platform/frontend:v25.1.1
     platform: linux/amd64
     networks:
       - frontend
@@ -115,7 +115,7 @@ services:
 
 # Uncomment the following section to enable Data Studios functionality. See [Data Studios configuration](../../data-studios.mdx) for more information.
 #  connect-proxy:
-#    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-proxy:0.8.0
+#    image: cr.seqera.io/enterprise/studios/proxy:0.8.0
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env
@@ -129,7 +129,7 @@ services:
 #      - redis
 #
 #  connect-server:
-#    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.8.0
+#    image: cr.seqera.io/enterprise/studios/server:0.8.0
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env
@@ -142,7 +142,7 @@ services:
   # Uncomment the following section to enable the pipeline optimization service. Add TOWER_ENABLE_GROUNDSWELL
   # or GROUNDSWELL_SERVER_URL to tower.env environment variables
   # groundswell:
-  #   image: cr.seqera.io/private/nf-tower-enterprise/groundswell:0.3.3
+  #   image: cr.seqera.io/enterprise/platform/pipeline-optimization:0.3.3
   #   command: bash -c 'bin/wait-for-it.sh db:3306 -t 60; bin/migrate-db.sh; bin/serve.sh'
   #   networks:
   #     - backend

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/k8s/data_studios/proxy.yml
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/k8s/data_studios/proxy.yml
@@ -19,7 +19,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: proxy
-          image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-proxy:0.8.0
+          image: cr.seqera.io/enterprise/studios/proxy:0.8.0
           env:
             - name: CONNECT_HTTP_PORT
               value: "8081"

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/k8s/data_studios/server.yml
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/k8s/data_studios/server.yml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: server
-          image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.8.0
+          image: cr.seqera.io/enterprise/studios/server:0.8.0
           ports:
             - containerPort: 7070
               name: server

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/k8s/groundswell.yml
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/k8s/groundswell.yml
@@ -96,7 +96,7 @@ spec:
                 name: tower-groundswell-cfg
 
         - name: migrate-db
-          image: "cr.seqera.io/private/nf-tower-enterprise/groundswell:0.4.7"
+          image: "cr.seqera.io/enterprise/platform/pipeline-optimization:0.4.7"
           command: ['/opt/groundswell/bin/migrate-db.sh']
           envFrom:
             - configMapRef:
@@ -106,7 +106,7 @@ spec:
 
       containers:
         - name: groundswell
-          image: "cr.seqera.io/private/nf-tower-enterprise/groundswell:0.4.7"
+          image: "cr.seqera.io/enterprise/platform/pipeline-optimization:0.4.7"
           env:
             - name: MPLCONFIGDIR
               value: "/tmp"

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/k8s/tower-cron.yml
@@ -21,7 +21,7 @@ spec:
             name: tower-yml
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.1.1
+          image: cr.seqera.io/enterprise/platform/migrate-db:v25.1.1
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -32,7 +32,7 @@ spec:
               subPath: tower.yml
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.1.1
+          image: cr.seqera.io/enterprise/platform/backend:v25.1.1
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/_templates/k8s/tower-svc.yml
@@ -29,7 +29,7 @@ spec:
         #    secretName: platform-oidc-certs
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.1.1
+          image: cr.seqera.io/enterprise/platform/backend:v25.1.1
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -91,7 +91,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.1.1
+          image: cr.seqera.io/enterprise/platform/frontend:v25.1.1
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/configuration/mirroring.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/configuration/mirroring.md
@@ -30,9 +30,9 @@ Create a YAML file (`seqera-images.yaml`) to specify which images to sync:
 ```yaml
 cr.seqera.io:
     images-by-semver:
-        private/nf-tower-enterprise/backend: ">= v25.3.1"
-        private/nf-tower-enterprise/frontend: ">= v25.3.1"
-        private/nf-tower-enterprise/migrate-db: ">= v25.3.1"
+        enterprise/platform/backend: ">= v25.3.1"
+        enterprise/platform/frontend: ">= v25.3.1"
+        enterprise/platform/migrate-db: ">= v25.3.1"
 ```
 
 Run the sync:

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/platform-docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/platform-docker-compose.md
@@ -80,11 +80,11 @@ For more information on configuration, see [Configuration options](./configurati
 
 An unprivileged version of the Seqera frontend image is also available. This image listens on an unprivileged port and therefore doesn't need to be run as the root user.
 
-Replace the tag of the frontend image `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x` with `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged`. Then update the `frontend` section of the `docker-compose.yml` file as follows, replacing the port mappings as needed:
+Replace the tag of the frontend image `cr.seqera.io/enterprise/platform/frontend:v24.x.x` with `cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged`. Then update the `frontend` section of the `docker-compose.yml` file as follows, replacing the port mappings as needed:
 
 ```yaml
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged
+    image: cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged
     platform: linux/amd64
     environment:
       NGINX_LISTEN_PORT: 8001  # If not defined, defaults to 8000

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/platform-kubernetes.md
@@ -105,7 +105,7 @@ kubectl apply -f tower-svc.yml
 
 An unprivileged version of the Seqera frontend image is also available. This image listens on an unprivileged port and therefore doesn't need to be run as the root user.
 
-Replace the tag of the frontend image `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x` with `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged`. In the `frontend` service below, specify the `targetPort` to match the environment variable `NGINX_LISTEN_PORT` (see below):
+Replace the tag of the frontend image `cr.seqera.io/enterprise/platform/frontend:v24.x.x` with `cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged`. In the `frontend` service below, specify the `targetPort` to match the environment variable `NGINX_LISTEN_PORT` (see below):
 
 ```yaml
 ---
@@ -119,7 +119,7 @@ spec:
   ...
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.0-unprivileged
+          image: cr.seqera.io/enterprise/platform/frontend:v25.3.0-unprivileged
           env:
             - name: NGINX_LISTEN_PORT  # If not defined, defaults to 8000.
               value: 8000

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.2.3
+    image: cr.seqera.io/enterprise/platform/migrate-db:v25.2.3
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -57,7 +57,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.2.3
+    image: cr.seqera.io/enterprise/platform/backend:v25.2.3
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -78,7 +78,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.2.3
+    image: cr.seqera.io/enterprise/platform/backend:v25.2.3
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -103,7 +103,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.2.3
+    image: cr.seqera.io/enterprise/platform/frontend:v25.2.3
     platform: linux/amd64
     networks:
       - frontend
@@ -115,7 +115,7 @@ services:
 
 # Uncomment the following section to enable Studios functionality. See [Studios configuration](../../../studios/overview) for more information.
 #  connect-proxy:
-#    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-proxy:0.8.3
+#    image: cr.seqera.io/enterprise/studios/proxy:0.8.3
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env
@@ -131,7 +131,7 @@ services:
 #     - $HOME/.tower/connect:/data
 #
 #  connect-server:
-#    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.8.3
+#    image: cr.seqera.io/enterprise/studios/server:0.8.3
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env
@@ -144,7 +144,7 @@ services:
   # Uncomment the following section to enable the pipeline optimization service. Add TOWER_ENABLE_GROUNDSWELL
   # or GROUNDSWELL_SERVER_URL to tower.env environment variables
   # groundswell:
-  #   image: cr.seqera.io/private/nf-tower-enterprise/groundswell:0.3.3
+  #   image: cr.seqera.io/enterprise/platform/pipeline-optimization:0.3.3
   #   command: bash -c 'bin/wait-for-it.sh db:3306 -t 60; bin/migrate-db.sh; bin/serve.sh'
   #   networks:
   #     - backend

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/k8s/data_studios/proxy.yml
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/k8s/data_studios/proxy.yml
@@ -19,7 +19,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: proxy
-          image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-proxy:0.8.3
+          image: cr.seqera.io/enterprise/studios/proxy:0.8.3
           env:
             - name: CONNECT_HTTP_PORT
               value: "8081"

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/k8s/data_studios/server.yml
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/k8s/data_studios/server.yml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: server
-          image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.8.3
+          image: cr.seqera.io/enterprise/studios/server:0.8.3
           ports:
             - containerPort: 7070
               name: server

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/k8s/groundswell.yml
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/k8s/groundswell.yml
@@ -96,7 +96,7 @@ spec:
                 name: tower-groundswell-cfg
 
         - name: migrate-db
-          image: "cr.seqera.io/private/nf-tower-enterprise/groundswell:0.4.7"
+          image: "cr.seqera.io/enterprise/platform/pipeline-optimization:0.4.7"
           command: ['/opt/groundswell/bin/migrate-db.sh']
           envFrom:
             - configMapRef:
@@ -106,7 +106,7 @@ spec:
 
       containers:
         - name: groundswell
-          image: "cr.seqera.io/private/nf-tower-enterprise/groundswell:0.4.7"
+          image: "cr.seqera.io/enterprise/platform/pipeline-optimization:0.4.7"
           env:
             - name: MPLCONFIGDIR
               value: "/tmp"

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/k8s/tower-cron.yml
@@ -21,7 +21,7 @@ spec:
             name: tower-yml
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.2.3
+          image: cr.seqera.io/enterprise/platform/migrate-db:v25.2.3
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -32,7 +32,7 @@ spec:
               subPath: tower.yml
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.2.3
+          image: cr.seqera.io/enterprise/platform/backend:v25.2.3
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/_templates/k8s/tower-svc.yml
@@ -29,7 +29,7 @@ spec:
         #    secretName: platform-oidc-certs
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.2.3
+          image: cr.seqera.io/enterprise/platform/backend:v25.2.3
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -91,7 +91,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.2.3
+          image: cr.seqera.io/enterprise/platform/frontend:v25.2.3
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/configuration/mirroring.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/configuration/mirroring.md
@@ -30,9 +30,9 @@ Create a YAML file (`seqera-images.yaml`) to specify which images to sync:
 ```yaml
 cr.seqera.io:
     images-by-semver:
-        private/nf-tower-enterprise/backend: ">= v25.3.1"
-        private/nf-tower-enterprise/frontend: ">= v25.3.1"
-        private/nf-tower-enterprise/migrate-db: ">= v25.3.1"
+        enterprise/platform/backend: ">= v25.3.1"
+        enterprise/platform/frontend: ">= v25.3.1"
+        enterprise/platform/migrate-db: ">= v25.3.1"
 ```
 
 Run the sync:

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/platform-docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/platform-docker-compose.md
@@ -80,11 +80,11 @@ For more information on configuration, see [Configuration options](./configurati
 
 An unprivileged version of the Seqera frontend image is also available. This image listens on an unprivileged port and therefore doesn't need to be run as the root user.
 
-Replace the tag of the frontend image `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x` with `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged`. Then update the `frontend` section of the `docker-compose.yml` file as follows, replacing the port mappings as needed:
+Replace the tag of the frontend image `cr.seqera.io/enterprise/platform/frontend:v24.x.x` with `cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged`. Then update the `frontend` section of the `docker-compose.yml` file as follows, replacing the port mappings as needed:
 
 ```yaml
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged
+    image: cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged
     platform: linux/amd64
     environment:
       NGINX_LISTEN_PORT: 8001  # If not defined, defaults to 8000

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/platform-kubernetes.md
@@ -105,7 +105,7 @@ kubectl apply -f tower-svc.yml
 
 An unprivileged version of the Seqera frontend image is also available. This image listens on an unprivileged port and therefore doesn't need to be run as the root user.
 
-Replace the tag of the frontend image `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x` with `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged`. In the `frontend` service below, specify the `targetPort` to match the environment variable `NGINX_LISTEN_PORT` (see below):
+Replace the tag of the frontend image `cr.seqera.io/enterprise/platform/frontend:v24.x.x` with `cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged`. In the `frontend` service below, specify the `targetPort` to match the environment variable `NGINX_LISTEN_PORT` (see below):
 
 ```yaml
 ---
@@ -119,7 +119,7 @@ spec:
   ...
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.0-unprivileged
+          image: cr.seqera.io/enterprise/platform/frontend:v25.3.0-unprivileged
           env:
             - name: NGINX_LISTEN_PORT  # If not defined, defaults to 8000.
               value: 8000

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/docker/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.3.6
+    image: cr.seqera.io/enterprise/platform/migrate-db:v25.3.6
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -64,7 +64,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.6
+    image: cr.seqera.io/enterprise/platform/backend:v25.3.6
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -85,7 +85,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.6
+    image: cr.seqera.io/enterprise/platform/backend:v25.3.6
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -110,7 +110,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.6
+    image: cr.seqera.io/enterprise/platform/frontend:v25.3.6
     platform: linux/amd64
     networks:
       - frontend
@@ -122,7 +122,7 @@ services:
 
 # Uncomment the following section to enable Studios functionality. See [Studios configuration](../../../studios/overview) for more information.
 #  connect-proxy:
-#    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-proxy:0.11.0
+#    image: cr.seqera.io/enterprise/studios/proxy:0.11.0
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env
@@ -139,7 +139,7 @@ services:
 #     - $HOME/.tower/connect:/data
 #
 #  connect-server:
-#    image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.11.0
+#    image: cr.seqera.io/enterprise/studios/server:0.11.0
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env
@@ -152,7 +152,7 @@ services:
   # Uncomment the following section to enable the pipeline optimization service. Add TOWER_ENABLE_GROUNDSWELL
   # or GROUNDSWELL_SERVER_URL to tower.env environment variables
   # groundswell:
-  #   image: cr.seqera.io/private/nf-tower-enterprise/groundswell:0.3.3
+  #   image: cr.seqera.io/enterprise/platform/pipeline-optimization:0.3.3
   #   command: bash -c 'bin/wait-for-it.sh db:3306 -t 60; bin/migrate-db.sh; bin/serve.sh'
   #   networks:
   #     - backend

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/data_studios/proxy.yml
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/data_studios/proxy.yml
@@ -19,7 +19,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: proxy
-          image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-proxy:0.11.0
+          image: cr.seqera.io/enterprise/studios/proxy:0.11.0
           env:
             - name: CONNECT_HTTP_PORT
               value: "8081"

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/data_studios/server.yml
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/data_studios/server.yml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: server
-          image: cr.seqera.io/private/nf-tower-enterprise/data-studio/connect-server:0.11.0
+          image: cr.seqera.io/enterprise/studios/server:0.11.0
           ports:
             - containerPort: 7070
               name: server

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/groundswell.yml
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/groundswell.yml
@@ -96,7 +96,7 @@ spec:
                 name: tower-groundswell-cfg
 
         - name: migrate-db
-          image: "cr.seqera.io/private/nf-tower-enterprise/groundswell:0.4.7"
+          image: "cr.seqera.io/enterprise/platform/pipeline-optimization:0.4.7"
           command: ['/opt/groundswell/bin/migrate-db.sh']
           envFrom:
             - configMapRef:
@@ -106,7 +106,7 @@ spec:
 
       containers:
         - name: groundswell
-          image: "cr.seqera.io/private/nf-tower-enterprise/groundswell:0.4.7"
+          image: "cr.seqera.io/enterprise/platform/pipeline-optimization:0.4.7"
           env:
             - name: MPLCONFIGDIR
               value: "/tmp"

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/tower-cron.yml
@@ -21,7 +21,7 @@ spec:
             name: tower-yml
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/private/nf-tower-enterprise/migrate-db:v25.3.6
+          image: cr.seqera.io/enterprise/platform/migrate-db:v25.3.6
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -32,7 +32,7 @@ spec:
               subPath: tower.yml
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.5
+          image: cr.seqera.io/enterprise/platform/backend:v25.3.5
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/tower-svc.yml
@@ -29,7 +29,7 @@ spec:
         #    secretName: platform-oidc-certs
       containers:
         - name: backend
-          image: cr.seqera.io/private/nf-tower-enterprise/backend:v25.3.6
+          image: cr.seqera.io/enterprise/platform/backend:v25.3.6
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -91,7 +91,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.6
+          image: cr.seqera.io/enterprise/platform/frontend:v25.3.6
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/configuration/mirroring.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/configuration/mirroring.md
@@ -30,9 +30,9 @@ Create a YAML file (`seqera-images.yaml`) to specify which images to sync:
 ```yaml
 cr.seqera.io:
     images-by-semver:
-        private/nf-tower-enterprise/backend: ">= v25.3.6"
-        private/nf-tower-enterprise/frontend: ">= v25.3.6"
-        private/nf-tower-enterprise/migrate-db: ">= v25.3.6"
+        enterprise/platform/backend: ">= v25.3.6"
+        enterprise/platform/frontend: ">= v25.3.6"
+        enterprise/platform/migrate-db: ">= v25.3.6"
 ```
 
 Run the sync:

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/platform-docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/platform-docker-compose.md
@@ -80,11 +80,11 @@ For more information on configuration, see [Configuration options](./configurati
 
 An unprivileged version of the Seqera frontend image is also available. This image listens on an unprivileged port and therefore doesn't need to be run as the root user.
 
-Replace the tag of the frontend image `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x` with `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged`. Then update the `frontend` section of the `docker-compose.yml` file as follows, replacing the port mappings as needed:
+Replace the tag of the frontend image `cr.seqera.io/enterprise/platform/frontend:v24.x.x` with `cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged`. Then update the `frontend` section of the `docker-compose.yml` file as follows, replacing the port mappings as needed:
 
 ```yaml
   frontend:
-    image: cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged
+    image: cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged
     platform: linux/amd64
     environment:
       NGINX_LISTEN_PORT: 8001  # If not defined, defaults to 8000

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/platform-kubernetes.md
@@ -105,7 +105,7 @@ kubectl apply -f tower-svc.yml
 
 An unprivileged version of the Seqera frontend image is also available. This image listens on an unprivileged port and therefore doesn't need to be run as the root user.
 
-Replace the tag of the frontend image `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x` with `cr.seqera.io/private/nf-tower-enterprise/frontend:v24.x.x-unprivileged`. In the `frontend` service below, specify the `targetPort` to match the environment variable `NGINX_LISTEN_PORT` (see below):
+Replace the tag of the frontend image `cr.seqera.io/enterprise/platform/frontend:v24.x.x` with `cr.seqera.io/enterprise/platform/frontend:v24.x.x-unprivileged`. In the `frontend` service below, specify the `targetPort` to match the environment variable `NGINX_LISTEN_PORT` (see below):
 
 ```yaml
 ---
@@ -119,7 +119,7 @@ spec:
   ...
       containers:
         - name: frontend
-          image: cr.seqera.io/private/nf-tower-enterprise/frontend:v25.3.6-unprivileged
+          image: cr.seqera.io/enterprise/platform/frontend:v25.3.6-unprivileged
           env:
             - name: NGINX_LISTEN_PORT  # If not defined, defaults to 8000.
               value: 8000


### PR DESCRIPTION
This PR is deprecating the legacy distribution endpoint `cr.seqera.io/private` in favor of `cr.seqera.io/enterprise` (for the Platform-related bundle) and the new `cr.seqera.io/ai` (for the AI-related apps).

I upgraded docs from v24+ onwards and added a banner to changelogs in the major/minor v24+ releases.