### PR TITLE
docs(cloud): Add IdP delegation documentation [PLAT-4827]

### DIFF
--- a/platform-cloud/cloud-sidebar.json
+++ b/platform-cloud/cloud-sidebar.json
@@ -22,6 +22,28 @@
           "getting-started/deployment-options",
           "getting-started/workspace-setup",
           "getting-started/single-sign-on",
+          {
+            "type": "category",
+            "label": "IdP delegation",
+            "link": {"type": "doc", "id": "getting-started/idp-delegation/overview"},
+            "collapsed": true,
+            "items": [
+              {
+                "type": "category",
+                "label": "Group catalog",
+                "link": {"type": "doc", "id": "getting-started/idp-delegation/group-catalog/overview"},
+                "collapsed": true,
+                "items": [
+                  "getting-started/idp-delegation/group-catalog/scim-okta",
+                  "getting-started/idp-delegation/group-catalog/scim-entra-id",
+                  "getting-started/idp-delegation/group-catalog/manual-google-workspace",
+                  "getting-started/idp-delegation/group-catalog/manual-keycloak"
+                ]
+              },
+              "getting-started/idp-delegation/auth0-connection-mapping",
+              "getting-started/idp-delegation/delegate-a-team"
+            ]
+          },
           "getting-started/quickstart-demo/add-pipelines",
           "getting-started/quickstart-demo/add-data",
           "getting-started/quickstart-demo/launch-pipelines",

--- a/platform-cloud/docs/getting-started/idp-delegation/auth0-connection-mapping.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/auth0-connection-mapping.md
@@ -1,0 +1,96 @@
+---
+title: "Auth0 connection mapping"
+description: "Map your IdP's groups claim through Auth0 so Seqera can see it at login."
+date created: "2026-05-12"
+last updated: "2026-05-12"
+tags: [sso, auth0, idp-delegation, administration, cloud-pro]
+---
+
+For IdP delegation to work on Cloud Pro, your IdP's `groups` claim must reach Seqera at login. Cloud Pro authenticates through Auth0, and Auth0 needs to be told how to extract the `groups` claim from the upstream IdP's token and surface it on the Auth0 user profile. This page provides copy-pasteable mapping snippets for the supported protocols and IdPs.
+
+:::caution
+Auth0 connection mapping is configured in **your** Auth0 tenant for Cloud Pro organizations that bring their own connection. Seqera cannot configure it on your behalf. Without this configuration, delegated Teams will never match — the `groups` claim won't be available at login evaluation time.
+:::
+
+## Before you begin
+
+- An active SSO connection. See [Single sign-on (SSO)](../single-sign-on).
+- Administrator access to the Auth0 tenant that hosts your SSO connection.
+- A populated IdP group catalog in Seqera. See [Manage your IdP group catalog](./group-catalog/overview).
+
+## Where to apply these snippets
+
+In Auth0:
+
+1. Open **Authentication**, then **Enterprise** (or the section matching your connection type).
+2. Select the connection that fronts your IdP.
+3. Open **Settings**, then **Mappings** (or the equivalent for your connection type).
+4. Paste the snippet for your protocol from one of the sections below.
+
+## OIDC connections
+
+For OIDC connections (Okta, Keycloak, Google Workspace, generic OIDC), use this `attribute_map`:
+
+```json
+{
+  "mapping_mode": "use_map",
+  "attributes": {
+    "name": "${context.tokenset.name}",
+    "given_name": "${context.tokenset.given_name}",
+    "family_name": "${context.tokenset.family_name}",
+    "nickname": "${context.tokenset.nickname}",
+    "picture": "${context.tokenset.picture}",
+    "email": "${context.tokenset.email}",
+    "email_verified": "${context.tokenset.email_verified}",
+    "groups": "${context.tokenset.groups}"
+  },
+  "userinfo_scope": "openid email profile groups",
+  "bind_all": true
+}
+```
+
+The two entries specific to delegation are:
+
+- `"groups": "${context.tokenset.groups}"` — copies the `groups` claim from the IdP's token into the Auth0 user profile.
+- `"userinfo_scope": "openid email profile groups"` — instructs Auth0 to request the `groups` scope from the IdP. Required for IdPs that gate group claims on a scope (Keycloak does; Okta does not).
+
+## SAML connections
+
+For SAML connections, use this `fieldsMap`:
+
+```json
+{
+  "groups": "<the SAML attribute name your IdP uses for groups>"
+}
+```
+
+The right-hand value differs by IdP:
+
+| IdP | SAML attribute name |
+|-----|---------------------|
+| Okta | `groups` |
+| Entra ID | `http://schemas.microsoft.com/ws/2008/06/identity/claims/groups` |
+| Other SAML providers | Check your IdP's SAML attribute statement configuration. |
+
+:::caution
+Entra ID's default group claim emits **group object GUIDs** (for example, `a8b3c0d1-...`), not display names. You have two options:
+
+- **Recommended** — configure Entra ID to emit display names. In the Entra application registration, open **Token configuration**, then **Add groups claim**, and configure the source attribute to emit display names where supported. Refer to Microsoft's documentation for the current UI flow.
+- **Alternative** — use the GUID itself as the **IdP Group** value on each Team and as the catalog identifier when adding groups manually. This works but makes the catalog harder to read.
+:::
+
+## Verify the mapping
+
+After saving the mapping in Auth0:
+
+1. Sign out of Seqera, then sign in again as a test user who's a member of at least one IdP group.
+2. In Auth0, open **Monitoring**, then **Logs**, and find the **Success Login** event for your test user.
+3. Expand the event details and look for `user.groups`. It should contain the array of group identifiers your IdP emitted.
+
+If `user.groups` is empty or missing:
+
+- Confirm the IdP itself is sending groups in the token. Most IdPs expose raw tokens through their administrator console — for example, Okta's **Token Preview** and Entra's **Token Configuration**.
+- Confirm the scope or attribute name in your snippet matches the IdP's emission.
+- Check Auth0's real-time logs during a login attempt for errors in the mapping.
+
+Once `user.groups` is populated, sign in to Seqera as the test user. Their delegated-Team memberships should reflect their IdP group membership immediately.

--- a/platform-cloud/docs/getting-started/idp-delegation/delegate-a-team.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/delegate-a-team.md
@@ -1,0 +1,72 @@
+---
+title: "Delegate a Team to an IdP group"
+description: "Map a Seqera Team to an identity provider group so membership is controlled at the IdP."
+date created: "2026-05-12"
+last updated: "2026-05-12"
+tags: [sso, idp-delegation, teams, administration, cloud-pro]
+---
+
+When you delegate a Team to an identity provider (IdP) group, the IdP becomes the sole authority for who belongs to that Team. Seqera evaluates each user's IdP claims at every SSO login and adds or removes them from the Team automatically.
+
+For the runtime model behind delegation, see [IdP delegation overview](./overview).
+
+## Before you begin
+
+- An active SSO connection on your organization. See [Single sign-on (SSO)](../single-sign-on).
+- A populated IdP group catalog. See [Manage your IdP group catalog](./group-catalog/overview).
+- An Auth0 connection mapping that emits the `groups` claim. See [Auth0 connection mapping](./auth0-connection-mapping).
+- Organization owner access to your Seqera organization.
+
+:::info
+If your organization doesn't have SSO configured, the **IdP Group** field appears on the Team form but is disabled. Cloud Basic organization owners see an upgrade prompt when selecting the field.
+:::
+
+## Delegate a Team
+
+1. From the organization's landing page, open the **Teams** tab.
+2. Select the Team you want to delegate, then **Edit**.
+3. In the **IdP Group** field, select a group from the dropdown. The dropdown is populated from your organization's IdP group catalog.
+4. Select **Update** to save.
+
+The same IdP group can be assigned to more than one Team. Each Team can reference exactly one IdP group.
+
+## What changes when a Team is delegated
+
+After you delegate a Team:
+
+- Membership becomes immutable in the Seqera UI. The **Add member** and **Remove member** controls are hidden.
+- The Team cannot be deleted. To delete a delegated Team, clear the **IdP Group** field first.
+- The Team's name, description, avatar, and **IdP Group** value remain editable.
+- Existing manual workspace and role assignments on the Team are preserved.
+- The Team is marked **Managed in IdP** in the Teams list.
+
+## What happens at login
+
+On every SSO login, Seqera evaluates each delegated Team against the user's `groups` claim and updates membership accordingly:
+
+- **Match found** — the user is added to the Team if they aren't already a member.
+- **No match** and the user was previously a member — they're removed from the Team.
+- **No match** and the user was never a delegation-driven member — no change.
+
+Users added manually to a Team with no **IdP Group** value keep their membership regardless of their IdP claims.
+
+If the user's token has no `groups` claim, or the claim is malformed, Seqera treats it as no group memberships and revokes any delegation-driven Team memberships the user previously had. To diagnose claim issues, see [Auth0 connection mapping](./auth0-connection-mapping).
+
+## Stop delegating a Team
+
+To convert a delegated Team back to manual management:
+
+1. Open the Team's **Edit** page.
+2. Clear the **IdP Group** field.
+3. Select **Update** to save.
+
+Existing members are kept. The **Add member** and **Remove member** controls become available again, and the Team can be deleted as normal.
+
+## Workspace and role assignment
+
+Delegation controls who belongs to the Team. It does **not** assign the Team to workspaces or grant roles. After delegation:
+
+- Assign the Team to a workspace using the workspace **Participants** page.
+- Set the Team's workspace role separately. See [User roles](../../orgs-and-teams/roles).
+
+This separation is intentional: the IdP owns membership, but the organization owns access policy.

--- a/platform-cloud/docs/getting-started/idp-delegation/group-catalog/manual-google-workspace.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/group-catalog/manual-google-workspace.md
@@ -1,0 +1,61 @@
+---
+title: "Manual entry for Google Workspace"
+description: "Populate Seqera's IdP group catalog manually for Google Workspace organizations."
+date created: "2026-05-12"
+last updated: "2026-05-12"
+tags: [sso, google-workspace, idp-delegation, administration, cloud-pro]
+---
+
+Google Workspace doesn't expose a SCIM 2.0 group provisioning API, so the Seqera group catalog is populated manually for Google Workspace organizations. This guide explains the format Seqera expects and where to find the right value in your Google Workspace administrator console.
+
+## Before you begin
+
+- Administrator access to your Google Workspace admin console.
+- Organization owner access to your Seqera organization.
+- An active SSO connection. To set up SSO, see [Single sign-on (SSO)](../../single-sign-on).
+
+## What value to enter
+
+Google Workspace identifies groups in OIDC tokens by the **group's primary email address**, not its display name. The value you enter in the Seqera catalog must match that email exactly — for example:
+
+```
+nextflow-admins@yourcompany.com
+```
+
+The value is case-insensitive but must include the full domain. Seqera matches the user's `groups` claim against this value at login.
+
+## Find a group's primary email
+
+1. Sign in to your Google Workspace admin console at [admin.google.com](https://admin.google.com).
+2. Open **Directory**, then **Groups**.
+3. Select the group you want to add to Seqera.
+4. Copy the **Group email** value at the top of the group's details page.
+
+## Add the group to Seqera
+
+1. In Seqera, open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
+2. Select **Add group manually**.
+3. In **Group identifier**, paste the group's email address.
+4. (Optional) In **Display name**, enter a human-friendly label for the group. This appears in the **IdP Group** dropdown on the Team form.
+5. Save.
+
+The group now appears in the catalog and in the **IdP Group** dropdown on the Team form. To delegate a Team to this group, see [Delegate a Team to an IdP group](../delegate-a-team).
+
+## Verify the value at login
+
+If a delegated Team isn't picking up users you expect, the most common cause is a mismatch between the value you entered and the value Google Workspace actually emits in the user's token.
+
+To inspect the value:
+
+1. Sign in to a Seqera Cloud Pro test account using SSO.
+2. In your Auth0 tenant, open **Monitoring**, then **Logs**, and find the **Success Login** event for your test user.
+3. Look for `user.groups` in the event details. The values listed there are the exact strings Seqera matches against the catalog.
+
+## Limitations
+
+- Google Workspace doesn't support SCIM group sync, so renames and deletes don't propagate automatically. If you rename a group in Workspace, update the catalog entry in Seqera. If you delete a group in Workspace, also delete the catalog entry to avoid stale references.
+- Nested groups are flattened by Google Workspace into the user's `groups` claim. A user is a member of any group whose membership chain reaches them.
+
+:::tip
+A manually-entered group is automatically promoted to SCIM-managed if your IdP later pushes the same group via SCIM. If you migrate from Google Workspace to an IdP that supports SCIM, your existing delegations continue to work without reconfiguration.
+:::

--- a/platform-cloud/docs/getting-started/idp-delegation/group-catalog/manual-google-workspace.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/group-catalog/manual-google-workspace.md
@@ -33,7 +33,7 @@ The value is case-insensitive but must include the full domain. Platform matches
 
 ## Add the group to Seqera
 
-1. In Seqera, open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
+1. In Platform, open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
 2. Select **Add group manually**.
 3. In **Group identifier**, paste the group's email address.
 4. (Optional) In **Display name**, enter a human-friendly label for the group. This appears in the **IdP Group** dropdown on the team form.
@@ -47,9 +47,9 @@ If a delegated team isn't picking up users you expect, the most common cause is 
 
 To inspect the value:
 
-1. Sign in to a Seqera Cloud Pro test account using SSO.
+1. Sign in to a Cloud Pro test account using SSO.
 2. In your Auth0 tenant, open **Monitoring**, then **Logs**, and find the **Success Login** event for your test user.
-  3. Look for `user.groups` in the event details. The values listed there are the exact strings Platform matches against the catalog.
+3. Look for `user.groups` in the event details. The values listed there are the exact strings Platform matches against the catalog.
 
 ## Limitations
 

--- a/platform-cloud/docs/getting-started/idp-delegation/group-catalog/manual-google-workspace.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/group-catalog/manual-google-workspace.md
@@ -6,7 +6,7 @@ last updated: "2026-05-12"
 tags: [sso, google-workspace, idp-delegation, administration, cloud-pro]
 ---
 
-Google Workspace doesn't expose a SCIM 2.0 group provisioning API, so the Seqera group catalog is populated manually for Google Workspace organizations. This guide explains the format Platform expects and where to find the right value in your Google Workspace administrator console.
+Google Workspace doesn't expose a SCIM 2.0 group provisioning API, so the Platform group catalog is populated manually for Google Workspace organizations. This guide explains the format Platform expects and where to find the right value in your Google Workspace administrator console.
 
 ## Before you begin
 

--- a/platform-cloud/docs/getting-started/idp-delegation/group-catalog/manual-google-workspace.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/group-catalog/manual-google-workspace.md
@@ -6,7 +6,7 @@ last updated: "2026-05-12"
 tags: [sso, google-workspace, idp-delegation, administration, cloud-pro]
 ---
 
-Google Workspace doesn't expose a SCIM 2.0 group provisioning API, so the Seqera group catalog is populated manually for Google Workspace organizations. This guide explains the format Seqera expects and where to find the right value in your Google Workspace administrator console.
+Google Workspace doesn't expose a SCIM 2.0 group provisioning API, so the Seqera group catalog is populated manually for Google Workspace organizations. This guide explains the format Platform expects and where to find the right value in your Google Workspace administrator console.
 
 ## Before you begin
 
@@ -16,19 +16,19 @@ Google Workspace doesn't expose a SCIM 2.0 group provisioning API, so the Seqera
 
 ## What value to enter
 
-Google Workspace identifies groups in OIDC tokens by the **group's primary email address**, not its display name. The value you enter in the Seqera catalog must match that email exactly — for example:
+Google Workspace identifies groups in OIDC tokens by the **group's primary email address**, not its display name. The value you enter in the Platform catalog must match that email exactly — for example:
 
 ```
 nextflow-admins@yourcompany.com
 ```
 
-The value is case-insensitive but must include the full domain. Seqera matches the user's `groups` claim against this value at login.
+The value is case-insensitive but must include the full domain. Platform matches the user's `groups` claim against this value at login.
 
 ## Find a group's primary email
 
 1. Sign in to your Google Workspace admin console at [admin.google.com](https://admin.google.com).
 2. Open **Directory**, then **Groups**.
-3. Select the group you want to add to Seqera.
+3. Select the group you want to add to Platform.
 4. Copy the **Group email** value at the top of the group's details page.
 
 ## Add the group to Seqera
@@ -36,24 +36,24 @@ The value is case-insensitive but must include the full domain. Seqera matches t
 1. In Seqera, open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
 2. Select **Add group manually**.
 3. In **Group identifier**, paste the group's email address.
-4. (Optional) In **Display name**, enter a human-friendly label for the group. This appears in the **IdP Group** dropdown on the Team form.
-5. Save.
+4. (Optional) In **Display name**, enter a human-friendly label for the group. This appears in the **IdP Group** dropdown on the team form.
+5. Select **Save**.
 
-The group now appears in the catalog and in the **IdP Group** dropdown on the Team form. To delegate a Team to this group, see [Delegate a Team to an IdP group](../delegate-a-team).
+The group now appears in the catalog and in the **IdP Group** dropdown on the team form. To delegate a team to this group, see [Delegate a team to an IdP group](../delegate-a-team).
 
 ## Verify the value at login
 
-If a delegated Team isn't picking up users you expect, the most common cause is a mismatch between the value you entered and the value Google Workspace actually emits in the user's token.
+If a delegated team isn't picking up users you expect, the most common cause is a mismatch between the value you entered and the value Google Workspace actually emits in the user's token.
 
 To inspect the value:
 
 1. Sign in to a Seqera Cloud Pro test account using SSO.
 2. In your Auth0 tenant, open **Monitoring**, then **Logs**, and find the **Success Login** event for your test user.
-3. Look for `user.groups` in the event details. The values listed there are the exact strings Seqera matches against the catalog.
+  3. Look for `user.groups` in the event details. The values listed there are the exact strings Platform matches against the catalog.
 
 ## Limitations
 
-- Google Workspace doesn't support SCIM group sync, so renames and deletes don't propagate automatically. If you rename a group in Workspace, update the catalog entry in Seqera. If you delete a group in Workspace, also delete the catalog entry to avoid stale references.
+- Google Workspace doesn't support SCIM group sync, so renames and deletes don't propagate automatically. If you rename a group in workspace, update the catalog entry in Platform. If you delete a group in workspace, also delete the catalog entry to avoid stale references.
 - Nested groups are flattened by Google Workspace into the user's `groups` claim. A user is a member of any group whose membership chain reaches them.
 
 :::tip

--- a/platform-cloud/docs/getting-started/idp-delegation/group-catalog/manual-keycloak.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/group-catalog/manual-keycloak.md
@@ -6,14 +6,14 @@ last updated: "2026-05-12"
 tags: [sso, keycloak, idp-delegation, administration, cloud-pro]
 ---
 
-Keycloak doesn't expose a SCIM 2.0 group provisioning API by default, so the Seqera group catalog is populated manually for Keycloak realms. This guide explains the format Seqera expects and where to find the right value in your Keycloak administrator console.
+Keycloak doesn't expose a SCIM 2.0 group provisioning API by default, so the Platform group catalog is populated manually for Keycloak realms. This guide explains the format Platform expects and where to find the right value in your Keycloak administrator console.
 
 ## Before you begin
 
 - Administrator access to your Keycloak realm.
 - Organization owner access to your Seqera organization.
 - An active SSO connection. To set up SSO, see [Single sign-on (SSO)](../../single-sign-on).
-- A **Group Membership** mapper configured on the client scope your Seqera connection uses, so the `groups` claim is included in tokens.
+- A **Group Membership** mapper configured on the client scope your Platform connection uses, so the `groups` claim is included in tokens.
 
 ## What value to enter
 
@@ -34,31 +34,31 @@ Check the **Full group path** setting on your Group Membership mapper before add
 1. Sign in to your Keycloak administrator console.
 2. Open the realm containing the Seqera client.
 3. Select **Groups** in the left sidebar.
-4. Navigate to the group you want to add to Seqera. The path shown in the breadcrumb is the value Keycloak emits when **Full group path** is **ON**.
+4. Navigate to the group you want to add to Platform. The path shown in the breadcrumb is the value Keycloak emits when **Full group path** is **ON**.
 
-## Add the group to Seqera
+## Add the group to Platform
 
-1. In Seqera, open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
+1. In Platform, open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
 2. Select **Add group manually**.
 3. In **Group identifier**, paste the group path (with the leading slash) or the bare group name, matching your Keycloak Group Membership mapper configuration.
 4. (Optional) In **Display name**, enter a human-friendly label for the group.
-5. Save.
+5. Select **Save**.
 
-The group now appears in the catalog and in the **IdP Group** dropdown on the Team form. To delegate a Team to this group, see [Delegate a Team to an IdP group](../delegate-a-team).
+The group now appears in the catalog and in the **IdP Group** dropdown on the team form. To delegate a team to this group, see [Delegate a team to an IdP group](../delegate-a-team).
 
 ## Verify the value at login
 
-If a delegated Team isn't picking up users you expect, inspect what Keycloak is actually emitting:
+If a delegated team isn't picking up users you expect, inspect what Keycloak is actually emitting:
 
-1. Sign in to a Seqera Cloud Pro test account using SSO.
+1. Sign in to a Cloud Pro test account using SSO.
 2. In your Auth0 tenant, open **Monitoring**, then **Logs**, and find the **Success Login** event for your test user.
-3. Look for `user.groups` in the event details. The values listed there are the exact strings Seqera matches against the catalog.
+3. Look for `user.groups` in the event details. The values listed there are the exact strings Platform matches against the catalog.
 
 If you see no `groups` claim in the Auth0 log, your Keycloak Group Membership mapper isn't attached to the client scope. See [Auth0 connection mapping](../auth0-connection-mapping) for the upstream scope and attribute requirements.
 
 ## Limitations
 
-- Keycloak doesn't push group changes to Seqera automatically. If you rename a group in Keycloak, update the catalog entry in Seqera. If you delete a group, also delete the catalog entry to avoid stale references.
+- Keycloak doesn't push group changes to Platform automatically. If you rename a group in Keycloak, update the catalog entry in Platform. If you delete a group, also delete the catalog entry to avoid stale references.
 - Nested groups in Keycloak each emit their own path in the `groups` claim. A user who belongs to `/engineering/admins` is emitted as a member of `/engineering/admins` only, not also of `/engineering`. Add catalog entries for every level you want to delegate.
 
 :::tip

--- a/platform-cloud/docs/getting-started/idp-delegation/group-catalog/manual-keycloak.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/group-catalog/manual-keycloak.md
@@ -1,0 +1,66 @@
+---
+title: "Manual entry for Keycloak"
+description: "Populate Seqera's IdP group catalog manually for Keycloak realms."
+date created: "2026-05-12"
+last updated: "2026-05-12"
+tags: [sso, keycloak, idp-delegation, administration, cloud-pro]
+---
+
+Keycloak doesn't expose a SCIM 2.0 group provisioning API by default, so the Seqera group catalog is populated manually for Keycloak realms. This guide explains the format Seqera expects and where to find the right value in your Keycloak administrator console.
+
+## Before you begin
+
+- Administrator access to your Keycloak realm.
+- Organization owner access to your Seqera organization.
+- An active SSO connection. To set up SSO, see [Single sign-on (SSO)](../../single-sign-on).
+- A **Group Membership** mapper configured on the client scope your Seqera connection uses, so the `groups` claim is included in tokens.
+
+## What value to enter
+
+Keycloak emits group memberships as **group paths** in the `groups` claim — for example:
+
+```
+/engineering/admins
+```
+
+The leading slash and the full path are significant. If your Group Membership mapper is configured with **Full group path: OFF**, Keycloak emits just the group name (`admins`) instead. The value in the Seqera catalog must match the token format exactly.
+
+:::caution
+Check the **Full group path** setting on your Group Membership mapper before adding catalog entries. Mixing full paths and bare names within the same realm leads to login-time mismatches that are hard to diagnose. Pick one format and use it consistently.
+:::
+
+## Find a group's path
+
+1. Sign in to your Keycloak administrator console.
+2. Open the realm containing the Seqera client.
+3. Select **Groups** in the left sidebar.
+4. Navigate to the group you want to add to Seqera. The path shown in the breadcrumb is the value Keycloak emits when **Full group path** is **ON**.
+
+## Add the group to Seqera
+
+1. In Seqera, open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
+2. Select **Add group manually**.
+3. In **Group identifier**, paste the group path (with the leading slash) or the bare group name, matching your Keycloak Group Membership mapper configuration.
+4. (Optional) In **Display name**, enter a human-friendly label for the group.
+5. Save.
+
+The group now appears in the catalog and in the **IdP Group** dropdown on the Team form. To delegate a Team to this group, see [Delegate a Team to an IdP group](../delegate-a-team).
+
+## Verify the value at login
+
+If a delegated Team isn't picking up users you expect, inspect what Keycloak is actually emitting:
+
+1. Sign in to a Seqera Cloud Pro test account using SSO.
+2. In your Auth0 tenant, open **Monitoring**, then **Logs**, and find the **Success Login** event for your test user.
+3. Look for `user.groups` in the event details. The values listed there are the exact strings Seqera matches against the catalog.
+
+If you see no `groups` claim in the Auth0 log, your Keycloak Group Membership mapper isn't attached to the client scope. See [Auth0 connection mapping](../auth0-connection-mapping) for the upstream scope and attribute requirements.
+
+## Limitations
+
+- Keycloak doesn't push group changes to Seqera automatically. If you rename a group in Keycloak, update the catalog entry in Seqera. If you delete a group, also delete the catalog entry to avoid stale references.
+- Nested groups in Keycloak each emit their own path in the `groups` claim. A user who belongs to `/engineering/admins` is emitted as a member of `/engineering/admins` only, not also of `/engineering`. Add catalog entries for every level you want to delegate.
+
+:::tip
+A manually-entered group is automatically promoted to SCIM-managed if your IdP later pushes the same group via SCIM. If you adopt a Keycloak SCIM extension in the future, your existing delegations continue to work without reconfiguration.
+:::

--- a/platform-cloud/docs/getting-started/idp-delegation/group-catalog/overview.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/group-catalog/overview.md
@@ -1,0 +1,61 @@
+---
+title: "Manage your IdP group catalog"
+description: "Populate Seqera with your IdP's groups using SCIM push or manual entry."
+date created: "2026-05-12"
+last updated: "2026-05-12"
+tags: [sso, scim, idp-delegation, administration, cloud-pro]
+---
+
+Seqera maintains a per-organization catalog of identity provider (IdP) groups. The catalog populates the **IdP Group** dropdown on the Team form, so organization owners can select a group when delegating a Team. The catalog is independent of user activity — groups appear as soon as they're synced or entered, before any user has signed in.
+
+Use the table below to choose the path that fits your IdP.
+
+| IdP | Recommended path | Setup guide |
+|-----|------------------|-------------|
+| Okta | SCIM push | [SCIM provisioning with Okta](./scim-okta) |
+| Entra ID | SCIM push | [SCIM provisioning with Entra ID](./scim-entra-id) |
+| Google Workspace | Manual entry | [Manual entry for Google Workspace](./manual-google-workspace) |
+| Keycloak | Manual entry | [Manual entry for Keycloak](./manual-keycloak) |
+| Other | SCIM push if your IdP supports SCIM 2.0 group provisioning; otherwise manual entry. | — |
+
+## SCIM push
+
+If your IdP supports SCIM 2.0 group provisioning, Seqera exposes a per-organization SCIM endpoint that the IdP can push to. Group create, rename, and delete events flow through automatically, and the catalog stays in sync without administrator intervention.
+
+To set up SCIM:
+
+1. Open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
+2. Copy the **SCIM endpoint URL** and the generated **bearer token**.
+3. Configure these values in your IdP's SCIM provisioning settings.
+4. Trigger an initial sync from the IdP.
+
+After the sync completes, the catalog displays every group your IdP shared, and the **IdP Group** dropdown on the Team form is populated.
+
+:::caution
+Treat the SCIM bearer token like a password. It grants write access to your organization's group catalog. If the token is compromised, rotate it immediately using **Generate new token** in the **Group mapping** panel — the previous token is revoked atomically.
+:::
+
+## Manual entry
+
+If your IdP doesn't support SCIM group sync, populate the catalog by entering group identifiers manually. The value to enter depends on your IdP — see the per-IdP guides for the format and where to find it.
+
+To add a group manually:
+
+1. Open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
+2. Select **Add group manually**.
+3. Enter the group identifier exactly as it appears in your IdP's `groups` claim. The form links to per-IdP guidance.
+4. Save.
+
+To delete a manually-entered group, select **Delete** on its row. If any delegated Team references the group, its members are immediately purged and a warning indicates that the Team has lost its source of membership.
+
+:::info
+A manually-entered group is automatically promoted to SCIM-managed if your IdP later pushes the same group via SCIM. The promotion happens in place — the catalog row is reused, and any delegated Teams that reference it continue to work without interruption. After promotion, the row's lifecycle is fully driven by SCIM, and the manual **Delete** action is no longer available; the row is removed when your IdP issues a SCIM `DELETE`.
+:::
+
+## What happens when a catalog entry is removed
+
+When a group is removed from the catalog — by SCIM `DELETE`, manual deletion, or IdP-side rename detection — Seqera does the following synchronously:
+
+- The catalog row is removed.
+- Every delegated Team that referenced the group has its delegation-driven members purged. The Team's other settings — name, workspace assignments, role — are preserved.
+- An orphaned-team warning appears in the **Group mapping** panel, listing the affected Teams. To restore the Team's membership, set its **IdP Group** field to a different group, or clear the field to convert the Team back to manual management.

--- a/platform-cloud/docs/getting-started/idp-delegation/group-catalog/overview.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/group-catalog/overview.md
@@ -6,7 +6,7 @@ last updated: "2026-05-12"
 tags: [sso, scim, idp-delegation, administration, cloud-pro]
 ---
 
-Seqera maintains a per-organization catalog of identity provider (IdP) groups. The catalog populates the **IdP Group** dropdown on the Team form, so organization owners can select a group when delegating a Team. The catalog is independent of user activity — groups appear as soon as they're synced or entered, before any user has signed in.
+Seqera maintains a per-organization catalog of identity provider (IdP) groups. The catalog populates the **IdP Group** dropdown on the team form, so organization owners can select a group when delegating a team. The catalog is independent of user activity and groups appear as soon as they're synced or entered, before any user has signed in.
 
 Use the table below to choose the path that fits your IdP.
 
@@ -20,7 +20,7 @@ Use the table below to choose the path that fits your IdP.
 
 ## SCIM push
 
-If your IdP supports SCIM 2.0 group provisioning, Seqera exposes a per-organization SCIM endpoint that the IdP can push to. Group create, rename, and delete events flow through automatically, and the catalog stays in sync without administrator intervention.
+If your IdP supports SCIM 2.0 group provisioning, Platform exposes a per-organization SCIM endpoint that the IdP can push to. Group create, rename, and delete events flow through automatically, and the catalog stays in sync without administrator intervention.
 
 To set up SCIM:
 
@@ -29,33 +29,33 @@ To set up SCIM:
 3. Configure these values in your IdP's SCIM provisioning settings.
 4. Trigger an initial sync from the IdP.
 
-After the sync completes, the catalog displays every group your IdP shared, and the **IdP Group** dropdown on the Team form is populated.
+After the sync completes, the catalog displays every group your IdP shared, and the **IdP Group** dropdown on the team form is populated.
 
 :::caution
-Treat the SCIM bearer token like a password. It grants write access to your organization's group catalog. If the token is compromised, rotate it immediately using **Generate new token** in the **Group mapping** panel — the previous token is revoked atomically.
+Treat the SCIM bearer token like a password. It grants write access to your organization's group catalog. If the token is compromised, rotate it immediately using **Generate new token** in the **Group mapping** panel. The previous token is revoked atomically.
 :::
 
 ## Manual entry
 
-If your IdP doesn't support SCIM group sync, populate the catalog by entering group identifiers manually. The value to enter depends on your IdP — see the per-IdP guides for the format and where to find it.
+If your IdP doesn't support SCIM group sync, populate the catalog by entering group identifiers manually. The value to enter depends on your IdP. See the per-IdP guides for the format and where to find it.
 
 To add a group manually:
 
 1. Open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
 2. Select **Add group manually**.
 3. Enter the group identifier exactly as it appears in your IdP's `groups` claim. The form links to per-IdP guidance.
-4. Save.
+4. Select **Save**.
 
-To delete a manually-entered group, select **Delete** on its row. If any delegated Team references the group, its members are immediately purged and a warning indicates that the Team has lost its source of membership.
+To delete a manually-entered group, select **Delete** on its row. If any delegated team references the group, its members are immediately purged and a warning indicates that the team has lost its source of membership.
 
 :::info
-A manually-entered group is automatically promoted to SCIM-managed if your IdP later pushes the same group via SCIM. The promotion happens in place — the catalog row is reused, and any delegated Teams that reference it continue to work without interruption. After promotion, the row's lifecycle is fully driven by SCIM, and the manual **Delete** action is no longer available; the row is removed when your IdP issues a SCIM `DELETE`.
+A manually-entered group is automatically promoted to SCIM-managed if your IdP later pushes the same group via SCIM. The promotion happens in place, the catalog row is reused, and any delegated teams that reference it continue to work without interruption. After promotion, the row's lifecycle is fully driven by SCIM, and the manual **Delete** action is no longer available; the row is removed when your IdP issues a SCIM `DELETE`.
 :::
 
 ## What happens when a catalog entry is removed
 
-When a group is removed from the catalog — by SCIM `DELETE`, manual deletion, or IdP-side rename detection — Seqera does the following synchronously:
+When a group is removed from the catalog by SCIM `DELETE`, manual deletion, or IdP-side rename detection, Platform does the following synchronously:
 
 - The catalog row is removed.
-- Every delegated Team that referenced the group has its delegation-driven members purged. The Team's other settings — name, workspace assignments, role — are preserved.
-- An orphaned-team warning appears in the **Group mapping** panel, listing the affected Teams. To restore the Team's membership, set its **IdP Group** field to a different group, or clear the field to convert the Team back to manual management.
+- Every delegated team that referenced the group has its delegation-driven members purged. The team's other settings (name, workspace assignments, role) are preserved.
+- An orphaned-team warning appears in the **Group mapping** panel, listing the affected teams. To restore the team's membership, set its **IdP Group** field to a different group, or clear the field to convert the team back to manual management.

--- a/platform-cloud/docs/getting-started/idp-delegation/group-catalog/scim-entra-id.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/group-catalog/scim-entra-id.md
@@ -6,22 +6,22 @@ last updated: "2026-05-12"
 tags: [sso, scim, entra-id, idp-delegation, administration, cloud-pro]
 ---
 
-Configure Microsoft Entra ID (formerly Azure AD) to push your tenant's groups to Seqera over SCIM 2.0. Once provisioning is enabled, the groups you assign to your Seqera enterprise application appear in Seqera's IdP group catalog and stay in sync with renames, additions, and deletions automatically.
+Configure Microsoft Entra ID (formerly Azure AD) to push your tenant's groups to Platform over SCIM 2.0. Once provisioning is enabled, the groups you assign to your Platform enterprise application appear in the IdP group catalog and stay in sync with renames, additions, and deletions automatically.
 
 ## Before you begin
 
-- An Entra ID enterprise application configured as your Seqera SSO connection. To set up SSO, see [Single sign-on (SSO)](../../single-sign-on).
-- Organization owner access to your Seqera organization.
+- An Entra ID enterprise application configured as your SSO connection. To set up SSO, see [Single sign-on (SSO)](../../single-sign-on).
+- Organization owner access to your Platform organization.
 - Administrator access to your Entra ID tenant with permission to manage application provisioning.
 
-## Get the Seqera SCIM connection details
+## Get the SCIM connection details
 
-1. In Seqera, open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
-2. Copy the **SCIM endpoint URL** — it has the form `https://<seqera-host>/orgs/<orgId>/scim/v2`.
+1. In Platform open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
+2. Copy the **SCIM endpoint URL** — it has the form `https://<host>/orgs/<orgId>/scim/v2`.
 3. Select **Generate token** to issue a SCIM bearer token. Copy it immediately; you can't view it again after closing the dialog.
 
 :::caution
-The bearer token grants write access to your group catalog. Store it in a secrets manager and rotate it on a schedule. To rotate, generate a new token in Seqera and update Entra ID's configuration; the previous token is revoked when the new one is issued.
+The bearer token grants write access to your group catalog. Store it in a secrets manager and rotate it on a schedule. To rotate, generate a new token in Platform and update Entra ID's configuration; the previous token is revoked when the new one is issued.
 :::
 
 ## Enable provisioning in Entra ID
@@ -31,36 +31,36 @@ The bearer token grants write access to your group catalog. Store it in a secret
 3. Open **Provisioning** and select **Get started**.
 4. Set **Provisioning Mode** to **Automatic**.
 5. Under **Admin Credentials**, provide:
-   - **Tenant URL** — the Seqera SCIM endpoint URL from the previous section.
-   - **Secret Token** — the Seqera bearer token from the previous section.
+   - **Tenant URL**: The SCIM endpoint URL from the previous section.
+   - **Secret Token**: The bearer token from the previous section.
 6. Select **Test Connection**. Entra ID should report success.
-7. Save.
+7. Select **Save**.
 
 ## Scope and start provisioning
 
 1. With **Provisioning** still open, expand **Settings**.
 2. Set **Scope** to **Sync only assigned users and groups**.
 3. Save, then set **Provisioning Status** to **On**.
-4. Return to the application's **Users and groups** tab and assign the groups you want Seqera to receive.
+4. Return to the application's **Users and groups** tab and assign the groups you want Platform to receive.
 
 Entra ID runs an initial cycle within minutes and then syncs incrementally every ~40 minutes.
 
 ## Group display names vs object IDs
 
 :::caution
-By default, Entra ID emits group **object GUIDs** in the `groups` claim, not display names. You have two options:
+By default, Entra ID emits group **object GUIDs** in the `groups` claim, not display names. There are two options provided:
 
-- **Recommended** — configure Entra ID to emit display names. In the application's **Token configuration**, add a **groups claim** and select **sAMAccountName** as the source where supported, or use a custom claims policy. This makes catalog entries and audit logs human-readable.
-- **Alternative** — accept the default GUID emission. Use the GUID as the **IdP Group** value on each Team. This works but makes the catalog harder to read.
+- **Recommended**: Configure Entra ID to emit display names. In the application's **Token configuration**, add a **groups claim** and select **sAMAccountName** as the source where supported, or use a custom claims policy. This makes catalog entries and audit logs human-readable.
+- **Alternative**: Accept the default GUID emission. Use the GUID as the **IdP Group** value on each team. This works but makes the catalog harder to read.
 
 Pick one approach for your tenant and use it consistently. The GUID and the display name don't both flow at the same time.
 :::
 
-## Verify in Seqera
+## Verify in Platform
 
-1. Return to Seqera's **Group mapping** panel.
+1. Return to **Group mapping** panel in Platform.
 2. Refresh the page. The assigned Entra ID groups should appear in the catalog list after the first provisioning cycle.
-3. Open any Team's edit form. The **IdP Group** dropdown is now populated with the synced groups.
+3. Open any team's edit form. The **IdP Group** dropdown is now populated with the synced groups.
 
 If groups don't appear, open the **Provisioning logs** for the application in Entra ID and review any failed actions.
 
@@ -68,18 +68,18 @@ If groups don't appear, open the **Provisioning logs** for the application in En
 
 Renames and deletes propagate automatically through SCIM:
 
-- **Rename** — the next provisioning cycle updates the catalog row's display name. Delegated Teams that reference the group continue to work without interruption.
-- **Delete** — Entra ID issues a SCIM `DELETE` for the group, or removes the assignment from the enterprise application. Seqera removes the catalog row and synchronously purges members from any delegated Team that referenced it. The affected Teams remain in place with empty membership and an orphaned-team warning.
+- **Rename**: The next provisioning cycle updates the catalog row's display name. Delegated Teams that reference the group continue to work without interruption.
+- **Delete**: Entra ID issues a SCIM `DELETE` for the group, or removes the assignment from the enterprise application. Seqera removes the catalog row and synchronously purges members from any delegated Team that referenced it. The affected Teams remain in place with empty membership and an orphaned-team warning.
 
 ## Troubleshooting
 
-### Groups appear in Entra ID but not in Seqera
+### Groups appear in Entra ID but not in Platform
 
-Confirm the bearer token configured in Entra ID matches the latest token Seqera issued. If you generated a new token after configuring Entra ID, the previous one is revoked.
+Confirm the bearer token configured in Entra ID matches the latest token Platform issued. If you generated a new token after configuring Entra ID, the previous one is revoked.
 
 ### Provisioning logs show `401 Unauthorized`
 
-The bearer token is invalid or expired. Generate a new token in Seqera and replace it in Entra ID.
+The bearer token is invalid or expired. Generate a new token and replace it in Entra ID.
 
 ### The catalog shows GUID-style identifiers instead of group names
 

--- a/platform-cloud/docs/getting-started/idp-delegation/group-catalog/scim-entra-id.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/group-catalog/scim-entra-id.md
@@ -1,0 +1,90 @@
+---
+title: "SCIM provisioning with Entra ID"
+description: "Configure Microsoft Entra ID to push group memberships to Seqera over SCIM 2.0."
+date created: "2026-05-12"
+last updated: "2026-05-12"
+tags: [sso, scim, entra-id, idp-delegation, administration, cloud-pro]
+---
+
+Configure Microsoft Entra ID (formerly Azure AD) to push your tenant's groups to Seqera over SCIM 2.0. Once provisioning is enabled, the groups you assign to your Seqera enterprise application appear in Seqera's IdP group catalog and stay in sync with renames, additions, and deletions automatically.
+
+## Before you begin
+
+- An Entra ID enterprise application configured as your Seqera SSO connection. To set up SSO, see [Single sign-on (SSO)](../../single-sign-on).
+- Organization owner access to your Seqera organization.
+- Administrator access to your Entra ID tenant with permission to manage application provisioning.
+
+## Get the Seqera SCIM connection details
+
+1. In Seqera, open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
+2. Copy the **SCIM endpoint URL** — it has the form `https://<seqera-host>/orgs/<orgId>/scim/v2`.
+3. Select **Generate token** to issue a SCIM bearer token. Copy it immediately; you can't view it again after closing the dialog.
+
+:::caution
+The bearer token grants write access to your group catalog. Store it in a secrets manager and rotate it on a schedule. To rotate, generate a new token in Seqera and update Entra ID's configuration; the previous token is revoked when the new one is issued.
+:::
+
+## Enable provisioning in Entra ID
+
+1. Sign in to the Azure portal and open **Entra ID**, then **Enterprise applications**.
+2. Select the application that fronts your Seqera SSO connection.
+3. Open **Provisioning** and select **Get started**.
+4. Set **Provisioning Mode** to **Automatic**.
+5. Under **Admin Credentials**, provide:
+   - **Tenant URL** — the Seqera SCIM endpoint URL from the previous section.
+   - **Secret Token** — the Seqera bearer token from the previous section.
+6. Select **Test Connection**. Entra ID should report success.
+7. Save.
+
+## Scope and start provisioning
+
+1. With **Provisioning** still open, expand **Settings**.
+2. Set **Scope** to **Sync only assigned users and groups**.
+3. Save, then set **Provisioning Status** to **On**.
+4. Return to the application's **Users and groups** tab and assign the groups you want Seqera to receive.
+
+Entra ID runs an initial cycle within minutes and then syncs incrementally every ~40 minutes.
+
+## Group display names vs object IDs
+
+:::caution
+By default, Entra ID emits group **object GUIDs** in the `groups` claim, not display names. You have two options:
+
+- **Recommended** — configure Entra ID to emit display names. In the application's **Token configuration**, add a **groups claim** and select **sAMAccountName** as the source where supported, or use a custom claims policy. This makes catalog entries and audit logs human-readable.
+- **Alternative** — accept the default GUID emission. Use the GUID as the **IdP Group** value on each Team. This works but makes the catalog harder to read.
+
+Pick one approach for your tenant and use it consistently. The GUID and the display name don't both flow at the same time.
+:::
+
+## Verify in Seqera
+
+1. Return to Seqera's **Group mapping** panel.
+2. Refresh the page. The assigned Entra ID groups should appear in the catalog list after the first provisioning cycle.
+3. Open any Team's edit form. The **IdP Group** dropdown is now populated with the synced groups.
+
+If groups don't appear, open the **Provisioning logs** for the application in Entra ID and review any failed actions.
+
+## Group rename and delete behavior
+
+Renames and deletes propagate automatically through SCIM:
+
+- **Rename** — the next provisioning cycle updates the catalog row's display name. Delegated Teams that reference the group continue to work without interruption.
+- **Delete** — Entra ID issues a SCIM `DELETE` for the group, or removes the assignment from the enterprise application. Seqera removes the catalog row and synchronously purges members from any delegated Team that referenced it. The affected Teams remain in place with empty membership and an orphaned-team warning.
+
+## Troubleshooting
+
+### Groups appear in Entra ID but not in Seqera
+
+Confirm the bearer token configured in Entra ID matches the latest token Seqera issued. If you generated a new token after configuring Entra ID, the previous one is revoked.
+
+### Provisioning logs show `401 Unauthorized`
+
+The bearer token is invalid or expired. Generate a new token in Seqera and replace it in Entra ID.
+
+### The catalog shows GUID-style identifiers instead of group names
+
+Entra ID is emitting object IDs rather than display names. See the **Group display names vs object IDs** caution above for the two options.
+
+### A group is assigned to the application but doesn't sync
+
+Confirm the provisioning scope is set to **Sync only assigned users and groups** and that the group is actually listed under **Users and groups**, not just nested in another assigned group.

--- a/platform-cloud/docs/getting-started/idp-delegation/group-catalog/scim-okta.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/group-catalog/scim-okta.md
@@ -6,22 +6,22 @@ last updated: "2026-05-12"
 tags: [sso, scim, okta, idp-delegation, administration, cloud-pro]
 ---
 
-Configure Okta to push your organization's groups to Seqera over SCIM 2.0. Once provisioning is enabled, your Okta group directory appears in Seqera's IdP group catalog and stays in sync with renames, additions, and deletions automatically.
+Configure Okta to push your organization's groups to Platform over SCIM 2.0. Once provisioning is enabled, your Okta group directory appears in Seqera's IdP group catalog and stays in sync with renames, additions, and deletions automatically.
 
 ## Before you begin
 
-- An Okta application configured as your Seqera SSO connection. To set up SSO, see [Single sign-on (SSO)](../../single-sign-on).
-- Organization owner access to your Seqera organization.
+- An Okta application configured as your SSO connection. To set up SSO, see [Single sign-on (SSO)](../../single-sign-on).
+- Organization owner access to your Platform organization.
 - Administrator access to your Okta tenant.
 
 ## Get the Seqera SCIM connection details
 
 1. In Seqera, open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
-2. Copy the **SCIM endpoint URL** — it has the form `https://<seqera-host>/orgs/<orgId>/scim/v2/Groups`.
+2. Copy the **SCIM endpoint URL**: it has the form `https://<host>/orgs/<orgId>/scim/v2/Groups`.
 3. Select **Generate token** to issue a SCIM bearer token. Copy it immediately; you can't view it again after closing the dialog.
 
 :::caution
-The bearer token grants write access to your group catalog. Store it in a secrets manager and rotate it on a schedule. To rotate, generate a new token in Seqera and update Okta's configuration; the previous token is revoked when the new one is issued.
+The bearer token grants write access to your group catalog. Store it in a secrets manager and rotate it on a schedule. To rotate, generate a new token in Platform and update Okta's configuration; the previous token is revoked when the new one is issued.
 :::
 
 ## Enable provisioning in Okta
@@ -30,23 +30,23 @@ The bearer token grants write access to your group catalog. Store it in a secret
 2. Open **Applications**, then select the application that fronts your Seqera SSO connection.
 3. Open the **Provisioning** tab and select **Configure API integration**.
 4. Select **Enable API integration** and provide:
-   - **Base URL** — the Seqera SCIM endpoint URL from the previous section, with `/Groups` removed (Okta appends the resource path).
-   - **API token** — the Seqera bearer token from the previous section.
+   - **Base URL**: The SCIM endpoint URL from the previous section, with `/Groups` removed (Okta appends the resource path).
+   - **API token**: The bearer token from the previous section.
 5. Select **Test API Credentials**. Okta should report a successful connection.
-6. Save.
+6. Select **Save**.
 
 ## Enable group push
 
 1. With the application still open, switch to the **Push Groups** tab.
 2. Select **Push Groups**, then **Find groups by name** (or **By rule** for dynamic group sets).
-3. Select the Okta groups you want available in Seqera.
+3. Select the Okta groups you want available in Platform.
 4. Confirm the push. Okta sends an initial provisioning batch.
 
-## Verify in Seqera
+## Verify in Platform
 
-1. Return to Seqera's **Group mapping** panel.
+1. Return to the **Group mapping** panel in Platform.
 2. Refresh the page. The pushed Okta groups should appear in the catalog list within a few seconds.
-3. Open any Team's edit form. The **IdP Group** dropdown is now populated with the synced groups.
+3. Open any team's edit form. The **IdP Group** dropdown is now populated with the synced groups.
 
 If groups don't appear, check the **Push Groups** status column in Okta for error details, and confirm that the **Provisioning** tab shows **Push Groups: ON**.
 
@@ -54,18 +54,18 @@ If groups don't appear, check the **Push Groups** status column in Okta for erro
 
 Renames and deletes propagate automatically:
 
-- **Rename** — the next SCIM push updates the catalog row's display name. Delegated Teams that reference the group continue to work without interruption.
-- **Delete** — Okta issues a SCIM `DELETE` for the group. Seqera removes the catalog row and synchronously purges members from any delegated Team that referenced it. The affected Teams remain in place with empty membership and an orphaned-team warning, so you can re-delegate them or revert to manual management.
+- **Rename**: The next SCIM push updates the catalog row's display name. Delegated teams that reference the group continue to work without interruption.
+- **Delete**: Okta issues a SCIM `DELETE` for the group. Platform removes the catalog row and synchronously purges members from any delegated Team that referenced it. The affected teams remain in place with empty membership and an orphaned-team warning, so you can re-delegate them or revert to manual management.
 
 ## Troubleshooting
 
-### Groups appear in Okta but not in Seqera
+### Groups appear in Okta but not in Platform
 
-Confirm the bearer token in Okta matches the latest token Seqera issued. If you generated a new token after configuring Okta, the previous one is revoked.
+Confirm the bearer token in Okta matches the latest token issued. If you generated a new token after configuring Okta, the previous one is revoked.
 
 ### `401 Unauthorized` from Okta logs
 
-The bearer token is invalid or expired. Generate a new token in Seqera and replace it in Okta.
+The bearer token is invalid or expired. Generate a new token and replace it in Okta.
 
 ### `409 Conflict` on a specific group
 

--- a/platform-cloud/docs/getting-started/idp-delegation/group-catalog/scim-okta.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/group-catalog/scim-okta.md
@@ -1,0 +1,72 @@
+---
+title: "SCIM provisioning with Okta"
+description: "Configure Okta to push group memberships to Seqera over SCIM 2.0."
+date created: "2026-05-12"
+last updated: "2026-05-12"
+tags: [sso, scim, okta, idp-delegation, administration, cloud-pro]
+---
+
+Configure Okta to push your organization's groups to Seqera over SCIM 2.0. Once provisioning is enabled, your Okta group directory appears in Seqera's IdP group catalog and stays in sync with renames, additions, and deletions automatically.
+
+## Before you begin
+
+- An Okta application configured as your Seqera SSO connection. To set up SSO, see [Single sign-on (SSO)](../../single-sign-on).
+- Organization owner access to your Seqera organization.
+- Administrator access to your Okta tenant.
+
+## Get the Seqera SCIM connection details
+
+1. In Seqera, open **Organization settings** and select **Manage single sign-on**, then **Group mapping**.
+2. Copy the **SCIM endpoint URL** — it has the form `https://<seqera-host>/orgs/<orgId>/scim/v2/Groups`.
+3. Select **Generate token** to issue a SCIM bearer token. Copy it immediately; you can't view it again after closing the dialog.
+
+:::caution
+The bearer token grants write access to your group catalog. Store it in a secrets manager and rotate it on a schedule. To rotate, generate a new token in Seqera and update Okta's configuration; the previous token is revoked when the new one is issued.
+:::
+
+## Enable provisioning in Okta
+
+1. Sign in to your Okta administrator console.
+2. Open **Applications**, then select the application that fronts your Seqera SSO connection.
+3. Open the **Provisioning** tab and select **Configure API integration**.
+4. Select **Enable API integration** and provide:
+   - **Base URL** — the Seqera SCIM endpoint URL from the previous section, with `/Groups` removed (Okta appends the resource path).
+   - **API token** — the Seqera bearer token from the previous section.
+5. Select **Test API Credentials**. Okta should report a successful connection.
+6. Save.
+
+## Enable group push
+
+1. With the application still open, switch to the **Push Groups** tab.
+2. Select **Push Groups**, then **Find groups by name** (or **By rule** for dynamic group sets).
+3. Select the Okta groups you want available in Seqera.
+4. Confirm the push. Okta sends an initial provisioning batch.
+
+## Verify in Seqera
+
+1. Return to Seqera's **Group mapping** panel.
+2. Refresh the page. The pushed Okta groups should appear in the catalog list within a few seconds.
+3. Open any Team's edit form. The **IdP Group** dropdown is now populated with the synced groups.
+
+If groups don't appear, check the **Push Groups** status column in Okta for error details, and confirm that the **Provisioning** tab shows **Push Groups: ON**.
+
+## Group rename and delete behavior
+
+Renames and deletes propagate automatically:
+
+- **Rename** — the next SCIM push updates the catalog row's display name. Delegated Teams that reference the group continue to work without interruption.
+- **Delete** — Okta issues a SCIM `DELETE` for the group. Seqera removes the catalog row and synchronously purges members from any delegated Team that referenced it. The affected Teams remain in place with empty membership and an orphaned-team warning, so you can re-delegate them or revert to manual management.
+
+## Troubleshooting
+
+### Groups appear in Okta but not in Seqera
+
+Confirm the bearer token in Okta matches the latest token Seqera issued. If you generated a new token after configuring Okta, the previous one is revoked.
+
+### `401 Unauthorized` from Okta logs
+
+The bearer token is invalid or expired. Generate a new token in Seqera and replace it in Okta.
+
+### `409 Conflict` on a specific group
+
+A group with the same display name already exists in another organization on the same instance. This applies to Seqera Platform Enterprise multi-organization deployments only. Cloud Pro organizations are scoped by `org_id` and aren't affected.

--- a/platform-cloud/docs/getting-started/idp-delegation/overview.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/overview.md
@@ -6,12 +6,12 @@ last updated: "2026-05-12"
 tags: [sso, idp-delegation, teams, administration, cloud-pro]
 ---
 
-IdP delegation lets you map a Seqera Team to a group in your identity provider (IdP). After you delegate a Team, the IdP becomes the sole authority for membership: every time a user signs in through SSO, Seqera reads the `groups` claim from their token and updates the user's delegated-Team memberships to match.
+IdP delegation lets you map a Seqera team to a group in your identity provider (IdP). After you delegate a team, the IdP becomes the sole authority for membership: every time a user signs in through SSO, Seqera reads the `groups` claim from their token and updates the user's delegated-team memberships to match.
 
 IdP delegation is available on **Cloud Pro** organizations with an active SSO connection. To set up SSO before configuring delegation, see [Single sign-on (SSO)](../single-sign-on).
 
 :::info
-Cloud Basic organizations see an upgrade prompt when an owner attempts to set the **IdP Group** field on a Team. To use IdP delegation, upgrade to Cloud Pro and configure SSO first.
+Cloud Basic organizations see an upgrade prompt when an owner attempts to set the **IdP Group** field on a team. To use IdP delegation, upgrade to Cloud Pro and configure SSO first.
 :::
 
 ## How it works
@@ -20,59 +20,59 @@ Delegation has three components that you configure once per organization.
 
 ### 1. The IdP group catalog
 
-Seqera maintains a per-organization catalog of IdP groups. The catalog populates the **IdP Group** dropdown on the Team form, so organization owners can select an IdP group when delegating a Team. Groups appear in the catalog as soon as they're synced or entered — before any user has signed in.
+Seqera maintains a per-organization catalog of IdP groups. The catalog populates the **IdP Group** dropdown on the team form, so organization owners can select an IdP group when delegating a team. Groups appear in the catalog as soon as they're synced or entered, before any user has signed in.
 
 The catalog is populated in one of two ways:
 
-- **SCIM 2.0 push** — your IdP pushes its group directory to Seqera's per-organization SCIM endpoint. Used with Okta and Entra ID.
-- **Manual entry** — for IdPs that don't support SCIM group sync (Google Workspace, Keycloak), an organization owner enters group identifiers in the catalog UI.
+- **SCIM 2.0 push**: Your IdP pushes its group directory to Seqera's per-organization SCIM endpoint. Used with Okta and Entra ID.
+- **Manual entry**: For IdPs that don't support SCIM group sync (Google Workspace, Keycloak), an organization owner enters group identifiers in the catalog UI.
 
 A manually-entered group is automatically promoted to SCIM-managed if your IdP later pushes the same group. See [Manage your IdP group catalog](./group-catalog/overview).
 
 ### 2. The `groups` claim
 
-At login, Seqera reads the user's IdP claims to decide which delegated Teams they belong to. The `groups` claim must be present in the token issued by Auth0, and its values must match the group identifiers in your catalog.
+At login, Seqera reads the user's IdP claims to decide which delegated teams they belong to. The `groups` claim must be present in the token issued by Auth0, and its values must match the group identifiers in your catalog.
 
 This requires an attribute mapping on the Auth0 SSO connection. See [Auth0 connection mapping](./auth0-connection-mapping).
 
-### 3. The Team's `IdP Group` field
+### 3. The team's `IdP Group` field
 
-When an organization owner sets the **IdP Group** field on a Team, the Team becomes delegated. This:
+When an organization owner sets the **IdP Group** field on a team, the team becomes delegated. This:
 
-- Marks the Team as "Managed in IdP" in the Teams list.
+- Marks the team as "Managed in IdP" in the teams list.
 - Hides the **Add member** and **Remove member** controls.
-- Blocks Team deletion until the field is cleared.
-- Leaves the Team's name, description, avatar, and workspace assignments editable.
+- Blocks team deletion until the field is cleared.
+- Leaves the team's name, description, avatar, and workspace assignments editable.
 
-The same IdP group can be assigned to more than one Team. Each Team can reference exactly one IdP group. See [Delegate a Team to an IdP group](./delegate-a-team).
+The same IdP group can be assigned to more than one team. Each team can reference exactly one IdP group. See [Delegate a team to an IdP group](./delegate-a-team).
 
 ## What happens at login
 
-On every SSO login, Seqera evaluates each delegated Team in your organization against the user's `groups` claim:
+On every SSO login, Seqera evaluates each delegated team in your organization against the user's `groups` claim:
 
-- **Match found** — the user is added to the Team if they aren't already a member.
-- **No match** and the user was previously a member — they're removed from the Team.
-- **No match** and the user was never a delegation-driven member — no change.
+- **Match found**: The user is added to the Team if they aren't already a member.
+- **No match**: If the user was previously a member they're removed from the team.
+- **No match**: If the user was never a delegation-driven member there is no change.
 
-Manual assignments to non-delegated Teams are never touched by this evaluation. Users added manually to a Team with no **IdP Group** value keep their membership regardless of their IdP claims.
+Manual assignments to non-delegated teams are never touched by this evaluation. Users added manually to a team with no **IdP Group** value keep their membership regardless of their IdP claims.
 
-If the user's token has no `groups` claim or the claim is malformed, Seqera treats it as no group memberships and revokes any delegation-driven Team memberships the user previously had.
+If the user's token has no `groups` claim or the claim is malformed, it's treated as no group memberships and revokes any delegation-driven team memberships the user previously had.
 
 ## Audit trail
 
 Delegation activity is recorded in the audit log:
 
-- Setting, changing, or clearing the **IdP Group** field on a Team produces a `team_updated` event with the previous and new value.
+- Setting, changing, or clearing the **IdP Group** field on a team produces a `team_updated` event with the previous and new value.
 - Each delegation-driven membership change at login produces a `team_member_added` or `team_member_removed` event.
 - Group catalog operations (create, rename, delete) produce `scimGroupCreated`, `scimGroupUpdated`, and `scimGroupDeleted` events so you can correlate catalog changes with downstream membership changes.
 
-SCIM-originated entries — operations performed by your IdP's provisioning agent against Seqera's SCIM endpoint — are attributed to a **System** operator rather than to a named administrator, because they authenticate with a SCIM bearer token. To correlate a SCIM event with a specific administrator action in your IdP, match by `displayName` and timestamp against your IdP's provisioning logs.
+SCIM-originated entries - operations performed by your IdP's provisioning agent against Seqera's SCIM endpoint - are attributed to a **System** operator rather than to a named administrator, because they authenticate with a SCIM bearer token. To correlate a SCIM event with a specific administrator action in your IdP, match by `displayName` and timestamp against your IdP's provisioning logs.
 
 ## Set up delegation
 
 Complete these steps in order. Each step links to a dedicated guide.
 
 1. [Configure SSO](../single-sign-on) for your organization if you haven't already.
-2. [Populate the IdP group catalog](./group-catalog/overview) — choose SCIM push or manual entry depending on your IdP.
+2. [Populate the IdP group catalog](./group-catalog/overview). Choose SCIM push or manual entry depending on your IdP.
 3. [Map your IdP's `groups` claim through Auth0](./auth0-connection-mapping) so it reaches Seqera at login.
-4. [Delegate a Team to an IdP group](./delegate-a-team).
+4. [Delegate a team to an IdP group](./delegate-a-team).

--- a/platform-cloud/docs/getting-started/idp-delegation/overview.md
+++ b/platform-cloud/docs/getting-started/idp-delegation/overview.md
@@ -1,0 +1,78 @@
+---
+title: "IdP delegation overview"
+description: "Map Seqera Teams to identity provider (IdP) groups so membership is controlled at the IdP and evaluated on every SSO login."
+date created: "2026-05-12"
+last updated: "2026-05-12"
+tags: [sso, idp-delegation, teams, administration, cloud-pro]
+---
+
+IdP delegation lets you map a Seqera Team to a group in your identity provider (IdP). After you delegate a Team, the IdP becomes the sole authority for membership: every time a user signs in through SSO, Seqera reads the `groups` claim from their token and updates the user's delegated-Team memberships to match.
+
+IdP delegation is available on **Cloud Pro** organizations with an active SSO connection. To set up SSO before configuring delegation, see [Single sign-on (SSO)](../single-sign-on).
+
+:::info
+Cloud Basic organizations see an upgrade prompt when an owner attempts to set the **IdP Group** field on a Team. To use IdP delegation, upgrade to Cloud Pro and configure SSO first.
+:::
+
+## How it works
+
+Delegation has three components that you configure once per organization.
+
+### 1. The IdP group catalog
+
+Seqera maintains a per-organization catalog of IdP groups. The catalog populates the **IdP Group** dropdown on the Team form, so organization owners can select an IdP group when delegating a Team. Groups appear in the catalog as soon as they're synced or entered — before any user has signed in.
+
+The catalog is populated in one of two ways:
+
+- **SCIM 2.0 push** — your IdP pushes its group directory to Seqera's per-organization SCIM endpoint. Used with Okta and Entra ID.
+- **Manual entry** — for IdPs that don't support SCIM group sync (Google Workspace, Keycloak), an organization owner enters group identifiers in the catalog UI.
+
+A manually-entered group is automatically promoted to SCIM-managed if your IdP later pushes the same group. See [Manage your IdP group catalog](./group-catalog/overview).
+
+### 2. The `groups` claim
+
+At login, Seqera reads the user's IdP claims to decide which delegated Teams they belong to. The `groups` claim must be present in the token issued by Auth0, and its values must match the group identifiers in your catalog.
+
+This requires an attribute mapping on the Auth0 SSO connection. See [Auth0 connection mapping](./auth0-connection-mapping).
+
+### 3. The Team's `IdP Group` field
+
+When an organization owner sets the **IdP Group** field on a Team, the Team becomes delegated. This:
+
+- Marks the Team as "Managed in IdP" in the Teams list.
+- Hides the **Add member** and **Remove member** controls.
+- Blocks Team deletion until the field is cleared.
+- Leaves the Team's name, description, avatar, and workspace assignments editable.
+
+The same IdP group can be assigned to more than one Team. Each Team can reference exactly one IdP group. See [Delegate a Team to an IdP group](./delegate-a-team).
+
+## What happens at login
+
+On every SSO login, Seqera evaluates each delegated Team in your organization against the user's `groups` claim:
+
+- **Match found** — the user is added to the Team if they aren't already a member.
+- **No match** and the user was previously a member — they're removed from the Team.
+- **No match** and the user was never a delegation-driven member — no change.
+
+Manual assignments to non-delegated Teams are never touched by this evaluation. Users added manually to a Team with no **IdP Group** value keep their membership regardless of their IdP claims.
+
+If the user's token has no `groups` claim or the claim is malformed, Seqera treats it as no group memberships and revokes any delegation-driven Team memberships the user previously had.
+
+## Audit trail
+
+Delegation activity is recorded in the audit log:
+
+- Setting, changing, or clearing the **IdP Group** field on a Team produces a `team_updated` event with the previous and new value.
+- Each delegation-driven membership change at login produces a `team_member_added` or `team_member_removed` event.
+- Group catalog operations (create, rename, delete) produce `scimGroupCreated`, `scimGroupUpdated`, and `scimGroupDeleted` events so you can correlate catalog changes with downstream membership changes.
+
+SCIM-originated entries — operations performed by your IdP's provisioning agent against Seqera's SCIM endpoint — are attributed to a **System** operator rather than to a named administrator, because they authenticate with a SCIM bearer token. To correlate a SCIM event with a specific administrator action in your IdP, match by `displayName` and timestamp against your IdP's provisioning logs.
+
+## Set up delegation
+
+Complete these steps in order. Each step links to a dedicated guide.
+
+1. [Configure SSO](../single-sign-on) for your organization if you haven't already.
+2. [Populate the IdP group catalog](./group-catalog/overview) — choose SCIM push or manual entry depending on your IdP.
+3. [Map your IdP's `groups` claim through Auth0](./auth0-connection-mapping) so it reaches Seqera at login.
+4. [Delegate a Team to an IdP group](./delegate-a-team).

--- a/platform-cloud/docs/orgs-and-teams/organizations.md
+++ b/platform-cloud/docs/orgs-and-teams/organizations.md
@@ -65,6 +65,10 @@ For information about what happens when a user deletes their account, see [user 
 
 **Teams** allow organization **owners** to group members and collaborators together into a single unit and to manage them as a whole.
 
+:::note
+If your organization has [single sign-on (SSO)](../getting-started/single-sign-on) configured, the Team form includes an **IdP Group** field. Leave it empty to manage Team membership manually, or select an IdP group to delegate membership to your identity provider. See [Delegate a Team to an IdP group](../getting-started/idp-delegation/delegate-a-team).
+:::
+
 ### Create a new team
 
 To create a new team:
@@ -76,6 +80,12 @@ To create a new team:
 5. Select **Add**.
 
 To start adding members to your team, select **Edit > Members of team > Add member** and enter the name or email address of the organization members or collaborators.
+
+### Delegate a Team to an IdP group
+
+Cloud Pro organizations with an active SSO connection can delegate Team membership to an identity provider (IdP) group. Once a Team is delegated, the IdP becomes the sole authority for who belongs — Seqera evaluates each user's IdP claims at every login and adjusts membership automatically. The Team's manual **Add member** and **Remove member** controls are hidden while delegation is active.
+
+For the full procedure and how delegation evaluates at login, see [Delegate a Team to an IdP group](../getting-started/idp-delegation/delegate-a-team).
 
 ## Collaborators
 


### PR DESCRIPTION
## Summary

Customer-facing documentation for [PLAT-4827](https://seqera.atlassian.net/browse/PLAT-4827) — IdP delegation & claims mapping on Cloud Pro. Builds on top of the merged Cloud SSO foundation in #1213.

This PR adds the documentation layer that explains how organization owners can map a Seqera Team to an IdP group, populate the group catalog (SCIM or manual), and configure the Auth0 attribute mapping that lets the \`groups\` claim reach Seqera at login.

## Pages added

Under [platform-cloud/docs/getting-started/idp-delegation/](https://github.com/seqeralabs/docs/tree/plat-4827-cloud-idp-delegation/platform-cloud/docs/getting-started/idp-delegation):

- \`overview.md\` — concept hub: the three components, login evaluation, audit trail
- \`group-catalog/overview.md\` — SCIM vs manual entry, promotion, orphan behavior
- \`group-catalog/scim-okta.md\` — full Okta SCIM setup procedure
- \`group-catalog/scim-entra-id.md\` — full Entra ID SCIM setup procedure
- \`group-catalog/manual-google-workspace.md\` — manual catalog entries for Google Workspace
- \`group-catalog/manual-keycloak.md\` — manual catalog entries for Keycloak
- \`auth0-connection-mapping.md\` — copy-paste OIDC and SAML attribute mapping snippets
- \`delegate-a-team.md\` — admin procedure plus what changes at login

## Pages updated

- \`platform-cloud/cloud-sidebar.json\` — new **IdP delegation** category nested in **Get started**
- \`platform-cloud/docs/orgs-and-teams/organizations.md\` — Teams section note + cross-link to the delegation procedure

## AC coverage (PLAT-4827)

| User story | Covered in |
|------------|------------|
| US1 / PLAT-5164 — Connect IdP groups | \`group-catalog/*\` |
| US2 / PLAT-5165 — Delegate a Team | \`delegate-a-team.md\`, \`organizations.md\` |
| US3 / PLAT-5166 — Login JIT evaluation | \`overview.md\`, \`delegate-a-team.md\` |
| US4 / PLAT-5167 — Immutability | \`delegate-a-team.md\` |
| US5 / PLAT-5168 — Audit trail (delegation/SCIM) | \`overview.md\` — \"Audit trail\" |
| US6 / PLAT-5169 — Cloud Basic upgrade prompt | \`overview.md\` info admonition |
| US7 / PLAT-5170 — Collaborator restriction | Covered by existing \`single-sign-on.md\` and \`roles.md\` (#1213) |
| USV / PLAT-5172 — Auth0 mapping copy-paste-ready | \`auth0-connection-mapping.md\` |

## Out of scope

- **US8 / PLAT-5171** — workspace assignment usability content is blocked on Figma. Will follow in a separate PR once UX assets land.
- **Audit log page** — Cloud doesn't have a dedicated audit-log doc; SCIM/delegation audit content sits in \`overview.md\` instead. If a Cloud audit-log page is added later, the section here can be lifted.
- **Changelog entries** — landing separately.

## Open questions for product/engineering

1. **PLAT-5238 expectation-setting** — should the Auth0 mapping page include a callout noting the wizard will pre-fill these snippets in a future release? Currently silent.
2. **Screenshots** — PLAT-5172 AC 1 implies the SCIM and Auth0 guides should be sufficient for setup without backend assistance. Would screenshots of the Okta, Entra, and Auth0 admin consoles raise the bar enough to commission them? Currently none.
3. **Auth0 mapping for Enterprise-on-Auth0 customers** — out of scope for this Cloud PR but flagged for the Enterprise companion PR.

## Reviewers

CODEOWNERS will auto-request docs reviewers. Please also add:

- A PLAT-4827 SME (Andrew Dawson reported the epic; Rob Newman commented on it)

## Test plan

- [ ] Local Docusaurus build (\`npm start\` or \`npm run build\` from repo root)
- [ ] All internal markdown links resolve
- [ ] New sidebar entries render in correct order under **Get started → IdP delegation**
- [ ] Cross-links from \`organizations.md\` and \`single-sign-on.md\` navigate correctly

Companion Enterprise PR: \`justine-idp-enterprise\` against \`enterprise-26.1-documentation\` (separate PR for the 26.1 release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PLAT-4827]: https://seqera.atlassian.net/browse/PLAT-4827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ