### PR TITLE
Fix broken metadata path check in check-cli-updates

### DIFF
--- a/.github/workflows/check-cli-updates.yml
+++ b/.github/workflows/check-cli-updates.yml
@@ -23,12 +23,17 @@ jobs:
       - name: Check if already documented
         id: check
         run: |
-          if [ -f "platform-cloud/docs/cli/metadata/cli-metadata-v${{ steps.cli-release.outputs.version }}.json" ]; then
+          # CLI metadata lives at platform-cli-docs/metadata/, not under
+          # platform-cloud/docs/cli/. The previous path never matched, so
+          # this check always evaluated to false and dispatched cli-release
+          # every single day for the same version.
+          METADATA_FILE="platform-cli-docs/metadata/cli-metadata-v${{ steps.cli-release.outputs.version }}.json"
+          if [ -f "$METADATA_FILE" ]; then
             echo "exists=true" >> $GITHUB_OUTPUT
-            echo "CLI v${{ steps.cli-release.outputs.version }} is already documented"
+            echo "CLI v${{ steps.cli-release.outputs.version }} is already documented ($METADATA_FILE)"
           else
             echo "exists=false" >> $GITHUB_OUTPUT
-            echo "CLI v${{ steps.cli-release.outputs.version }} needs documentation"
+            echo "CLI v${{ steps.cli-release.outputs.version }} needs documentation (expected $METADATA_FILE)"
           fi
 
       - name: Trigger update workflow


### PR DESCRIPTION
## Summary

[check-cli-updates.yml](.github/workflows/check-cli-updates.yml) polls tower-cli daily for new releases and is supposed to fire a `cli-release` dispatch only when the latest version isn't already documented. The existence check looked for metadata at `platform-cloud/docs/cli/metadata/cli-metadata-v<version>.json`, but CLI metadata actually lives at `platform-cli-docs/metadata/`. The wrong path never matched, so the workflow always evaluated `exists=false` and dispatched `cli-release` every day for the same version.

The downstream [update-cli-docs.yml](.github/workflows/update-cli-docs.yml) was re-running against the same `cli-docs-v<version>` branch each time, which `peter-evans/create-pull-request` deduplicates into a single PR — so the symptom was wasted CI minutes, not duplicate PRs.

## Change

Point the existence check at the correct directory (`platform-cli-docs/metadata/`) and surface the resolved path in the workflow log so future path drifts are easier to spot.

## Test plan

- [ ] Manual-dispatch with no input. Confirm the log line reads "is already documented" against the actual file under `platform-cli-docs/metadata/` (the most recent metadata version present in the repo).
- [ ] Confirm the workflow exits without dispatching `cli-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)