### PR TITLE
docs: Add Redis/Valkey compatibility matrix to install prereqs [EDU-1130]

### DIFF
--- a/platform-enterprise_docs/enterprise/platform-docker-compose.md
+++ b/platform-enterprise_docs/enterprise/platform-docker-compose.md
@@ -30,22 +30,49 @@ GRANT ALL PRIVILEGES ON tower.* TO 'tower'@'%';
 
 See [Database configuration](./configuration/overview#seqera-and-redis-databases) for details.
 
-## Redis configuration
+## Redis or Valkey configuration
+
+Seqera Platform requires a Redis-compatible cache store for transient data, primarily Nextflow job metrics reporting. Both Redis and Valkey are supported.
 
 :::info
 The bundled `redis` container in `docker-compose.yml` is intended for evaluation and small workloads. For production, use a managed service or an [official Redis installation source](https://redis.io/docs/latest/operate/oss_and_stack/install/).
 :::
 
-Configure the Redis connection URL in your Seqera environment:
+### Supported versions
 
-```bash
-TOWER_REDIS_URL=redis://<redis-host>:6379
-```
+| Cache / version | Status                       |
+| --------------- | ---------------------------- |
+| Redis 6.x       | Not supported (EoL upstream) |
+| Redis 7.2       | Supported                    |
+| Redis 7.4       | Supported                    |
+| Redis 8.0       | Not supported                |
+| Redis 8.2+      | Supported                    |
+| Redis 9.x       | Not supported                |
+| Valkey 7.x      | Supported (from 26.1)        |
+| Valkey 8.x      | Supported (from 26.1)        |
 
-Use a managed Redis service for production:
+### Connection URL
+
+Configure the connection URL in your Seqera environment using the scheme that matches your cache backend:
+
+| Backend         | Scheme       | Example                                  |
+| --------------- | ------------ | ---------------------------------------- |
+| Redis           | `redis://`   | `TOWER_REDIS_URL=redis://<host>:6379`    |
+| Redis with TLS  | `rediss://`  | `TOWER_REDIS_URL=rediss://<host>:6380`   |
+| Valkey          | `valkey://`  | `TOWER_REDIS_URL=valkey://<host>:6379`   |
+| Valkey with TLS | `valkeyss://`| `TOWER_REDIS_URL=valkeyss://<host>:6380` |
+
+The Redisson client embedded in Platform 26.1+ supports Valkey 7 and 8 dial schemes — no further configuration is required. Redis password and ACL configuration carry over unchanged when migrating to Valkey.
+
+### Managed service options
+
+Use a managed cache service for production:
+
 - [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html) (`cache.m4.large` or larger)
 - [Azure Cache for Redis](https://learn.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-overview) (C3 tier or larger)
 - [Google Memorystore](https://cloud.google.com/memorystore/docs/redis) (M2 tier or larger)
+
+For migration guidance from Redis to Valkey on an existing installation, see [Cache layer changes](./upgrade#cache-layer-changes-redis-eol-and-valkey-support).
 
 
 ## Deploy Seqera Enterprise

--- a/platform-enterprise_docs/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_docs/enterprise/platform-kubernetes.md
@@ -40,19 +40,45 @@ GRANT ALL PRIVILEGES ON tower.* TO 'tower'@'%';
 
 See [Database configuration](./configuration/overview#seqera-and-redis-databases) for details.
 
-## Redis configuration
+## Redis or Valkey configuration
 
-Configure the Redis connection URL in your Seqera environment:
+Seqera Platform requires a Redis-compatible cache store for transient data, primarily Nextflow job metrics reporting. Both Redis and Valkey are supported.
 
-```bash
-TOWER_REDIS_URL=redis://<redis-host>:6379
-```
+### Supported versions
 
-Use a managed Redis service for production:
+| Cache / version | Status                       |
+| --------------- | ---------------------------- |
+| Redis 6.x       | Not supported (EoL upstream) |
+| Redis 7.2       | Supported                    |
+| Redis 7.4       | Supported                    |
+| Redis 8.0       | Not supported                |
+| Redis 8.2+      | Supported                    |
+| Redis 9.x       | Not supported                |
+| Valkey 7.x      | Supported (from 26.1)        |
+| Valkey 8.x      | Supported (from 26.1)        |
+
+### Connection URL
+
+Configure the connection URL in your Seqera environment using the scheme that matches your cache backend:
+
+| Backend         | Scheme       | Example                                  |
+| --------------- | ------------ | ---------------------------------------- |
+| Redis           | `redis://`   | `TOWER_REDIS_URL=redis://<host>:6379`    |
+| Redis with TLS  | `rediss://`  | `TOWER_REDIS_URL=rediss://<host>:6380`   |
+| Valkey          | `valkey://`  | `TOWER_REDIS_URL=valkey://<host>:6379`   |
+| Valkey with TLS | `valkeyss://`| `TOWER_REDIS_URL=valkeyss://<host>:6380` |
+
+The Redisson client embedded in Platform 26.1+ supports Valkey 7 and 8 dial schemes — no further configuration is required. Redis password and ACL configuration carry over unchanged when migrating to Valkey.
+
+### Managed service options
+
+Use a managed cache service for production:
 
 - [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html) (`cache.m4.large` or larger)
 - [Azure Cache for Redis](https://learn.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-overview) (C3 tier or larger)
 - [Google Memorystore](https://cloud.google.com/memorystore/docs/redis) (M2 tier or larger)
+
+For migration guidance from Redis to Valkey on an existing installation, see [Cache layer changes](./upgrade#cache-layer-changes-redis-eol-and-valkey-support).
 
 ## Deploy Seqera Enterprise
 

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-docker-compose.md
@@ -30,22 +30,49 @@ GRANT ALL PRIVILEGES ON tower.* TO 'tower'@'%';
 
 See [Database configuration](./configuration/overview#seqera-and-redis-databases) for details.
 
-## Redis configuration
+## Redis or Valkey configuration
+
+Seqera Platform requires a Redis-compatible cache store for transient data, primarily Nextflow job metrics reporting. Both Redis and Valkey are supported.
 
 :::info
 The bundled `redis` container in `docker-compose.yml` is intended for evaluation and small workloads. For production, use a managed service or an [official Redis installation source](https://redis.io/docs/latest/operate/oss_and_stack/install/).
 :::
 
-Configure the Redis connection URL in your Seqera environment:
+### Supported versions
 
-```bash
-TOWER_REDIS_URL=redis://<redis-host>:6379
-```
+| Cache / version | Status                       |
+| --------------- | ---------------------------- |
+| Redis 6.x       | Not supported (EoL upstream) |
+| Redis 7.2       | Supported                    |
+| Redis 7.4       | Supported                    |
+| Redis 8.0       | Not supported                |
+| Redis 8.2+      | Supported                    |
+| Redis 9.x       | Not supported                |
+| Valkey 7.x      | Supported (from 26.1)        |
+| Valkey 8.x      | Supported (from 26.1)        |
 
-Use a managed Redis service for production:
+### Connection URL
+
+Configure the connection URL in your Seqera environment using the scheme that matches your cache backend:
+
+| Backend         | Scheme       | Example                                  |
+| --------------- | ------------ | ---------------------------------------- |
+| Redis           | `redis://`   | `TOWER_REDIS_URL=redis://<host>:6379`    |
+| Redis with TLS  | `rediss://`  | `TOWER_REDIS_URL=rediss://<host>:6380`   |
+| Valkey          | `valkey://`  | `TOWER_REDIS_URL=valkey://<host>:6379`   |
+| Valkey with TLS | `valkeyss://`| `TOWER_REDIS_URL=valkeyss://<host>:6380` |
+
+The Redisson client embedded in Platform 26.1+ supports Valkey 7 and 8 dial schemes — no further configuration is required. Redis password and ACL configuration carry over unchanged when migrating to Valkey.
+
+### Managed service options
+
+Use a managed cache service for production:
+
 - [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html) (`cache.m4.large` or larger)
 - [Azure Cache for Redis](https://learn.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-overview) (C3 tier or larger)
 - [Google Memorystore](https://cloud.google.com/memorystore/docs/redis) (M2 tier or larger)
+
+For migration guidance from Redis to Valkey on an existing installation, see [Cache layer changes](./upgrade#cache-layer-changes-redis-eol-and-valkey-support).
 
 
 ## Deploy Seqera Enterprise

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-kubernetes.md
@@ -40,19 +40,45 @@ GRANT ALL PRIVILEGES ON tower.* TO 'tower'@'%';
 
 See [Database configuration](./configuration/overview#seqera-and-redis-databases) for details.
 
-## Redis configuration
+## Redis or Valkey configuration
 
-Configure the Redis connection URL in your Seqera environment:
+Seqera Platform requires a Redis-compatible cache store for transient data, primarily Nextflow job metrics reporting. Both Redis and Valkey are supported.
 
-```bash
-TOWER_REDIS_URL=redis://<redis-host>:6379
-```
+### Supported versions
 
-Use a managed Redis service for production:
+| Cache / version | Status                       |
+| --------------- | ---------------------------- |
+| Redis 6.x       | Not supported (EoL upstream) |
+| Redis 7.2       | Supported                    |
+| Redis 7.4       | Supported                    |
+| Redis 8.0       | Not supported                |
+| Redis 8.2+      | Supported                    |
+| Redis 9.x       | Not supported                |
+| Valkey 7.x      | Supported (from 26.1)        |
+| Valkey 8.x      | Supported (from 26.1)        |
+
+### Connection URL
+
+Configure the connection URL in your Seqera environment using the scheme that matches your cache backend:
+
+| Backend         | Scheme       | Example                                  |
+| --------------- | ------------ | ---------------------------------------- |
+| Redis           | `redis://`   | `TOWER_REDIS_URL=redis://<host>:6379`    |
+| Redis with TLS  | `rediss://`  | `TOWER_REDIS_URL=rediss://<host>:6380`   |
+| Valkey          | `valkey://`  | `TOWER_REDIS_URL=valkey://<host>:6379`   |
+| Valkey with TLS | `valkeyss://`| `TOWER_REDIS_URL=valkeyss://<host>:6380` |
+
+The Redisson client embedded in Platform 26.1+ supports Valkey 7 and 8 dial schemes — no further configuration is required. Redis password and ACL configuration carry over unchanged when migrating to Valkey.
+
+### Managed service options
+
+Use a managed cache service for production:
 
 - [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html) (`cache.m4.large` or larger)
 - [Azure Cache for Redis](https://learn.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-overview) (C3 tier or larger)
 - [Google Memorystore](https://cloud.google.com/memorystore/docs/redis) (M2 tier or larger)
+
+For migration guidance from Redis to Valkey on an existing installation, see [Cache layer changes](./upgrade#cache-layer-changes-redis-eol-and-valkey-support).
 
 ## Deploy Seqera Enterprise
 


### PR DESCRIPTION
Port the cache compatibility matrix and Valkey connection scheme info from the 26.1 upgrade page into the Docker Compose and Kubernetes install prerequisites so customers can confirm supported cache backends during onboarding without consulting the upgrade guide.

Fixes https://seqera.atlassian.net/browse/EDU-1130