### PR TITLE
docs(studios): reword "approach is recommended" for consistency

### DIFF
--- a/platform-cloud/docs/studios/container-images.md
+++ b/platform-cloud/docs/studios/container-images.md
@@ -33,7 +33,7 @@ When pushed to the container registry, an image template is tagged with the foll
 - `<tool_version>-<major>.<minor>`, such as `4.2.3-0.9`. When adding a new container template image this is the tag displayed in Seqera Platform.
 - `<tool_version>-<major>.<minor>.<patch>`, such as `4.2.3-0.9.0`.
 
-To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This approach is recommended for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
+To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This is the recommended approach for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
 
 ### JupyterLab 4.2.5
 

--- a/platform-enterprise_docs/studios/container-images.md
+++ b/platform-enterprise_docs/studios/container-images.md
@@ -33,7 +33,7 @@ When pushed to the container registry, an image template is tagged with the foll
 - `<tool_version>-<major>.<minor>`, such as `4.2.3-0.10`. When adding a new container template image this is the tag displayed in Seqera Platform.
 - `<tool_version>-<major>.<minor>.<patch>`, such as `4.2.3-0.10.0`.
 
-To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This approach is recommended for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
+To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This is the recommended approach for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
 
 ### JupyterLab 4.2.5
 

--- a/platform-enterprise_versioned_docs/version-24.2/data_studios/overview.md
+++ b/platform-enterprise_versioned_docs/version-24.2/data_studios/overview.md
@@ -61,7 +61,7 @@ When pushed to the container registry, an image template is tagged with the foll
 - `<tool_version>-<major>.<minor>`, such as `4.2.3-0.7`. When adding a new data studio container template image this is the tag displayed in Seqera Platform.
 - `<tool_version>-<major>.<minor>.<patch>`, such as `4.2.3-0.7.1`.
 
-To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This approach is recommended for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
+To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This is the recommended approach for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
 
 **JupyterLab 4.2.5**
 

--- a/platform-enterprise_versioned_docs/version-25.1/studios/overview.md
+++ b/platform-enterprise_versioned_docs/version-25.1/studios/overview.md
@@ -61,7 +61,7 @@ When pushed to the container registry, an image template is tagged with the foll
 - `<tool_version>-<major>.<minor>`, such as `4.2.3-0.7`. When adding a new container template image this is the tag displayed in Seqera Platform.
 - `<tool_version>-<major>.<minor>.<patch>`, such as `4.2.3-0.7.1`.
 
-To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This approach is recommended for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
+To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This is the recommended approach for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
 
 ### JupyterLab 4.2.5
 

--- a/platform-enterprise_versioned_docs/version-25.2/studios/container-images.md
+++ b/platform-enterprise_versioned_docs/version-25.2/studios/container-images.md
@@ -33,7 +33,7 @@ When pushed to the container registry, an image template is tagged with the foll
 - `<tool_version>-<major>.<minor>`, such as `4.2.3-0.8`. When adding a new container template image this is the tag displayed in Seqera Platform.
 - `<tool_version>-<major>.<minor>.<patch>`, such as `4.2.3-0.8.4`.
 
-To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This approach is recommended for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
+To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This is the recommended approach for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
 
 ### JupyterLab 4.2.5
 

--- a/platform-enterprise_versioned_docs/version-25.3/studios/container-images.md
+++ b/platform-enterprise_versioned_docs/version-25.3/studios/container-images.md
@@ -33,7 +33,7 @@ When pushed to the container registry, an image template is tagged with the foll
 - `<tool_version>-<major>.<minor>`, such as `4.2.3-0.11`. When adding a new container template image this is the tag displayed in Seqera Platform.
 - `<tool_version>-<major>.<minor>.<patch>`, such as `4.2.3-0.11.0`.
 
-To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This approach is recommended for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
+To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This is the recommended approach for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
 
 ### JupyterLab 4.2.5
 

--- a/platform-enterprise_versioned_docs/version-26.1/studios/container-images.md
+++ b/platform-enterprise_versioned_docs/version-26.1/studios/container-images.md
@@ -33,7 +33,7 @@ When pushed to the container registry, an image template is tagged with the foll
 - `<tool_version>-<major>.<minor>`, such as `4.2.3-0.10`. When adding a new container template image this is the tag displayed in Seqera Platform.
 - `<tool_version>-<major>.<minor>.<patch>`, such as `4.2.3-0.10.0`.
 
-To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This approach is recommended for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
+To view the latest versions of the images, see [public.cr.seqera.io](https://public.cr.seqera.io/). You can also augment the Seqera-provided image templates or use your own custom container image templates. This is the recommended approach for managing reproducible analysis environments. For more information, see [Custom environments][custom-envs].
 
 ### JupyterLab 4.2.5
 


### PR DESCRIPTION
## Summary

Pure copy fix. Changes:

> This approach is recommended for managing reproducible analysis environments.

to:

> This is the recommended approach for managing reproducible analysis environments.

No content change — just rephrases for slightly better flow. Applied wherever the sentence currently exists in the Studios docs.

## Files touched (7)

| File | Tree |
|------|------|
| `platform-enterprise_docs/studios/container-images.md` | Enterprise (unversioned / next release) |
| `platform-enterprise_versioned_docs/version-26.1/studios/container-images.md` | Enterprise 26.1 |
| `platform-enterprise_versioned_docs/version-25.3/studios/container-images.md` | Enterprise 25.3 |
| `platform-enterprise_versioned_docs/version-25.2/studios/container-images.md` | Enterprise 25.2 |
| `platform-enterprise_versioned_docs/version-25.1/studios/overview.md` | Enterprise 25.1 (Studios docs lived in `overview.md` before the container-images split) |
| `platform-enterprise_versioned_docs/version-24.2/data_studios/overview.md` | Enterprise 24.2 (pre-rebrand, under `data_studios/`) |
| `platform-cloud/docs/studios/container-images.md` | Platform Cloud |

`grep` confirms no remaining instances of the old phrasing in any non-build path.

## Test plan

- [ ] Netlify preview renders the updated sentence on Studios container-images (or overview) pages for Cloud and Enterprise (unversioned, 26.1, 25.3, 25.2, 25.1, 24.2).
- [ ] No surrounding markdown or link references altered (single-line replacement only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)