### PR TITLE
Port cloud datasets page updates to enterprise 26.1

### DIFF
--- a/platform-enterprise_docs/data/datasets.md
+++ b/platform-enterprise_docs/data/datasets.md
@@ -68,7 +68,7 @@ Seqera doesn't validate your dataset file contents. While datasets can contain s
 All Seqera user roles have access to the datasets feature in organization workspaces. There are two ways to add a dataset:
 
 1. Direct upload: This is the best option if immutability is a requirement but size cannot exceed 10 MB.
-1. Link to an externally hosted file: This is the best option for very large size files but relies on the external hosting service for availability and immutability.
+2. Link to an externally hosted file: This is the best option for very large size files but relies on the external hosting service for availability and immutability.
 
 ### Direct upload
 

--- a/platform-enterprise_docs/data/datasets.md
+++ b/platform-enterprise_docs/data/datasets.md
@@ -106,10 +106,10 @@ For linked datasets, versioning is unavailable.
 ### Add a dataset version
 
 1. Select the three dots next to the dataset you want to add a new version for.
-1. Select **Add version**.
-2. Upload a dataset to your workspace with drag-and-drop or use the system **Upload file** file explorer dialog.
-3. For datasets that use their first row for column names, customize the dataset view using the **Set first row as header** option.
-4. Select **Add**.
+2. Select **Add version**.
+3. Upload a dataset to your workspace with drag-and-drop or use the system **Upload file** file explorer dialog.
+4. For datasets that use their first row for column names, customize the dataset view using the **Set first row as header** option.
+5. Select **Add**.
 
 :::caution
 All subsequent versions of a dataset must be the same format (CSV or TSV) as the initial version.

--- a/platform-enterprise_docs/data/datasets.md
+++ b/platform-enterprise_docs/data/datasets.md
@@ -87,13 +87,13 @@ The size of the uploaded dataset file cannot exceed 10 MB.
 ### Link to an externally hosted file
 
 1. In the sidebar navigation, select **Datasets**.
-1. Select **Add Dataset** and choose **Link to URL**.
-1. Complete the **Name** and **Description** fields using information relevant to your dataset.
-1. Optionally add one or more **Labels** to your dataset. You can use labels as a search filter but they don't apply to other resources in Seqera.
-1. Copy and paste the dataset URL into the **Dataset URL** field.
-1. For datasets that use their first row for column names, customize the dataset view using the **Set first row as header** option.
-1. Select **Add**.
-1. The dataset will be displayed with a `Linked` badge for easy identification.
+2. Select **Add Dataset** and choose **Link to URL**.
+3. Complete the **Name** and **Description** fields using information relevant to your dataset.
+4. Optionally add one or more **Labels** to your dataset. You can use labels as a search filter but they don't apply to other resources in Seqera.
+5. Copy and paste the dataset URL into the **Dataset URL** field.
+6. For datasets that use their first row for column names, customize the dataset view using the **Set first row as header** option.
+7. Select **Add**.
+8. The dataset will be displayed with a `Linked` badge for easy identification.
 
 ## Manage dataset versions
 

--- a/platform-enterprise_docs/data/datasets.md
+++ b/platform-enterprise_docs/data/datasets.md
@@ -73,12 +73,12 @@ All Seqera user roles have access to the datasets feature in organization worksp
 ### Direct upload
 
 1. In the sidebar navigation, select **Datasets**.
-1. Select **Add Dataset** and choose **Upload file**.
-1. Complete the **Name** and **Description** fields using information relevant to your dataset.
-1. Optionally add one or more **Labels** to your dataset. You can use labels as a search filter but they don't apply to other resources in Seqera.
-1. Upload a dataset to your workspace with drag-and-drop or use the **Upload file** file explorer dialog.
-1. For datasets that use their first row for column names, customize the dataset view using the **Set first row as header** option.
-1. Select **Add**.
+2. Select **Add Dataset** and choose **Upload file**.
+3. Complete the **Name** and **Description** fields using information relevant to your dataset.
+4. Optionally add one or more **Labels** to your dataset. You can use labels as a search filter but they don't apply to other resources in Seqera.
+5. Upload a dataset to your workspace with drag-and-drop or use the **Upload file** file explorer dialog.
+6. For datasets that use their first row for column names, customize the dataset view using the **Set first row as header** option.
+7. Select **Add**.
 
 :::warning
 The size of the uploaded dataset file cannot exceed 10 MB.

--- a/platform-enterprise_docs/data/datasets.md
+++ b/platform-enterprise_docs/data/datasets.md
@@ -31,7 +31,7 @@ On the datasets screen, you can:
 
 ## Format
 
-The most commonly used datasets for Nextflow pipelines are samplesheets, where each row consists of a sample, the location of files for that sample (such as FASTQ files), and other sample details. For example, [*nf-core/rnaseq*](https://github.com/nf-core/rnaseq) works with input datasets (samplesheets) containing sample names, FASTQ file locations, and indications of strandedness. The Seqera Community Showcase sample dataset for *nf-core/rnaseq* looks like this:
+The most commonly used datasets for Nextflow pipelines are sample sheets, where each row consists of a sample identifier, the location of the sample's files (e.g., FASTQ files), and other sample details. For example, [*nf-core/rnaseq*](https://github.com/nf-core/rnaseq) works with input datasets (sample sheets) that include sample names, FASTQ file locations, and strandedness annotations. The Seqera Community Showcase sample dataset for *nf-core/rnaseq* looks like this:
 
 **Example rnaseq dataset**
 

--- a/platform-enterprise_docs/data/datasets.md
+++ b/platform-enterprise_docs/data/datasets.md
@@ -140,8 +140,8 @@ Once disabled, a dataset version cannot be re-enabled.
 To use a dataset with pipelines added to your workspace:
 
 1. Open any pipeline that contains a pipeline schema from the [Launchpad](../launch/launchpad).
-1. Select the input field for the pipeline, removing any default values.
-1. Pick the dataset to use as input to your pipeline.
+2. Select the input field for the pipeline, removing any default values.
+3. Pick the dataset to use as input to your pipeline.
 
 :::note
 The input field drop-down menu will only display datasets that match the file type specified in the `nextflow_schema.json` of the chosen pipeline. If the schema specifies `"mimetype": "text/csv"`, no TSV datasets will be available for use with that pipeline, and vice-versa. If multiple dataset versions exist, the pipeline input will always default to the **latest** version.

--- a/platform-enterprise_docs/data/datasets.md
+++ b/platform-enterprise_docs/data/datasets.md
@@ -2,7 +2,7 @@
 title: "Datasets"
 description: "Using datasets in Seqera Platform."
 date created: "2023-04-23"
-last updated: "2025-10-30"
+last updated: "2026-05-18"
 tags: [datasets, manage-datasets, create-datasets, add-dataset-version]
 ---
 
@@ -10,19 +10,28 @@ tags: [datasets, manage-datasets, create-datasets, add-dataset-version]
 This feature is only available in organization workspaces.
 :::
 
-Datasets in Seqera are CSV (comma-separated values) and TSV (tab-separated values) files stored in a workspace. They are used as inputs to pipelines to simplify data management, minimize user data-input errors, and facilitate reproducible workflows.
+Datasets are CSV (comma-separated values) and TSV (tab-separated values) files stored in, or linked to, a workspace. They are used as inputs to pipelines to simplify data management, minimize user data-input errors, and facilitate reproducible workflows.
 
 On the datasets screen, you can:
 
+- Upload directly or link to an externally hosted dataset.
 - View the count of pipeline runs in the workspace that have used a specific dataset input.
 - Apply multiple labels to datasets for easier searching and grouping.
 - Sort datasets by name, most recently updated, and most recently used.
 - Hide datasets that are not used in the workspace.
 - View dataset metadata (created by, last updated, last used).
 - Edit dataset details (name, description, and labels).
-- Upload new versions of a dataset.
+- Create new versions of an uploaded dataset.
 
-The most commonly used datasets for Nextflow pipelines are samplesheets, where each row consists of a sample, the location of files for that sample (such as FASTQ files), and other sample details. For example, [nf-core/rnaseq](https://github.com/nf-core/rnaseq) works with input datasets (samplesheets) containing sample names, FASTQ file locations, and indications of strandedness. The Seqera Community Showcase sample dataset for _nf-core/rnaseq_ looks like this:
+## Benefits
+
+- Datasets reduce errors that occur due to manual data entry when you launch pipelines.
+- Datasets can be generated automatically in response to events (such as S3 storage new file notifications).
+- Datasets can streamline differential data analysis when using the same pipeline to launch a run for each dataset as it becomes available.
+
+## Format
+
+The most commonly used datasets for Nextflow pipelines are samplesheets, where each row consists of a sample, the location of files for that sample (such as FASTQ files), and other sample details. For example, [*nf-core/rnaseq*](https://github.com/nf-core/rnaseq) works with input datasets (samplesheets) containing sample names, FASTQ file locations, and indications of strandedness. The Seqera Community Showcase sample dataset for *nf-core/rnaseq* looks like this:
 
 **Example rnaseq dataset**
 
@@ -40,53 +49,73 @@ The most commonly used datasets for Nextflow pipelines are samplesheets, where e
 Use [Data Explorer](../data/data-explorer) to browse for cloud storage objects directly and copy the object paths to be used in your datasets.
 :::
 
-The combination of datasets, [secrets](../secrets/overview), and [actions](../pipeline-actions/overview) in the application allows you to automate workflows to curate your data and maintain and launch pipelines based on specific events. See [here](https://seqera.io/blog/workflow-automation/) for an example of pipeline workflow automation using Seqera.
+### Automation and pipeline schemas
 
-- Datasets reduce errors that occur due to manual data entry when you launch pipelines.
-- Datasets can be generated automatically in response to events (such as S3 storage new file notifications).
-- Datasets can streamline differential data analysis when using the same pipeline to launch a run for each dataset as it becomes available.
+The combination of datasets, [secrets](../secrets/overview), and [actions](../pipeline-actions/overview) allows you to automate workflows to curate your data and maintain and launch pipelines based on specific events. See [workflow-automation](https://seqera.io/blog/workflow-automation/) for an example of pipeline workflow automation.
 
 For your pipeline to use your dataset as input during runtime, information about the dataset and file format must be included in the relevant parameters of your [pipeline schema](../pipeline-schema/overview). The pipeline schema specifies the accepted dataset file type in the `mimetype` attribute (either `text/csv` or `text/tsv`).
 
-## Dataset validation and file content requirements
+## Dataset file content requirements and validation
 
-Seqera doesn't validate your dataset file contents. While datasets can contain static file links, you're responsible for maintaining the access to that data.
-
-Datasets can point to files stored in various locations, such as Amazon S3 or GitHub. To stage the file paths defined in the dataset, Nextflow requires access to the infrastructure where the files reside, whether on cloud or HPC systems. Add the access keys for data sources that require authentication to your [secrets](../secrets/overview).
-
-## Create a dataset
-
-All Seqera user roles have access to the datasets feature in organization workspaces.
+Datasets can point to files stored in various locations, such as Amazon S3, GitHub, or Hugging Face. To stage the file paths defined in the dataset, Nextflow requires access to the infrastructure where the files reside, whether on cloud or HPC systems. Add the access keys for data sources that require authentication to your [secrets](../secrets/overview).
 
 :::note
-The size of the dataset file cannot exceed 10 MB.
+Seqera doesn't validate your dataset file contents. While datasets can contain static file links, you're responsible for maintaining the access to that data.
 :::
 
-1. In the sidebar navigation, select the **Datasets** link under the Data heading in your organization workspace.
-2. Select **Add Dataset**.
-3. Complete the **Name** and **Description** fields using information relevant to your dataset.
-4. Optionally add one or more **Labels** to your dataset. You can use labels as a search filter but they don't apply to other resources in Seqera.
-4. Upload a dataset to your workspace with drag-and-drop or use the system **Upload file** file explorer dialog.
-5. For datasets that use their first row for column names, customize the dataset view using the **Set first row as header** option.
-6. Select **Add**.
+## Add a dataset
+
+All Seqera user roles have access to the datasets feature in organization workspaces. There are two ways to add a dataset:
+
+1. Direct upload: This is the best option if immutability is a requirement but size cannot exceed 10 MB.
+1. Link to an externally hosted file: This is the best option for very large size files but relies on the external hosting service for availability and immutability.
+
+### Direct upload
+
+1. In the sidebar navigation, select **Datasets**.
+1. Select **Add Dataset** and choose **Upload file**.
+1. Complete the **Name** and **Description** fields using information relevant to your dataset.
+1. Optionally add one or more **Labels** to your dataset. You can use labels as a search filter but they don't apply to other resources in Seqera.
+1. Upload a dataset to your workspace with drag-and-drop or use the **Upload file** file explorer dialog.
+1. For datasets that use their first row for column names, customize the dataset view using the **Set first row as header** option.
+1. Select **Add**.
+
+:::warning
+The size of the uploaded dataset file cannot exceed 10 MB.
+:::
+
+### Link to an externally hosted file
+
+1. In the sidebar navigation, select **Datasets**.
+1. Select **Add Dataset** and choose **Link to URL**.
+1. Complete the **Name** and **Description** fields using information relevant to your dataset.
+1. Optionally add one or more **Labels** to your dataset. You can use labels as a search filter but they don't apply to other resources in Seqera.
+1. Copy and paste the dataset URL into the **Dataset URL** field.
+1. For datasets that use their first row for column names, customize the dataset view using the **Set first row as header** option.
+1. Select **Add**.
+1. The dataset will be displayed with a `Linked` badge for easy identification.
 
 ## Manage dataset versions
 
-Seqera can manage multiple versions of an existing dataset.
+For directly uploaded datasets, Seqera can manage multiple versions.
 
-### Adding a dataset version
+:::note
+For linked datasets, versioning is unavailable.
+:::
+
+### Add a dataset version
 
 1. Select the three dots next to the dataset you want to add a new version for.
-2. Select **Add version**.
-3. Upload a dataset to your workspace with drag-and-drop or use the system **Upload file** file explorer dialog.
-4. For datasets that use their first row for column names, customize the dataset view using the **Set first row as header** option.
-5. Select **Add**.
+1. Select **Add version**.
+1. Upload a dataset to your workspace with drag-and-drop or use the system **Upload file** file explorer dialog.
+1. For datasets that use their first row for column names, customize the dataset view using the **Set first row as header** option.
+1. Select **Add**.
 
 :::caution
 All subsequent versions of a dataset must be the same format (CSV or TSV) as the initial version.
 :::
 
-### Viewing dataset versions
+### View dataset versions
 
 To see all versions of a dataset, use the **Show** drop-down menu in the **Preview** tab. A preview of the most recent version of the dataset is automatically displayed and the version flagged as **(latest)**, provided it is not disabled.
 
@@ -96,7 +125,7 @@ To download a dataset version, select the **Download** icon.
 
 To copy a permalink to the dataset, select the **Copy** icon.
 
-### Disabling a dataset version
+### Disable a dataset version
 
 One or more dataset versions can be **disabled** by selecting the **Disable version** option. Disabling a dataset version means that it cannot be selected as an input to a pipeline run. If the most recent version of a dataset is disabled, the most recent previous non-disabled version is flagged as **(latest)**.
 
@@ -105,13 +134,14 @@ For compliance reasons, datasets or dataset versions cannot be deleted, they can
 
 Once disabled, a dataset version cannot be re-enabled.
 :::
-### Use a dataset
+
+## Use a dataset
 
 To use a dataset with pipelines added to your workspace:
 
 1. Open any pipeline that contains a pipeline schema from the [Launchpad](../launch/launchpad).
-2. Select the input field for the pipeline, removing any default values.
-3. Pick the dataset to use as input to your pipeline.
+1. Select the input field for the pipeline, removing any default values.
+1. Pick the dataset to use as input to your pipeline.
 
 :::note
 The input field drop-down menu will only display datasets that match the file type specified in the `nextflow_schema.json` of the chosen pipeline. If the schema specifies `"mimetype": "text/csv"`, no TSV datasets will be available for use with that pipeline, and vice-versa. If multiple dataset versions exist, the pipeline input will always default to the **latest** version.
@@ -135,6 +165,7 @@ You can toggle between **Visible**, **Hidden**, and **All** datasets in the **Sh
 :::note
 Hidden datasets do not count toward your per workspace quota.
 :::
+
 **Filter datasets**
 
 Filter the list of datasets to only display datasets that match one or more filters defined in the **Search datasets** field. Select the info icon to see the list of available filters.

--- a/platform-enterprise_docs/data/datasets.md
+++ b/platform-enterprise_docs/data/datasets.md
@@ -107,9 +107,9 @@ For linked datasets, versioning is unavailable.
 
 1. Select the three dots next to the dataset you want to add a new version for.
 1. Select **Add version**.
-1. Upload a dataset to your workspace with drag-and-drop or use the system **Upload file** file explorer dialog.
-1. For datasets that use their first row for column names, customize the dataset view using the **Set first row as header** option.
-1. Select **Add**.
+2. Upload a dataset to your workspace with drag-and-drop or use the system **Upload file** file explorer dialog.
+3. For datasets that use their first row for column names, customize the dataset view using the **Set first row as header** option.
+4. Select **Add**.
 
 :::caution
 All subsequent versions of a dataset must be the same format (CSV or TSV) as the initial version.


### PR DESCRIPTION
## Summary

Fixes PLAT-501, PLAT-2733

Brings `platform-enterprise_docs/data/datasets.md` in line with the cloud version (`platform-cloud/docs/data/datasets.md`), reflecting that 26.1 enterprise gains the link-to-URL dataset feature.

### Content ported from cloud
- New `### Link to an externally hosted file` subsection under `## Add a dataset`, plus `Linked` badge mention and "versioning unavailable for linked datasets" note.
- Restored `## Benefits`, `## Format`, and `### Automation and pipeline schemas` section structure.
- Intro reads "stored in, or linked to, a workspace"; added "Upload directly or link to..." bullet; Hugging Face listed alongside Amazon S3 and GitHub as a supported file location.

### Style and consistency
- Heading verbs standardized to imperative across action sections: `Add a dataset`, `Add a dataset version`, `View dataset versions`, `Disable a dataset version`, `Use a dataset`, `Manage datasets`.
- 10 MB limit upgraded from `:::note` to `:::warning` to match cloud.
- Ordered lists normalized to repeated `1.`.
- `*nf-core/rnaseq*` italics use asterisks to match cloud.

### Bug fixes carried in
- Duplicate `4.` step in the create-a-dataset list.
- Missing blank line before `### Use a dataset`.
- Cloud's `a uploaded` typo corrected to `an uploaded` during port.
- Added missing trailing period on "Copy and paste the dataset URL into the **Dataset URL** field."

### Kept enterprise-specific
- "This feature is only available in organization workspaces" callout retained.
- Broader frontmatter tag list retained (`datasets, manage-datasets, create-datasets, add-dataset-version`).

## Test plan

- [ ] Review Netlify deploy preview for `platform-enterprise_docs/data/datasets.md`.
- [ ] Confirm with product/eng that linked (URL) datasets ship in 26.1 enterprise — if not, the `### Link to an externally hosted file` subsection and related notes need to be reverted before merge.
- [ ] Verify heading anchors haven't broken cross-page links to this file (search for `#using-a-dataset`, `#managing-datasets`, `#adding-a-dataset` references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)