### PR TITLE
chore: update Docker image tags from v26.1 to v26.1.0 in deployment templates

### DIFF
--- a/platform-enterprise_docs/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_docs/enterprise/_templates/docker/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/enterprise/platform/migrate-db:v26.1
+    image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.0
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -64,7 +64,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/enterprise/platform/backend:v26.1
+    image: cr.seqera.io/enterprise/platform/backend:v26.1.0
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -85,7 +85,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/enterprise/platform/backend:v26.1
+    image: cr.seqera.io/enterprise/platform/backend:v26.1.0
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -110,7 +110,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/enterprise/platform/frontend:v26.1
+    image: cr.seqera.io/enterprise/platform/frontend:v26.1.0
     platform: linux/amd64
     networks:
       - frontend

--- a/platform-enterprise_docs/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/tower-cron.yml
@@ -21,7 +21,7 @@ spec:
             name: tower-yml
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/enterprise/platform/migrate-db:v26.1
+          image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.0
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -32,7 +32,7 @@ spec:
               subPath: tower.yml
       containers:
         - name: backend
-          image: cr.seqera.io/enterprise/platform/backend:v26.1
+          image: cr.seqera.io/enterprise/platform/backend:v26.1.0
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform-enterprise_docs/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/tower-svc.yml
@@ -29,7 +29,7 @@ spec:
         #    secretName: platform-oidc-certs
       containers:
         - name: backend
-          image: cr.seqera.io/enterprise/platform/backend:v26.1
+          image: cr.seqera.io/enterprise/platform/backend:v26.1.0
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -88,7 +88,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/enterprise/platform/frontend:v26.1
+          image: cr.seqera.io/enterprise/platform/frontend:v26.1.0
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/enterprise/platform/migrate-db:v26.1
+    image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.0
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -64,7 +64,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/enterprise/platform/backend:v26.1
+    image: cr.seqera.io/enterprise/platform/backend:v26.1.0
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -85,7 +85,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/enterprise/platform/backend:v26.1
+    image: cr.seqera.io/enterprise/platform/backend:v26.1.0
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -110,7 +110,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/enterprise/platform/frontend:v26.1
+    image: cr.seqera.io/enterprise/platform/frontend:v26.1.0
     platform: linux/amd64
     networks:
       - frontend

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-cron.yml
@@ -21,7 +21,7 @@ spec:
             name: tower-yml
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/enterprise/platform/migrate-db:v26.1
+          image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.0
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -32,7 +32,7 @@ spec:
               subPath: tower.yml
       containers:
         - name: backend
-          image: cr.seqera.io/enterprise/platform/backend:v26.1
+          image: cr.seqera.io/enterprise/platform/backend:v26.1.0
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-svc.yml
@@ -29,7 +29,7 @@ spec:
         #    secretName: platform-oidc-certs
       containers:
         - name: backend
-          image: cr.seqera.io/enterprise/platform/backend:v26.1
+          image: cr.seqera.io/enterprise/platform/backend:v26.1.0
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -88,7 +88,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/enterprise/platform/frontend:v26.1
+          image: cr.seqera.io/enterprise/platform/frontend:v26.1.0
           ports:
             - containerPort: 80
       restartPolicy: Always


### PR DESCRIPTION
Noticed that the image tags used for 26.1 deployment files are incorrect. Updated it to use the correct tag `v26.1.0`

