### PR TITLE
fix: remove duplicate line from IAM policy

### DIFF
--- a/platform-cloud/docs/compute-envs/aws-cloud.md
+++ b/platform-cloud/docs/compute-envs/aws-cloud.md
@@ -524,7 +524,6 @@ The policy scopes every ARN-eligible action to the `seqera-sched-*` prefix. The 
       "Sid": "EC2NetworkDiscovery",
       "Effect": "Allow",
       "Action": [
-      "Action": [
        "ec2:DescribeImages",
         "ec2:DescribeVpcs",
         "ec2:DescribeSubnets",


### PR DESCRIPTION
Just removing a duplicated entry on a policy, it probably slipped in approving PR suggestions