### PR TITLE
fix: typos in cloud lineage and launch docs

### DIFF
--- a/platform-cloud/docs/launch/launchpad.md
+++ b/platform-cloud/docs/launch/launchpad.md
@@ -42,7 +42,7 @@ The launch form accepts URL query parameters. See [Populate launch form with URL
 - **Commit ID**: Pin pipeline revision to the most recent HEAD commit ID. If no commit ID is pinned, the latest revision of the repository branch or tag is used.
 - **Pull latest**: Fetch the most recent HEAD commit ID of the pipeline revision at launch time. Unpins the **Commit ID**, if set.
   :::info
-  See [Git revision management][pipeline-revision] for more information on **Revision**, **Commit ID**, and **Pull latest**, behavior.
+  See [Git revision management][pipeline-revision] for more information on **Revision**, **Commit ID**, and **Pull latest** behavior.
   :::
 - **Work directory**: The cloud storage or file system path where pipeline scratch data is stored. Seqera will create a scratch sub-folder if only a cloud bucket location is specified. Use file system paths for local or HPC compute environments.
   :::note

--- a/platform-cloud/docs/orgs-and-teams/workspace-management.md
+++ b/platform-cloud/docs/orgs-and-teams/workspace-management.md
@@ -88,7 +88,7 @@ If configuring **manually**, two additional settings can be defined:
 | Field | Required | Description |
 |-------|----------|-------------|
 | **SQS Queue name** | No | The Amazon Simple Queue Service (SQS) name. If left empty, Platform generates a default queue name in the form `<bucket-name>-notifications`. |
-| **SQS Quene ARN** | No | The ARN of the SQS queue. This is useful if you Platform deployment requires cross-account access. |
+| **SQS Queue ARN** | No | The ARN of the SQS queue. This is useful if your Platform deployment requires cross-account access. |
 
 #### Credentials
 


### PR DESCRIPTION
## Summary

Cleans up three small typos introduced in #1435:

- `SQS Quene ARN` → `SQS Queue ARN` (workspace lineage settings table)
- `if you Platform deployment` → `if your Platform deployment` (same table)
- Stray comma in the launchpad revision tip: `**Pull latest**, behavior` → `**Pull latest** behavior`

Equivalent fixes are being applied to `platform-enterprise_docs/` on the in-flight enterprise 26.1 docs branch.

## Test plan

- [ ] Netlify preview renders the **Lineage** table without the misspelling
- [ ] Launchpad revision tip reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)