### PR TITLE
Revise version compatibility information [EDU-694]

### DIFF
--- a/platform-cloud/docs/functionality_matrix/overview.md
+++ b/platform-cloud/docs/functionality_matrix/overview.md
@@ -1,34 +1,53 @@
 ---
-title: "Version compatibility"
+title: "Default version compatibility"
 description: "Platform / nf-launcher / Nextflow / Fusion version compatibility"
-date: "20 Jun 2024"
+date created: "2024-06-20"
+last updated: "2026-06-07"
 tags: [compatibility, nextflow, nf-launcher]
 ---
 
-The two most recent major Seqera Platform versions (24.1.x, 23.4.x, etc) are supported at any given time.
+The two most recent major Seqera Platform versions (25.3.x, 26.1.x, etc) are supported at any given time.
 
 Each version makes use of `nf-launcher` to determine the Nextflow version used as its baseline. You can override this version during pipeline launch, but note that Seqera may not work reliably with Nextflow versions other than the baseline version. To use a Nextflow version other than the baseline in your pipeline run, use a [pre-run script](../launch/advanced#pre-and-post-run-scripts) during launch.
 
 If no Nextflow version is specified in your configuration, Seqera defaults to the baseline version outlined below:
 
-| Platform version | nf-launcher version | Nextflow version | Fusion version |
-| ---------------- | ------------------- | ---------------- | -------------- |
-| 24.2.4           | j17-24.10.4         | 24.10.4          | 2.4            |
-| 24.2.3           | j17-24.10.4         | 24.10.4          | 2.4            |
-| 24.2.2           | j17-24.10.0         | 24.10.0          | 2.4            |
-| 24.2.0           | j17-24.10.0         | 24.10.0          | 2.4            |
-| 24.1.5           | j17-24.04.4         | 24.04.4          | 2.3            |
-| 24.1.4           | j17-24.04.4         | 24.04.4          | 2.3            |
-| 24.1.3           | j17-24.04.4         | 24.04.4          | 2.3            |
-| 24.1.1           | j17-23.10.1-up1     | 23.10.1          | 2.2            |
-| 23.4.4           | j17-23.10.1         | 23.10.1          | 2.2            |
-| 23.4.3           | j17-23.10.1         | 23.10.1          | 2.2            |
-| 23.4.2           | j17-23.10.1         | 23.10.1          | 2.2            |
-| 23.4.1           | j17-23.10.1         | 23.10.1          | 2.2            |
-| 23.4.0           | j17-23.04.3         | 23.04.3          | 2.1            |
-| 23.3.0           | j17-23.04.3         | 23.04.3          | 2.1            |
-| 23.3.0           | j17-23.04.3         | 23.04.3          | 2.1            |
-| 23.2.0           | j17.23.04.2-up3     | 23.04.2          | 2.1            |
-| 23.1.3           | j17-23.04.1         | 23.04.1          | 2.1            |
+| Platform version | nf-launcher version | Nextflow version | Fusion version | Connect client version|
+| ---------------- | ------------------- | ---------------- | -------------- |-------------- |
+| 26.1.0           | j21-26.04           | 25.10.2          | 2.4            | 0.12.0        |
+| 25.3.6           | j21-25.10.2         | 25.10.2          | 2.4            | 0.11.0        |
+| 25.3.4           | j21-25.10.2         | 25.10.2          | 2.4            | 0.9.0         |
+| 25.3.1           | j21-25.10.2         | 25.10.2          | 2.4            | 0.9.0         |
+| 25.3.0           | j21-25.04.8         | 25.04.8          | 2.4            |               |
+| 25.2.4           | j21-25.04.3         | 25.04.3          | 2.4            |               |
+| 25.2.3           | j21-25.04.3         | 25.04.3          | 2.4            |               |
+| 25.2.2           | j21-25.04.3         | 25.04.3          | 2.4            |               |
+| 25.2.3           | j21-25.04.3         | 25.04.3          | 2.4            |               |
+| 25.2.1           | j21-25.04.3         | 25.04.3          | 2.4            |               |
+| 25.1.3           | j17-24.10.9-b1      | 24.10.9          | 2.4            |               |
+| 25.2.0           | j21-25.04.3         | 25.04.3          | 2.4            |               |
+| 25.1.5           | j17-24.10.9-b1      | 24.10.9          | 2.4            |               |
+| 25.1.4           | j17-24.10.9-b1      | 24.10.9          | 2.4            |               |
+| 25.1.3           | j17-24.10.9-b1      | 24.10.9          | 2.4            |               |
+| 25.2.3           | j21-25.04.3         | 25.04.3          | 2.4            |               |
+| 25.2.1           | j21-25.04.3         | 25.04.3          | 2.4            |               |
+| 25.1.3           | j17-24.10.9-b1      | 24.10.9          | 2.4            |               |
+| 25.1.1           | j17-24.10.5         | 24.10.5          | 2.4            |               |
+| 25.1.0           | j17-24.10.5         | 24.10.5          | 2.4            |               |
+| 24.2.7           | j17-24.10.9-a1      | 24.10.9          | 2.4            |               |
+| 24.2.4           | j17-24.10.4         | 24.10.4          | 2.4            |               |
+| 24.2.1           | j17-24.10.2         | 24.10.2          | 2.4            |               |
+| 25.1.0           | j17-24.10.5         | 24.10.5          | 2.4            |               |
+| 24.2.7           | j17-24.10.9-a1      | 24.10.9          | 2.4            |               |
+| 24.2.6           | j17-24.10.9-a1      | 24.10.9          | 2.4            |               |
+| 25.1.0           | j17-24.10.5         | 24.10.5          | 2.4            |               |
+| 24.2.7           | j17-24.10.9-a1      | 24.10.9          | 2.4            |               |
+| 24.2.4           | j17-24.10.4         | 24.10.4          | 2.4            |               |
+| 24.2.1           | j17-24.10.2         | 24.10.2          | 2.4            |               |
+| 24.2.4           | j17-24.10.4         | 24.10.4          | 2.4            |               |
+| 24.2.3           | j17-24.10.4         | 24.10.4          | 2.4            |               |
+| 24.2.2           | j17-24.10.0         | 24.10.0          | 2.4            |               |
+| 24.2.1           | j17-24.10.2         | 24.10.2          | 2.4            |               |
+| 24.2.0           | j17-24.10.0         | 24.10.0          | 2.4            |               |
 
-nf-launcher versions prefixed with j17 refer to Java version 17; j11 refers to Java 11.
+nf-launcher versions prefixed with j21 refer to Java version 21; j17 refers to Java version 17.

--- a/platform-enterprise_versioned_docs/version-26.1/functionality_matrix/overview.md
+++ b/platform-enterprise_versioned_docs/version-26.1/functionality_matrix/overview.md
@@ -14,7 +14,7 @@ If no Nextflow version is specified in your configuration, Seqera defaults to th
 
 | Platform version | nf-launcher version | Nextflow version | Fusion version | Connect client version|
 | ---------------- | ------------------- | ---------------- | -------------- |-------------- |
-| 26.1.0           | j21-25.10.2         | 25.10.2          | 2.4            | 0.12.0        |
+| 26.1.0           | j21-26.04           | 25.10.2          | 2.4            | 0.12.0        |
 | 25.3.6           | j21-25.10.2         | 25.10.2          | 2.4            | 0.11.0        |
 | 25.3.4           | j21-25.10.2         | 25.10.2          | 2.4            | 0.9.0         |
 | 25.3.1           | j21-25.10.2         | 25.10.2          | 2.4            | 0.9.0         |


### PR DESCRIPTION
Fixes: https://seqera.atlassian.net/browse/EDU-694

Updated version compatibility details for Seqera Platform, including new platform versions and their corresponding nf-launcher, Nextflow, Fusion, and Connect client versions.

@jordeu, please could you confirm Fusion versions. Thanks!
@georgi-seqera, please could you confirm Connect versions. Thanks!