### PR TITLE
ci: use docs bot app tokens for table workflows

### DIFF
--- a/.github/workflows/update-audit-events-docs.yml
+++ b/.github/workflows/update-audit-events-docs.yml
@@ -23,9 +23,13 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   update-audit-events:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Validate payload
@@ -41,6 +45,7 @@ jobs:
           INPUT_CHANGED_FILES: ${{ github.event.inputs.changed_files }}
           INPUT_PLATFORM_REF: ${{ github.event.inputs.platform_ref }}
           INPUT_PREVIOUS_TAG: ${{ github.event.inputs.previous_tag }}
+          GH_ACTOR: ${{ github.actor }}
         run: |
           if [ "$EVENT_NAME" = "repository_dispatch" ]; then
             CHANGED_FILES="$DISPATCH_CHANGED_FILES"
@@ -51,7 +56,7 @@ jobs:
             PREVIOUS_TAG="$DISPATCH_PREVIOUS_TAG"
           else
             CHANGED_FILES="$INPUT_CHANGED_FILES"
-            TRIGGERED_BY="${{ github.actor }}"
+            TRIGGERED_BY="$GH_ACTOR"
             PLATFORM_COMMIT="$INPUT_PLATFORM_REF"
             COMMIT_MESSAGE="Manual workflow trigger"
             PLATFORM_REF="$INPUT_PLATFORM_REF"
@@ -81,10 +86,12 @@ jobs:
             echo "changed_files=$CHANGED_FILES"
             echo "triggered_by=$TRIGGERED_BY"
             echo "platform_commit=$PLATFORM_COMMIT"
-            echo "commit_message=$COMMIT_MESSAGE"
             echo "platform_ref=$PLATFORM_REF"
             echo "previous_tag=$PREVIOUS_TAG"
             echo "branch_ref=$BRANCH_REF"
+            echo "commit_message<<GHEOF"
+            printf '%s\n' "$COMMIT_MESSAGE"
+            echo "GHEOF"
           } >> "$GITHUB_OUTPUT"
 
           echo "Validation passed"
@@ -95,13 +102,22 @@ jobs:
       - name: Checkout docs repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
 
+      - name: Generate Platform app token
+        id: platform-app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # ratchet:actions/create-github-app-token@v3.0.0
+        with:
+          app-id: ${{ secrets.DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.DOCS_BOT_APP_PRIVATE_KEY }}
+          owner: seqeralabs
+          repositories: platform
+
       - name: Checkout Platform repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
         with:
           repository: seqeralabs/platform
           ref: ${{ steps.validate.outputs.platform_ref }}
           path: platform-repo
-          token: ${{ secrets.PLATFORM_REPO_PAT }}
+          token: ${{ steps.platform-app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # ratchet:actions/setup-python@v6.2.0
@@ -126,11 +142,21 @@ jobs:
             git diff --stat
           fi
 
+      - name: Generate docs app token
+        if: steps.check_changes.outputs.has_changes == 'true'
+        id: docs-app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # ratchet:actions/create-github-app-token@v3.0.0
+        with:
+          app-id: ${{ secrets.DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.DOCS_BOT_APP_PRIVATE_KEY }}
+          owner: seqeralabs
+          repositories: docs
+
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # ratchet:peter-evans/create-pull-request@v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.docs-app-token.outputs.token }}
           commit-message: |
             Update audit events documentation from Platform
 

--- a/.github/workflows/update-permissions-docs.yml
+++ b/.github/workflows/update-permissions-docs.yml
@@ -24,8 +24,7 @@ on:
         type: string
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update-permissions:
@@ -108,13 +107,22 @@ jobs:
       - name: Checkout docs repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
 
+      - name: Generate Platform app token
+        id: platform-app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # ratchet:actions/create-github-app-token@v3.0.0
+        with:
+          app-id: ${{ secrets.DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.DOCS_BOT_APP_PRIVATE_KEY }}
+          owner: seqeralabs
+          repositories: platform
+
       - name: Checkout Platform repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
         with:
           repository: seqeralabs/platform
           ref: ${{ steps.validate.outputs.platform_ref }}
           path: platform-repo
-          token: ${{ secrets.PLATFORM_REPO_PAT }}
+          token: ${{ steps.platform-app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # ratchet:actions/setup-python@v6.2.0
@@ -140,11 +148,21 @@ jobs:
             git diff --stat
           fi
 
+      - name: Generate docs app token
+        if: steps.check_changes.outputs.has_changes == 'true'
+        id: docs-app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # ratchet:actions/create-github-app-token@v3.0.0
+        with:
+          app-id: ${{ secrets.DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.DOCS_BOT_APP_PRIVATE_KEY }}
+          owner: seqeralabs
+          repositories: docs
+
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # ratchet:peter-evans/create-pull-request@v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.docs-app-token.outputs.token }}
           commit-message: |
             Update permissions documentation from Platform
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The workflow listens for the `permissions-docs-updated` dispatch event from Plat
 - `docs/grants_roles.md`
 - `docs/grants_operations.md`
 
-When changes are detected, the workflow checks out Platform, regenerates the permissions tables, and opens a draft PR against this repository. The generated PR branch is named `permissions-docs-update-{platform_commit}`.
+When changes are detected, the workflow checks out Platform with a Platform-scoped docs bot app token, regenerates the permissions tables, and opens a draft PR against this repository with a Docs-scoped docs bot app token. The generated PR branch is named `permissions-docs-update-{platform_ref}`.
 
 The Platform trigger runs for Cloud release tags such as `v26.1.0-cycle41` and Enterprise release candidate tags such as `v26.2.0-RC1-enterprise`. Cloud tags compare against the previous Cloud release tag. Enterprise RC tags compare against the previous stable Enterprise release tag, such as `v26.1.0-enterprise`.
 
@@ -208,11 +208,13 @@ If the docs workflow does not start:
 - Confirm the Platform-side workflow detected one of the expected source files. If the tag diff does not include the source file, no dispatch event is sent.
 - Check that the Platform workflow dispatched the expected event type: `permissions-docs-updated` or `audit-events-docs-updated`.
 - Confirm the Platform repository has the docs bot secrets required to dispatch to this repository.
+- Confirm this repository has the docs bot secrets required to read Platform and create draft PRs: `DOCS_BOT_APP_ID` and `DOCS_BOT_APP_PRIVATE_KEY`.
 
 If the docs workflow starts but fails:
 
 - Check the **Validate payload** step. The workflows reject unexpected file paths.
-- Check the Platform checkout step. Private Platform checkout requires `PLATFORM_REPO_PAT`.
+- Check the Platform app token and checkout steps. The docs bot GitHub App must be installed on Platform with contents read access.
+- Check the docs app token step. Draft PR creation requires the docs bot GitHub App to be installed on this repository with contents and pull request write access.
 - Check the update script output. Parse failures usually mean the source table headings or columns changed.
 - Check the **Check for changes** step. If the generated tables already match, the workflow exits without opening a PR.
 


### PR DESCRIPTION
## Summary

- use the docs bot GitHub App token to checkout Platform in table update workflows
- use the docs bot GitHub App token to create generated docs PRs
- remove PAT troubleshooting guidance from the workflow README section

## Validation

- actionlint .github/workflows/update-permissions-docs.yml .github/workflows/update-audit-events-docs.yml
- ruby YAML parse for both workflows
- git diff --check