### PR TITLE
Fix indentation in tower.yml navbar configuration

### DIFF
--- a/platform-enterprise_docs/enterprise/configuration/overview.mdx
+++ b/platform-enterprise_docs/enterprise/configuration/overview.mdx
@@ -587,11 +587,11 @@ Modify your Seqera instance's navigation menu options.
 
 ```yaml
 tower:
-    navbar:
+  navbar:
     menus:
-        - label: "My Community"
+      - label: "My Community"
         url: "https://host.com/foo"
-        - label: "My Pipelines"
+      - label: "My Pipelines"
         url: "https://other.com/bar"
 ```
 


### PR DESCRIPTION
Reported by @bebosudo in Slack: https://seqera.slack.com/archives/C040MFU06AE/p1779787448113659

Looks like the indendation was ok in the enterprise docs for 23x but got broken in 24x onwards. Not sure if you want to back-port the fix or not, I'll leave it as just the one fix for now.