### PR TITLE
Move lineage AWS IAM permissions into compute env and manual setup pages

### DIFF
--- a/platform-cloud/docs/compute-envs/aws-batch.md
+++ b/platform-cloud/docs/compute-envs/aws-batch.md
@@ -270,6 +270,26 @@ A permissive and broad policy with all the required permissions is provided here
         "ec2:GetConsoleOutput"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "OptionalLineageIntegrationSQSAndS3",
+      "Effect": "Allow",
+      "Action": [
+        "sqs:CreateQueue",
+        "sqs:GetQueueAttributes",
+        "sqs:SetQueueAttributes",
+        "sqs:GetQueueUrl",
+        "sqs:ReceiveMessage",
+        "sqs:DeleteMessage",
+        "s3:CreateBucket",
+        "s3:GetBucketNotificationConfiguration",
+        "s3:PutBucketNotificationConfiguration",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": [
+        "arn:aws:sqs:*:*:seqera-lineage-*",
+        "arn:aws:s3:::seqera-lineage-*"
+      ]
     }
   ]
 }
@@ -600,6 +620,39 @@ Platform can retrieve the EC2 instance console output to detect errors in the us
   "Resource": "*"
 }
 ```
+
+### Data lineage (optional)
+
+If [data lineage](../data/data-lineage) is enabled in your workspace, the Platform integration credentials require the following additional permissions to create the queue infrastructure and bucket notifications used by the lineage service:
+
+```json
+{
+  "Sid": "LineageIntegrationSQS",
+  "Effect": "Allow",
+  "Action": [
+    "sqs:CreateQueue",
+    "sqs:GetQueueAttributes",
+    "sqs:SetQueueAttributes",
+    "sqs:GetQueueUrl",
+    "sqs:ReceiveMessage",
+    "sqs:DeleteMessage"
+  ],
+  "Resource": "arn:aws:sqs:<REGION>:<ACCOUNT_ID>:seqera-lineage-*"
+},
+{
+  "Sid": "LineageIntegrationS3",
+  "Effect": "Allow",
+  "Action": [
+    "s3:CreateBucket",
+    "s3:GetBucketNotificationConfiguration",
+    "s3:PutBucketNotificationConfiguration",
+    "s3:GetBucketLocation"
+  ],
+  "Resource": "arn:aws:s3:::seqera-lineage-*"
+}
+```
+
+If you manage your own EC2 instance role or head job role (rather than letting Seqera create them with Batch Forge), see [Manual AWS Batch configuration](../enterprise/advanced-topics/manual-aws-batch-setup#create-an-ec2-instance-role) for the additional S3 permissions required on those roles.
 
 ## Create the IAM policy
 

--- a/platform-cloud/docs/compute-envs/aws-batch.md
+++ b/platform-cloud/docs/compute-envs/aws-batch.md
@@ -652,7 +652,7 @@ If [data lineage](../data/data-lineage) is enabled in your workspace, the Platfo
 }
 ```
 
-If you manage your own EC2 instance role or head job role (rather than letting Seqera create them with Batch Forge), see [Manual AWS Batch configuration](../enterprise/advanced-topics/manual-aws-batch-setup#create-an-ec2-instance-role) for the additional S3 permissions required on those roles.
+If you manage your own EC2 instance role or head job role (rather than letting Seqera create them with Batch Forge), see [Manual AWS Batch configuration](../enterprise/advanced-topics/manual-aws-batch-setup#create-an-ec2-instance-role) for additional S3 permissions to add to those roles.
 
 ## Create the IAM policy
 

--- a/platform-cloud/docs/compute-envs/aws-batch.md
+++ b/platform-cloud/docs/compute-envs/aws-batch.md
@@ -623,7 +623,7 @@ Platform can retrieve the EC2 instance console output to detect errors in the us
 
 ### Data lineage (optional)
 
-If [data lineage](../data/data-lineage) is enabled in your workspace, the Platform integration credentials require the following additional permissions to create the queue infrastructure and bucket notifications used by the lineage service:
+If you enable [data lineage](../data/data-lineage) in your workspace, add the following permissions to your Platform integration credentials to create the queue infrastructure and bucket notifications used by the lineage service:
 
 ```json
 {

--- a/platform-cloud/docs/compute-envs/aws-cloud.md
+++ b/platform-cloud/docs/compute-envs/aws-cloud.md
@@ -338,7 +338,7 @@ Platform can retrieve the EC2 instance console output to detect errors in the us
 
 ### Data lineage (optional)
 
-If [data lineage](../data/data-lineage) is enabled in your workspace, the Platform integration credentials require the following additional permissions to create the queue infrastructure and bucket notifications used by the lineage service:
+If you enable [data lineage](../data/data-lineage) in your workspace, add the following permissions to your Platform integration credentials to create the queue infrastructure and bucket notifications used by the lineage service:
 
 ```json
 {

--- a/platform-cloud/docs/compute-envs/aws-cloud.md
+++ b/platform-cloud/docs/compute-envs/aws-cloud.md
@@ -367,7 +367,7 @@ If [data lineage](../data/data-lineage) is enabled in your workspace, the Platfo
 }
 ```
 
-If you manage your own EC2 instance role (rather than letting Seqera create it automatically), attach the additional S3 policy described in [Manual AWS Batch configuration](../enterprise/advanced-topics/manual-aws-batch-setup#create-an-ec2-instance-role) to that role.
+If you manage your own EC2 instance role (rather than letting Seqera create it automatically), see [Manual AWS Batch configuration](../enterprise/advanced-topics/manual-aws-batch-setup#create-an-ec2-instance-role) for the additional S3 policy to attach to that role.
 
 ## Create the IAM policy
 

--- a/platform-cloud/docs/compute-envs/aws-cloud.md
+++ b/platform-cloud/docs/compute-envs/aws-cloud.md
@@ -163,6 +163,26 @@ A permissive and broad policy with all the required permissions is provided here
         "ec2:GetConsoleOutput"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "OptionalLineageIntegrationSQSAndS3",
+      "Effect": "Allow",
+      "Action": [
+        "sqs:CreateQueue",
+        "sqs:GetQueueAttributes",
+        "sqs:SetQueueAttributes",
+        "sqs:GetQueueUrl",
+        "sqs:ReceiveMessage",
+        "sqs:DeleteMessage",
+        "s3:CreateBucket",
+        "s3:GetBucketNotificationConfiguration",
+        "s3:PutBucketNotificationConfiguration",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": [
+        "arn:aws:sqs:*:*:seqera-lineage-*",
+        "arn:aws:s3:::seqera-lineage-*"
+      ]
     }
   ]
 }
@@ -315,6 +335,39 @@ Platform can retrieve the EC2 instance console output to detect errors in the us
   "Resource": "*"
 }
 ```
+
+### Data lineage (optional)
+
+If [data lineage](../data/data-lineage) is enabled in your workspace, the Platform integration credentials require the following additional permissions to create the queue infrastructure and bucket notifications used by the lineage service:
+
+```json
+{
+  "Sid": "LineageIntegrationSQS",
+  "Effect": "Allow",
+  "Action": [
+    "sqs:CreateQueue",
+    "sqs:GetQueueAttributes",
+    "sqs:SetQueueAttributes",
+    "sqs:GetQueueUrl",
+    "sqs:ReceiveMessage",
+    "sqs:DeleteMessage"
+  ],
+  "Resource": "arn:aws:sqs:<REGION>:<ACCOUNT_ID>:seqera-lineage-*"
+},
+{
+  "Sid": "LineageIntegrationS3",
+  "Effect": "Allow",
+  "Action": [
+    "s3:CreateBucket",
+    "s3:GetBucketNotificationConfiguration",
+    "s3:PutBucketNotificationConfiguration",
+    "s3:GetBucketLocation"
+  ],
+  "Resource": "arn:aws:s3:::seqera-lineage-*"
+}
+```
+
+If you manage your own EC2 instance role (rather than letting Seqera create it automatically), attach the additional S3 policy described in [Manual AWS Batch configuration](../enterprise/advanced-topics/manual-aws-batch-setup#create-an-ec2-instance-role) to that role.
 
 ## Create the IAM policy
 

--- a/platform-cloud/docs/data/data-lineage.md
+++ b/platform-cloud/docs/data/data-lineage.md
@@ -54,72 +54,12 @@ Changing the lineage storage bucket path after lineage data is generated will re
 
 When launching a pipeline in a data-lineage enabled workspace, the **Enable lineage** toggle in the pipeline **Run setup** reflects the **Enable lineage by default** workspace setting. This can be turned off to _explicitly exclude_ data lineage creation for the pipeline run.
 
-### Additional IAM permissions required
+### IAM permissions required
 
-If using existing AWS Batch or AWS Cloud compute environments with custom IAM roles, the following service role policies are required:
+Data lineage requires additional AWS IAM permissions. The permissions required depend on the role:
 
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "ListObjectsInBucket",
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": "arn:aws:s3:::seqera-lineage-<workspace-id>"
-        },
-        {
-            "Sid": "AllObjectActions",
-            "Effect": "Allow",
-            "Action": "s3:*Object",
-            "Resource": "arn:aws:s3:::seqera-lineage-<workspace-id>/*"
-        },
-        {
-            "Sid": "AllowObjectTagging",
-            "Effect": "Allow",
-            "Action": [
-                "s3:PutObjectTagging",
-                "s3:GetObjectTagging"
-            ],
-            "Resource": "arn:aws:s3:::seqera-lineage-<workspace-id>/*"
-        }
-    ]
-}
-```
-
-Platform integration credentials require the following additional permissions:
-
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "sqs:CreateQueue",
-                "sqs:GetQueueAttributes",
-                "sqs:SetQueueAttributes",
-                "sqs:GetQueueUrl",
-                "sqs:ReceiveMessage",
-                "sqs:DeleteMessage"
-            ],
-            "Resource": "arn:aws:sqs:*:*:seqera-lineage-*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:CreateBucket",
-                "s3:GetBucketNotificationConfiguration",
-                "s3:PutBucketNotificationConfiguration",
-                "s3:GetBucketLocation"
-            ],
-            "Resource": "arn:aws:s3:::seqera-lineage-*"
-        }
-    ]
-}
-```
+- **Platform integration credentials** (IAM user): see [AWS Batch — Data lineage](../compute-envs/aws-batch#data-lineage-optional) or [AWS Cloud — Data lineage](../compute-envs/aws-cloud#data-lineage-optional)
+- **EC2 instance role / head job role** (manually managed): see [Manual AWS Batch configuration](../enterprise/advanced-topics/manual-aws-batch-setup#create-an-ec2-instance-role)
 
 ### Advanced: Experimenting with data lineage
 

--- a/platform-cloud/docs/enterprise/advanced-topics/manual-aws-batch-setup.mdx
+++ b/platform-cloud/docs/enterprise/advanced-topics/manual-aws-batch-setup.mdx
@@ -95,7 +95,7 @@ Create a role that controls which AWS resources the EC2 instances launched by AW
 	- `seqera-batchjob` (the instance role policy created above)
 1. Enter `seqera-instancerole` as the role name and add an optional description and tags if needed, then select **Create**.
 
-If [data lineage](../../data/data-lineage) is enabled in your workspace, attach the following additional policy to this role to allow access to the lineage S3 bucket:
+If you enable [data lineage](../data/data-lineage) in your workspace, attach the following additional policy to this role to allow access to the lineage S3 bucket:
 
 ```json
 {

--- a/platform-cloud/docs/enterprise/advanced-topics/manual-aws-batch-setup.mdx
+++ b/platform-cloud/docs/enterprise/advanced-topics/manual-aws-batch-setup.mdx
@@ -95,6 +95,39 @@ Create a role that controls which AWS resources the EC2 instances launched by AW
 	- `seqera-batchjob` (the instance role policy created above)
 1. Enter `seqera-instancerole` as the role name and add an optional description and tags if needed, then select **Create**.
 
+If [data lineage](../../data/data-lineage) is enabled in your workspace, attach the following additional policy to this role to allow access to the lineage S3 bucket:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "LineageListBucket",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": "arn:aws:s3:::seqera-lineage-<workspace-id>"
+        },
+        {
+            "Sid": "LineageObjectAccess",
+            "Effect": "Allow",
+            "Action": "s3:*Object",
+            "Resource": "arn:aws:s3:::seqera-lineage-<workspace-id>/*"
+        },
+        {
+            "Sid": "LineageObjectTagging",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObjectTagging",
+                "s3:GetObjectTagging"
+            ],
+            "Resource": "arn:aws:s3:::seqera-lineage-<workspace-id>/*"
+        }
+    ]
+}
+```
+
 ### Create a Nextflow head job role
 
 Create an IAM role for the Nextflow head job. This role is attached to the Nextflow head job container and grants it the permissions needed to orchestrate workflow tasks and retrieve task logs from CloudWatch. You specify this role in the **Head Job role** field when creating a manual compute environment in Seqera Platform.


### PR DESCRIPTION
## Summary

Addresses the suggestion in seqeralabs/docs#1383 (comment): https://github.com/seqeralabs/docs/pull/1383#issuecomment-4406502772

- **AWS Batch** and **AWS Cloud** pages: add a new _Data lineage (optional)_ section under _Required Platform IAM permissions_ with the Platform integration credentials (SQS queue management + S3 bucket notifications), scoped to `<REGION>/<ACCOUNT_ID>` for SQS
- **Manual AWS Batch setup** page: add the lineage S3 bucket policy to the _Create an EC2 instance role_ section, for users who manage their own roles rather than using Batch Forge
- **Data lineage** page: replace the inline policy blocks with cross-references to the two pages above, split by role type (integration credentials vs. instance/head job role)

## Test plan

- [ ] Check Netlify preview for `platform-cloud/docs/compute-envs/aws-batch`, `aws-cloud`, `data/data-lineage`, and `enterprise/advanced-topics/manual-aws-batch-setup`
- [ ] Verify anchor links `#data-lineage-optional` resolve correctly in both compute env pages
- [ ] Verify cross-reference links in data-lineage.md resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)