### PR TITLE
Bump enterprise versioned docs to 26.1.2

### DIFF
--- a/.claude/skills/version-bumps/SKILL.md
+++ b/.claude/skills/version-bumps/SKILL.md
@@ -3,7 +3,8 @@ name: version-bumps
 description: >
   Bump hard-coded version numbers across the Seqera docs in the two places they recur:
   (1) enterprise point releases — six files in platform-enterprise_versioned_docs/version-XX.Y/
-  that pin Docker image tags and Kubernetes manifests to a released version, and
+  that pin Docker image tags and Kubernetes manifests to a released version, plus the
+  cloud-side functionality matrix that mirrors the enterprise compatibility table, and
   (2) the Connect client used by Studios — Dockerfile ARG defaults, docker build commands,
   prerequisite "or later" lines, and container-image tag samples scattered across
   platform-cloud/, platform-enterprise_docs/, and the versioned snapshots.
@@ -20,8 +21,8 @@ what to change, and what NOT to touch.
 
 ## Surface 1: Enterprise point release pins
 
-When an enterprise point release is cut (e.g. `25.3.4` → `25.3.5`), six files in the
-**versioned** docs tree pin Docker image tags and Kubernetes manifests to the released version:
+When an enterprise point release is cut (e.g. `25.3.4` → `25.3.5`), seven files need manual
+bumps. Six are in the **versioned** docs tree, which is frozen against the released version:
 
 - `platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/docker/docker-compose.yml`
 - `platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/k8s/tower-cron.yml`
@@ -30,9 +31,17 @@ When an enterprise point release is cut (e.g. `25.3.4` → `25.3.5`), six files 
 - `platform-enterprise_versioned_docs/version-25.3/enterprise/platform-kubernetes.md`
 - `platform-enterprise_versioned_docs/version-25.3/functionality_matrix/overview.md`
 
-**Why these and not their `platform-enterprise_docs/` equivalents:** the unversioned tree
-always points at the *next upcoming* enterprise version and flows through normal doc updates.
-The versioned tree is frozen against the released version, so the pins live there.
+The seventh lives in the cloud docs — a parallel copy of the enterprise compatibility table
+that needs the same row addition each release:
+
+- `platform-cloud/docs/functionality_matrix/overview.md`
+
+**Why these and not the rest of `platform-enterprise_docs/`:** the unversioned enterprise
+tree always points at the *next upcoming* enterprise version and flows through normal doc
+updates. The versioned tree is frozen against the released version, so the Docker/K8s pins
+live there. The cloud functionality matrix is the exception to "no cloud-side bumps" because
+it's a shared reference listing every released platform version regardless of surface — it
+must gain the new row alongside the enterprise versioned copy.
 
 **How to apply:**
 
@@ -41,11 +50,13 @@ The versioned tree is frozen against the released version, so the pins live ther
    editing.
 2. Surface anything that drifted:
    ```bash
-   grep -rl "<old-version>" platform-enterprise_versioned_docs/version-<MAJOR.MINOR>/
+   grep -rl "<old-version>" platform-enterprise_versioned_docs/version-<MAJOR.MINOR>/ platform-cloud/docs/functionality_matrix/overview.md
    ```
-3. Edit the six files manually. Version bumps in these files can be context-dependent
-   (Docker image tag in one place, a `helm install --version` flag in another), so don't
-   blanket-replace — review each hit.
+3. Edit the seven files manually. Version bumps in these files can be context-dependent
+   (Docker image tag in one place, a `helm install --version` flag in another, a new row
+   in a compatibility table), so don't blanket-replace — review each hit. For the two
+   functionality matrices, decide with the user whether to add a new row (keeps history)
+   or replace the existing row; if adding, keep the cloud and enterprise tables in sync.
 4. The changelog file `changelog/seqera-enterprise/v<version>.md` is a release notes artifact,
    not a version bump target.
 
@@ -127,7 +138,7 @@ After bumping either surface, run these to confirm the new state:
 
 ```bash
 # Enterprise release pins (substitute your version directory)
-grep -rn "<new-version>" platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/ platform-enterprise_versioned_docs/version-25.3/enterprise/configuration/mirroring.md platform-enterprise_versioned_docs/version-25.3/enterprise/platform-kubernetes.md platform-enterprise_versioned_docs/version-25.3/functionality_matrix/overview.md
+grep -rn "<new-version>" platform-enterprise_versioned_docs/version-25.3/enterprise/_templates/ platform-enterprise_versioned_docs/version-25.3/enterprise/configuration/mirroring.md platform-enterprise_versioned_docs/version-25.3/enterprise/platform-kubernetes.md platform-enterprise_versioned_docs/version-25.3/functionality_matrix/overview.md platform-cloud/docs/functionality_matrix/overview.md
 
 # Connect client pins
 grep -rnIE "CONNECT_CLIENT_VERSION|connect-client[: ]v?[0-9]|connect-(client|server|server/proxy).{0,15}v?[0-9]+\.[0-9]+|Connect (client|server).{0,30}Version [0-9]" platform-cloud platform-enterprise_docs platform-enterprise_versioned_docs/version-26.1 --include="*.md" --include="*.mdx"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,15 +309,21 @@ When cutting an enterprise point release (e.g., `25.3.4` → `25.3.5`), the foll
 - `enterprise/platform-kubernetes.md`
 - `functionality_matrix/overview.md`
 
-The equivalent files under `platform-enterprise_docs/` do **not** need bumping here — they always point at the next upcoming enterprise version and are updated through the normal doc workflow.
+The cloud-side compatibility table is a parallel copy of the enterprise functionality matrix and needs the same row addition each release:
+
+- `platform-cloud/docs/functionality_matrix/overview.md`
+
+Other files under `platform-enterprise_docs/` and `platform-cloud/` do **not** need bumping here — the unversioned enterprise tree always points at the next upcoming enterprise version, and cloud surfaces are updated through the normal doc workflow.
 
 Use the following to surface anything that drifted before editing:
 
 ```bash
-grep -rl "{old-version}" platform-enterprise_versioned_docs/version-25.3/
+grep -rl "{old-version}" platform-enterprise_versioned_docs/version-25.3/ platform-cloud/docs/functionality_matrix/overview.md
 ```
 
 > **Note:** When the minor version rolls (e.g., a 25.4 release), the target directory changes to `platform-enterprise_versioned_docs/version-25.4/`. Verify the correct versioned directory before applying changes.
+
+For the full version-bump playbook (including the Connect client surface), see `.claude/skills/version-bumps/SKILL.md`.
 
 ## Troubleshooting
 

--- a/platform-cloud/docs/functionality_matrix/overview.md
+++ b/platform-cloud/docs/functionality_matrix/overview.md
@@ -14,7 +14,7 @@ If no Nextflow version is specified in your configuration, Seqera defaults to th
 
 | Platform version | nf-launcher version | Nextflow version | Fusion version | Connect client version|
 | ---------------- | ------------------- | ---------------- | -------------- |-------------- |
-| 26.1.1           | j21-26.04           | 25.10.2          | 2.4            | 0.12.0        |
+| 26.1.2           | j21-26.04           | 25.10.2          | 2.4            | 0.12.0        |
 | 26.1.0           | j21-26.04           | 25.10.2          | 2.4            | 0.12.0        |
 | 25.3.6           | j21-25.10.2         | 25.10.2          | 2.4            | 0.11.0        |
 | 25.3.4           | j21-25.10.2         | 25.10.2          | 2.4            | 0.9.0         |

--- a/platform-cloud/docs/functionality_matrix/overview.md
+++ b/platform-cloud/docs/functionality_matrix/overview.md
@@ -2,7 +2,7 @@
 title: "Default version compatibility"
 description: "Platform / nf-launcher / Nextflow / Fusion version compatibility"
 date created: "2024-06-20"
-last updated: "2026-06-07"
+last updated: "2026-06-08"
 tags: [compatibility, nextflow, nf-launcher]
 ---
 
@@ -14,6 +14,7 @@ If no Nextflow version is specified in your configuration, Seqera defaults to th
 
 | Platform version | nf-launcher version | Nextflow version | Fusion version | Connect client version|
 | ---------------- | ------------------- | ---------------- | -------------- |-------------- |
+| 26.1.1           | j21-26.04           | 25.10.2          | 2.4            | 0.12.0        |
 | 26.1.0           | j21-26.04           | 25.10.2          | 2.4            | 0.12.0        |
 | 25.3.6           | j21-25.10.2         | 25.10.2          | 2.4            | 0.11.0        |
 | 25.3.4           | j21-25.10.2         | 25.10.2          | 2.4            | 0.9.0         |

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/docker-compose.yml
@@ -85,7 +85,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/enterprise/platform/backend:v26.1.1
+    image: cr.seqera.io/enterprise/platform/backend:v26.1.2
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.1
+    image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.2
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -64,7 +64,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/enterprise/platform/backend:v26.1.1
+    image: cr.seqera.io/enterprise/platform/backend:v26.1.2
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -110,7 +110,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/enterprise/platform/frontend:v26.1.1
+    image: cr.seqera.io/enterprise/platform/frontend:v26.1.2
     platform: linux/amd64
     networks:
       - frontend

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.0
+    image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.1
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -64,7 +64,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/enterprise/platform/backend:v26.1.0
+    image: cr.seqera.io/enterprise/platform/backend:v26.1.1
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -85,7 +85,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/enterprise/platform/backend:v26.1.0
+    image: cr.seqera.io/enterprise/platform/backend:v26.1.1
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -110,7 +110,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/enterprise/platform/frontend:v26.1.0
+    image: cr.seqera.io/enterprise/platform/frontend:v26.1.1
     platform: linux/amd64
     networks:
       - frontend

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-cron.yml
@@ -21,7 +21,7 @@ spec:
             name: tower-yml
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.0
+          image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.1
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -32,7 +32,7 @@ spec:
               subPath: tower.yml
       containers:
         - name: backend
-          image: cr.seqera.io/enterprise/platform/backend:v26.1.0
+          image: cr.seqera.io/enterprise/platform/backend:v26.1.1
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-svc.yml
@@ -29,7 +29,7 @@ spec:
         #    secretName: platform-oidc-certs
       containers:
         - name: backend
-          image: cr.seqera.io/enterprise/platform/backend:v26.1.1
+          image: cr.seqera.io/enterprise/platform/backend:v26.1.2
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -88,7 +88,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/enterprise/platform/frontend:v26.1.1
+          image: cr.seqera.io/enterprise/platform/frontend:v26.1.2
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-svc.yml
@@ -29,7 +29,7 @@ spec:
         #    secretName: platform-oidc-certs
       containers:
         - name: backend
-          image: cr.seqera.io/enterprise/platform/backend:v26.1.0
+          image: cr.seqera.io/enterprise/platform/backend:v26.1.1
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -88,7 +88,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/enterprise/platform/frontend:v26.1.0
+          image: cr.seqera.io/enterprise/platform/frontend:v26.1.1
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/mirroring.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/mirroring.md
@@ -30,9 +30,9 @@ Create a YAML file (`seqera-images.yaml`) to specify which images to sync:
 ```yaml
 cr.seqera.io:
     images-by-semver:
-        enterprise/platform/backend: ">= v25.3.4"
-        enterprise/platform/frontend: ">= v25.3.4"
-        enterprise/platform/migrate-db: ">= v25.3.4"
+        enterprise/platform/backend: ">= v26.1.1"
+        enterprise/platform/frontend: ">= v26.1.1"
+        enterprise/platform/migrate-db: ">= v26.1.1"
 ```
 
 Run the sync:

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/mirroring.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/mirroring.md
@@ -30,9 +30,9 @@ Create a YAML file (`seqera-images.yaml`) to specify which images to sync:
 ```yaml
 cr.seqera.io:
     images-by-semver:
-        enterprise/platform/backend: ">= v26.1.1"
-        enterprise/platform/frontend: ">= v26.1.1"
-        enterprise/platform/migrate-db: ">= v26.1.1"
+        enterprise/platform/backend: ">= v26.1.2"
+        enterprise/platform/frontend: ">= v26.1.2"
+        enterprise/platform/migrate-db: ">= v26.1.2"
 ```
 
 Run the sync:

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-kubernetes.md
@@ -141,7 +141,7 @@ spec:
   ...
       containers:
         - name: frontend
-          image: cr.seqera.io/enterprise/platform/frontend:v26.1.1-unprivileged
+          image: cr.seqera.io/enterprise/platform/frontend:v26.1.2-unprivileged
           env:
             - name: NGINX_LISTEN_PORT  # If not defined, defaults to 8000.
               value: 8000

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-kubernetes.md
@@ -141,7 +141,7 @@ spec:
   ...
       containers:
         - name: frontend
-          image: cr.seqera.io/enterprise/platform/frontend:v25.3.0-unprivileged
+          image: cr.seqera.io/enterprise/platform/frontend:v26.1.1-unprivileged
           env:
             - name: NGINX_LISTEN_PORT  # If not defined, defaults to 8000.
               value: 8000

--- a/platform-enterprise_versioned_docs/version-26.1/functionality_matrix/overview.md
+++ b/platform-enterprise_versioned_docs/version-26.1/functionality_matrix/overview.md
@@ -14,7 +14,7 @@ If no Nextflow version is specified in your configuration, Seqera defaults to th
 
 | Platform version | nf-launcher version | Nextflow version | Fusion version | Connect client version|
 | ---------------- | ------------------- | ---------------- | -------------- |-------------- |
-| 26.1.1           | j21-26.04           | 25.10.2          | 2.4            | 0.12.0        |
+| 26.1.2           | j21-26.04           | 25.10.2          | 2.4            | 0.12.0        |
 | 26.1.0           | j21-26.04           | 25.10.2          | 2.4            | 0.12.0        |
 | 25.3.6           | j21-25.10.2         | 25.10.2          | 2.4            | 0.11.0        |
 | 25.3.4           | j21-25.10.2         | 25.10.2          | 2.4            | 0.9.0         |

--- a/platform-enterprise_versioned_docs/version-26.1/functionality_matrix/overview.md
+++ b/platform-enterprise_versioned_docs/version-26.1/functionality_matrix/overview.md
@@ -2,7 +2,7 @@
 title: "Default version compatibility"
 description: "Platform / nf-launcher / Nextflow / Fusion version compatibility"
 date created: "2024-06-20"
-last updated: "2026-05-21"
+last updated: "2026-06-08"
 tags: [compatibility, nextflow, nf-launcher]
 ---
 

--- a/platform-enterprise_versioned_docs/version-26.1/functionality_matrix/overview.md
+++ b/platform-enterprise_versioned_docs/version-26.1/functionality_matrix/overview.md
@@ -14,6 +14,7 @@ If no Nextflow version is specified in your configuration, Seqera defaults to th
 
 | Platform version | nf-launcher version | Nextflow version | Fusion version | Connect client version|
 | ---------------- | ------------------- | ---------------- | -------------- |-------------- |
+| 26.1.1           | j21-26.04           | 25.10.2          | 2.4            | 0.12.0        |
 | 26.1.0           | j21-26.04           | 25.10.2          | 2.4            | 0.12.0        |
 | 25.3.6           | j21-25.10.2         | 25.10.2          | 2.4            | 0.11.0        |
 | 25.3.4           | j21-25.10.2         | 25.10.2          | 2.4            | 0.9.0         |


### PR DESCRIPTION
Bump pinned Docker image tags and Kubernetes manifests in version-26.1/ from 26.1.0 to 26.1.1, fix drifted 25.3.x references in mirroring.md and platform-kubernetes.md, and add a 26.1.1 row to the functionality matrix.