### PR TITLE
docs: Remove some more mentions of redis/valkey v8/v9 EDU-1130

### DIFF
--- a/platform-enterprise_docs/enterprise/upgrade.md
+++ b/platform-enterprise_docs/enterprise/upgrade.md
@@ -113,11 +113,7 @@ If you are running on MySQL 5.7, MySQL 8.0, or MariaDB, complete your database m
 | Redis 6.x | EoL upstream — no longer supported | Upgrade to Redis 7.2+ or migrate to Valkey 7+ |
 | Redis 7.2 | Supported | No action |
 | Redis 7.4 | Supported | No action |
-| Redis 8.0 | Not supported | Upgrade to Redis 8.2+ or migrate to Valkey 7+ |
-| Redis 8.2+ | Supported | No action |
-| Redis 9.x | Not supported | Do not upgrade Redis to version 9 |
 | Valkey 7.x | Newly supported in 26.1 | Optional migration path from Redis |
-| Valkey 8.x | Supported | Optional migration path from Redis |
 
 ### Migrating from Redis to Valkey
 

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/upgrade.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/upgrade.md
@@ -113,11 +113,7 @@ If you are running on MySQL 5.7, MySQL 8.0, or MariaDB, complete your database m
 | Redis 6.x | EoL upstream — no longer supported | Upgrade to Redis 7.2+ or migrate to Valkey 7+ |
 | Redis 7.2 | Supported | No action |
 | Redis 7.4 | Supported | No action |
-| Redis 8.0 | Not supported | Upgrade to Redis 8.2+ or migrate to Valkey 7+ |
-| Redis 8.2+ | Supported | No action |
-| Redis 9.x | Not supported | Do not upgrade Redis to version 9 |
 | Valkey 7.x | Newly supported in 26.1 | Optional migration path from Redis |
-| Valkey 8.x | Supported | Optional migration path from Redis |
 
 ### Migrating from Redis to Valkey
 


### PR DESCRIPTION
Follow up of #1509, I missed to remove v8 from the upgrade pages.