### PR TITLE
fix: Use correct s3 action names for data lineage

### DIFF
--- a/platform-cloud/docs/compute-envs/_policies/aws-batch-full-policy.json
+++ b/platform-cloud/docs/compute-envs/_policies/aws-batch-full-policy.json
@@ -201,8 +201,8 @@
         "sqs:ReceiveMessage",
         "sqs:DeleteMessage",
         "s3:CreateBucket",
-        "s3:GetBucketNotificationConfiguration",
-        "s3:PutBucketNotificationConfiguration",
+        "s3:GetBucketNotification",
+        "s3:PutBucketNotification",
         "s3:GetBucketLocation"
       ],
       "Resource": [

--- a/platform-cloud/docs/compute-envs/_policies/aws-cloud-full-policy.json
+++ b/platform-cloud/docs/compute-envs/_policies/aws-cloud-full-policy.json
@@ -105,8 +105,8 @@
         "sqs:ReceiveMessage",
         "sqs:DeleteMessage",
         "s3:CreateBucket",
-        "s3:GetBucketNotificationConfiguration",
-        "s3:PutBucketNotificationConfiguration",
+        "s3:GetBucketNotification",
+        "s3:PutBucketNotification",
         "s3:GetBucketLocation"
       ],
       "Resource": [

--- a/platform-cloud/docs/compute-envs/aws-batch.mdx
+++ b/platform-cloud/docs/compute-envs/aws-batch.mdx
@@ -435,8 +435,8 @@ If you enable [data lineage](../data/data-lineage) in your workspace, add the fo
   "Effect": "Allow",
   "Action": [
     "s3:CreateBucket",
-    "s3:GetBucketNotificationConfiguration",
-    "s3:PutBucketNotificationConfiguration",
+    "s3:GetBucketNotification",
+    "s3:PutBucketNotification",
     "s3:GetBucketLocation"
   ],
   "Resource": "arn:aws:s3:::seqera-lineage-*"

--- a/platform-cloud/docs/compute-envs/aws-cloud.mdx
+++ b/platform-cloud/docs/compute-envs/aws-cloud.mdx
@@ -277,8 +277,8 @@ If you enable [data lineage](../data/data-lineage) in your workspace, add the fo
   "Effect": "Allow",
   "Action": [
     "s3:CreateBucket",
-    "s3:GetBucketNotificationConfiguration",
-    "s3:PutBucketNotificationConfiguration",
+    "s3:GetBucketNotification",
+    "s3:PutBucketNotification",
     "s3:GetBucketLocation"
   ],
   "Resource": "arn:aws:s3:::seqera-lineage-*"

--- a/platform-enterprise_docs/data/data-lineage.md
+++ b/platform-enterprise_docs/data/data-lineage.md
@@ -116,8 +116,8 @@ Platform integration credentials require the following additional permissions:
             "Effect": "Allow",
             "Action": [
                 "s3:CreateBucket",
-                "s3:GetBucketNotificationConfiguration",
-                "s3:PutBucketNotificationConfiguration",
+                "s3:GetBucketNotification",
+                "s3:PutBucketNotification",
                 "s3:GetBucketLocation"
             ],
             "Resource": "arn:aws:s3:::seqera-lineage-*"

--- a/platform-enterprise_versioned_docs/version-26.1/data/data-lineage.md
+++ b/platform-enterprise_versioned_docs/version-26.1/data/data-lineage.md
@@ -114,8 +114,8 @@ Platform integration credentials require the following additional permissions:
             "Effect": "Allow",
             "Action": [
                 "s3:CreateBucket",
-                "s3:GetBucketNotificationConfiguration",
-                "s3:PutBucketNotificationConfiguration",
+                "s3:GetBucketNotification",
+                "s3:PutBucketNotification",
                 "s3:GetBucketLocation"
             ],
             "Resource": "arn:aws:s3:::seqera-lineage-*"


### PR DESCRIPTION
This is a simple find and replace to use the correct s3 action names `s3:{Get,Put}BucketNotification`.