### PR TITLE
Add 20-minute timeout to check-internal-links

### DIFF
--- a/.github/workflows/check-internal-links.yml
+++ b/.github/workflows/check-internal-links.yml
@@ -6,6 +6,11 @@ on: [pull_request]
 jobs:
   check-internal-links:
     runs-on: ubuntu-latest
+    # `npm run build` can hang on Docusaurus regressions (infinite-loop
+    # plugins, runaway memory). Without a timeout the org default (360 min)
+    # ties up a runner. 20 minutes is comfortably above typical build time
+    # (~6-8 min) and well under the default.
+    timeout-minutes: 20
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Check out repo


### PR DESCRIPTION
## Summary

The [check-internal-links.yml](.github/workflows/check-internal-links.yml) job runs \`npm run build\` to verify Docusaurus has no broken internal links. Without a \`timeout-minutes\` setting the org default of 360 minutes applies — so a Docusaurus regression (infinite-loop plugin, runaway memory) ties up a runner for six hours before the job is killed.

20 minutes is comfortably above typical build time (~6-8 min) and well under the default.

## Test plan

- [ ] Confirm a normal PR still passes well within the new limit (logs show the build completing in <20 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)