### PR TITLE
Fix Studios server/proxy image tags in enterprise deployment templates

### DIFF
--- a/platform-enterprise_docs/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_docs/enterprise/_templates/docker/docker-compose.yml
@@ -122,7 +122,7 @@ services:
 
 # Uncomment the following section to enable Studios functionality. See [Studios configuration](../../../studios/overview) for more information.
 #  connect-proxy:
-#    image: cr.seqera.io/enterprise/studios/proxy:0.12.0
+#    image: cr.seqera.io/enterprise/studios/proxy:0.11.0
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env
@@ -138,7 +138,7 @@ services:
 #     - $HOME/.tower/connect:/data
 #
 #  connect-server:
-#    image: cr.seqera.io/enterprise/studios/server:0.12.0
+#    image: cr.seqera.io/enterprise/studios/server:0.11.0
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env

--- a/platform-enterprise_docs/enterprise/_templates/k8s/data_studios/proxy.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/data_studios/proxy.yml
@@ -19,7 +19,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: proxy
-          image: cr.seqera.io/enterprise/studios/proxy:0.10.0
+          image: cr.seqera.io/enterprise/studios/proxy:0.11.0
           env:
             - name: CONNECT_HTTP_PORT
               value: "8081"

--- a/platform-enterprise_docs/enterprise/_templates/k8s/data_studios/server.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/data_studios/server.yml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: server
-          image: cr.seqera.io/enterprise/studios/server:0.12.0
+          image: cr.seqera.io/enterprise/studios/server:0.11.0
           ports:
             - containerPort: 7070
               name: server

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/docker-compose.yml
@@ -122,7 +122,7 @@ services:
 
 # Uncomment the following section to enable Studios functionality. See [Studios configuration](../../../studios/overview) for more information.
 #  connect-proxy:
-#    image: cr.seqera.io/enterprise/studios/proxy:0.12.0
+#    image: cr.seqera.io/enterprise/studios/proxy:0.11.0
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env
@@ -138,7 +138,7 @@ services:
 #     - $HOME/.tower/connect:/data
 #
 #  connect-server:
-#    image: cr.seqera.io/enterprise/studios/server:0.12.0
+#    image: cr.seqera.io/enterprise/studios/server:0.11.0
 #    platform: linux/amd64
 #    env_file:
 #      - data-studios.env

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/data_studios/proxy.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/data_studios/proxy.yml
@@ -19,7 +19,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: proxy
-          image: cr.seqera.io/enterprise/studios/proxy:0.10.0
+          image: cr.seqera.io/enterprise/studios/proxy:0.11.0
           env:
             - name: CONNECT_HTTP_PORT
               value: "8081"

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/data_studios/server.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/data_studios/server.yml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: server
-          image: cr.seqera.io/enterprise/studios/server:0.12.0
+          image: cr.seqera.io/enterprise/studios/server:0.11.0
           ports:
             - containerPort: 7070
               name: server


### PR DESCRIPTION
## Summary

The 26.1 enterprise release docs (#1303) introduced incorrect Studios image tags in the deployment templates, in both `platform-enterprise_docs/` and `platform-enterprise_versioned_docs/version-26.1/`:

- `enterprise/_templates/k8s/data_studios/server.yml` references `cr.seqera.io/enterprise/studios/server:0.12.0`, which was never published — 0.12.x is the Connect **client** version line, and the latest Connect **server** release is 0.11.0 (per the [Connect changelog](https://docs.seqera.io/platform-enterprise/studios/connect)). Manifest requests for `server:0.12.0` return 404, so customers following the [studios-kubernetes](https://docs.seqera.io/platform-enterprise/enterprise/studios-kubernetes) page get an unpullable image.
- `enterprise/_templates/k8s/data_studios/proxy.yml` was left at `proxy:0.10.0`, regressing it from the 0.11.0 that the 25.3 docs shipped.
- The commented-out Studios block in `enterprise/_templates/docker/docker-compose.yml` references `server:0.12.0` and `proxy:0.12.0`, both nonexistent.

This PR points all server/proxy references at 0.11.0, matching the 25.3 docs and the registry contents (verified against cr.seqera.io: server tags 0.10.0/0.11.0, proxy tags 0.10.0/0.11.0, no 0.12.0 for either).

Reported by a customer in FreshDesk ticket FD-7635.

## Changes

8 image-tag lines across 6 files; no other content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)