### PR TITLE
fix: link-checker action

### DIFF
--- a/.github/workflows/check-internal-links.yml
+++ b/.github/workflows/check-internal-links.yml
@@ -22,7 +22,14 @@ jobs:
         run: npm ci
 
       - name: Cache Docusaurus build artifacts
-        uses: docuactions/cache@f2453304952c829ed0d650e53fc747f87194a385 # ratchet:docuactions/cache@v1
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5.0.5
+        with:
+          path: |
+            ${{ github.workspace }}/.docusaurus
+            ${{ github.workspace }}/**/.cache
+          key: ${{ runner.os }}-docusaurus-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          restore-keys: |
+            ${{ runner.os }}-docusaurus-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
 
       - name: Build Docusaurus website
         env:


### PR DESCRIPTION
the upstream action is just wrapping actions/cache and has not been updated in 2 years. 

https://github.com/docuactions/cache/blob/main/action.yml

Pull it in-line and update. 