### PR TITLE
docs: Remove Redis/Valkey v8 from supported, remove valkey:// protocol EDU-1130

### DIFF
--- a/platform-enterprise_docs/enterprise/platform-docker-compose.md
+++ b/platform-enterprise_docs/enterprise/platform-docker-compose.md
@@ -45,11 +45,7 @@ The bundled `redis` container in `docker-compose.yml` is intended for evaluation
 | Redis 6.x       | Not supported (EoL upstream) |
 | Redis 7.2       | Supported                    |
 | Redis 7.4       | Supported                    |
-| Redis 8.0       | Not supported                |
-| Redis 8.2+      | Supported                    |
-| Redis 9.x       | Not supported                |
 | Valkey 7.x      | Supported (from 26.1)        |
-| Valkey 8.x      | Supported (from 26.1)        |
 
 ### Connection URL
 
@@ -59,10 +55,8 @@ Configure the connection URL in your Seqera environment using the scheme that ma
 | --------------- | ------------ | ---------------------------------------- |
 | Redis           | `redis://`   | `TOWER_REDIS_URL=redis://<host>:6379`    |
 | Redis with TLS  | `rediss://`  | `TOWER_REDIS_URL=rediss://<host>:6380`   |
-| Valkey          | `valkey://`  | `TOWER_REDIS_URL=valkey://<host>:6379`   |
-| Valkey with TLS | `valkeyss://`| `TOWER_REDIS_URL=valkeyss://<host>:6380` |
 
-The Redisson client embedded in Platform 26.1+ supports Valkey 7 and 8 dial schemes — no further configuration is required. Redis password and ACL configuration carry over unchanged when migrating to Valkey.
+The Redisson client embedded in Platform 26.1+ supports Valkey 7 dial schema — no further configuration is required. Redis password and ACL configuration carry over unchanged when migrating to Valkey.
 
 ### Managed service options
 

--- a/platform-enterprise_docs/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_docs/enterprise/platform-kubernetes.md
@@ -51,11 +51,7 @@ Seqera Platform requires a Redis-compatible cache store for transient data, prim
 | Redis 6.x       | Not supported (EoL upstream) |
 | Redis 7.2       | Supported                    |
 | Redis 7.4       | Supported                    |
-| Redis 8.0       | Not supported                |
-| Redis 8.2+      | Supported                    |
-| Redis 9.x       | Not supported                |
 | Valkey 7.x      | Supported (from 26.1)        |
-| Valkey 8.x      | Supported (from 26.1)        |
 
 ### Connection URL
 
@@ -65,10 +61,8 @@ Configure the connection URL in your Seqera environment using the scheme that ma
 | --------------- | ------------ | ---------------------------------------- |
 | Redis           | `redis://`   | `TOWER_REDIS_URL=redis://<host>:6379`    |
 | Redis with TLS  | `rediss://`  | `TOWER_REDIS_URL=rediss://<host>:6380`   |
-| Valkey          | `valkey://`  | `TOWER_REDIS_URL=valkey://<host>:6379`   |
-| Valkey with TLS | `valkeyss://`| `TOWER_REDIS_URL=valkeyss://<host>:6380` |
 
-The Redisson client embedded in Platform 26.1+ supports Valkey 7 and 8 dial schemes — no further configuration is required. Redis password and ACL configuration carry over unchanged when migrating to Valkey.
+The Redisson client embedded in Platform 26.1+ supports Valkey 7 dial schema — no further configuration is required. Redis password and ACL configuration carry over unchanged when migrating to Valkey.
 
 ### Managed service options
 

--- a/platform-enterprise_docs/enterprise/upgrade.md
+++ b/platform-enterprise_docs/enterprise/upgrade.md
@@ -121,7 +121,7 @@ If you are running on MySQL 5.7, MySQL 8.0, or MariaDB, complete your database m
 
 ### Migrating from Redis to Valkey
 
-To migrate from Redis to Valkey, update the `TOWER_REDIS_URL` connection scheme to use `valkey://` (or `valkeyss://` for TLS). The Redisson client embedded in Platform 26.1 has been upgraded to support Valkey 7 and 8 dial schemes; no further configuration is required.
+To migrate from Redis to Valkey, update the `TOWER_REDIS_URL` environment variable. The Redisson client embedded in Platform 26.1 has been upgraded to support Valkey 7 dial schema; no further configuration is required.
 
 :::note
 Redis password and ACL configuration carry over unchanged when migrating to Valkey.

--- a/platform-enterprise_docs/seqera-ai/quickstart.md
+++ b/platform-enterprise_docs/seqera-ai/quickstart.md
@@ -12,7 +12,7 @@ You will need the following to get started:
 
 - [Seqera CLI](./installation.mdx)
 - A user account on your Seqera Platform Enterprise deployment
-- `SEQERA_AI_BACKEND_URL` set to your organization's agent backend (see [Installation](./installation.mdx#configure-the-enterprise-backend))
+- `SEQERA_AI_BACKEND_URL` set to your organization's agent backend (see [Installation](./installation.mdx#configure-the-co-scientist-backend))
 :::
 
 ## Step 1: Log in to Seqera Platform

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-docker-compose.md
@@ -45,11 +45,7 @@ The bundled `redis` container in `docker-compose.yml` is intended for evaluation
 | Redis 6.x       | Not supported (EoL upstream) |
 | Redis 7.2       | Supported                    |
 | Redis 7.4       | Supported                    |
-| Redis 8.0       | Not supported                |
-| Redis 8.2+      | Supported                    |
-| Redis 9.x       | Not supported                |
 | Valkey 7.x      | Supported (from 26.1)        |
-| Valkey 8.x      | Supported (from 26.1)        |
 
 ### Connection URL
 
@@ -59,10 +55,8 @@ Configure the connection URL in your Seqera environment using the scheme that ma
 | --------------- | ------------ | ---------------------------------------- |
 | Redis           | `redis://`   | `TOWER_REDIS_URL=redis://<host>:6379`    |
 | Redis with TLS  | `rediss://`  | `TOWER_REDIS_URL=rediss://<host>:6380`   |
-| Valkey          | `valkey://`  | `TOWER_REDIS_URL=valkey://<host>:6379`   |
-| Valkey with TLS | `valkeyss://`| `TOWER_REDIS_URL=valkeyss://<host>:6380` |
 
-The Redisson client embedded in Platform 26.1+ supports Valkey 7 and 8 dial schemes — no further configuration is required. Redis password and ACL configuration carry over unchanged when migrating to Valkey.
+The Redisson client embedded in Platform 26.1+ supports Valkey 7 dial schema — no further configuration is required. Redis password and ACL configuration carry over unchanged when migrating to Valkey.
 
 ### Managed service options
 

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-kubernetes.md
@@ -51,11 +51,7 @@ Seqera Platform requires a Redis-compatible cache store for transient data, prim
 | Redis 6.x       | Not supported (EoL upstream) |
 | Redis 7.2       | Supported                    |
 | Redis 7.4       | Supported                    |
-| Redis 8.0       | Not supported                |
-| Redis 8.2+      | Supported                    |
-| Redis 9.x       | Not supported                |
 | Valkey 7.x      | Supported (from 26.1)        |
-| Valkey 8.x      | Supported (from 26.1)        |
 
 ### Connection URL
 
@@ -65,10 +61,8 @@ Configure the connection URL in your Seqera environment using the scheme that ma
 | --------------- | ------------ | ---------------------------------------- |
 | Redis           | `redis://`   | `TOWER_REDIS_URL=redis://<host>:6379`    |
 | Redis with TLS  | `rediss://`  | `TOWER_REDIS_URL=rediss://<host>:6380`   |
-| Valkey          | `valkey://`  | `TOWER_REDIS_URL=valkey://<host>:6379`   |
-| Valkey with TLS | `valkeyss://`| `TOWER_REDIS_URL=valkeyss://<host>:6380` |
 
-The Redisson client embedded in Platform 26.1+ supports Valkey 7 and 8 dial schemes — no further configuration is required. Redis password and ACL configuration carry over unchanged when migrating to Valkey.
+The Redisson client embedded in Platform 26.1+ supports Valkey 7 dial schema — no further configuration is required. Redis password and ACL configuration carry over unchanged when migrating to Valkey.
 
 ### Managed service options
 

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/upgrade.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/upgrade.md
@@ -121,7 +121,7 @@ If you are running on MySQL 5.7, MySQL 8.0, or MariaDB, complete your database m
 
 ### Migrating from Redis to Valkey
 
-To migrate from Redis to Valkey, update the `TOWER_REDIS_URL` connection scheme to use `valkey://` (or `valkeyss://` for TLS). The Redisson client embedded in Platform 26.1 has been upgraded to support Valkey 7 and 8 dial schemes; no further configuration is required.
+To migrate from Redis to Valkey, update the `TOWER_REDIS_URL` environment variable. The Redisson client embedded in Platform 26.1 has been upgraded to support Valkey 7 dial schema; no further configuration is required.
 
 :::note
 Redis password and ACL configuration carry over unchanged when migrating to Valkey.

--- a/platform-enterprise_versioned_docs/version-26.1/seqera-ai/quickstart.md
+++ b/platform-enterprise_versioned_docs/version-26.1/seqera-ai/quickstart.md
@@ -12,7 +12,7 @@ You will need the following to get started:
 
 - [Seqera CLI](./installation.mdx)
 - A user account on your Seqera Platform Enterprise deployment
-- `SEQERA_AI_BACKEND_URL` set to your organization's agent backend (see [Installation](./installation.mdx#configure-the-enterprise-backend))
+- `SEQERA_AI_BACKEND_URL` set to your organization's agent backend (see [Installation](./installation.mdx#configure-the-co-scientist-backend))
 :::
 
 ## Step 1: Log in to Seqera Platform


### PR DESCRIPTION
Follow up of #1502.
While I was working on [adding `valkey://` support in the helm charts](https://github.com/seqeralabs/helm-charts/pull/163) I found out that Platform doesn't actually support the new protocol schema.
Moreover, we only tested Valkey 7 in Platform only, not in all the products (Studios, Wave, Co-scientist). We're not testing redis/valkey v8 either.