### PR TITLE
docs: add optional serviceAccountTokenCreator role for WIF + Data Explorer (GCP)

### DIFF
--- a/platform-cloud/docs/compute-envs/google-cloud-batch.md
+++ b/platform-cloud/docs/compute-envs/google-cloud-batch.md
@@ -112,6 +112,15 @@ Setting up WIF requires the following steps in the GCP Console:
   tityPools/{POOL}/providers/{PROVIDER}`. If you specify a custom value, it must match exactly what you enter in the Token audience field when creating the Google WIF credential in Seqera.
 4. Define an attribute mapping and condition. At a minimum set `google.subject=assertion.sub`. This maps the subject claim from Seqera's JWT to GCP's identity space. For more information see [here](https://docs.cloud.google.com/iam/docs/workload-identity-federation-with-other-providers#mappings-and-conditions). You may see a pop-up asking to configure your application and provide an OIDC ID token path. This pop-up can be dismissed.
 5. Grant `roles/iam.workloadIdentityUser` on the service account that WIF will impersonate to the Workload Identity Pool principal. This can be set for all pool identities or for a specific workspace. If you have not yet created a service account do so following the guidelines above.
+6. If you use the same WIF credential for Data Explorer, grant `roles/iam.serviceAccountTokenCreator` on the service account to itself:
+
+   ```bash
+   gcloud iam service-accounts add-iam-policy-binding SA_EMAIL \
+     --member="serviceAccount:SA_EMAIL" \
+     --role="roles/iam.serviceAccountTokenCreator"
+   ```
+
+   Replace `SA_EMAIL` with the service account email. Without this role, viewing or downloading file contents in Data Explorer fails with a signing error. Running pipelines is not affected.
 
 After setting up WIF in the GCP Console, you need the following information to create a credential in Seqera Platform:
 

--- a/platform-cloud/docs/compute-envs/google-cloud-batch.md
+++ b/platform-cloud/docs/compute-envs/google-cloud-batch.md
@@ -120,7 +120,7 @@ Setting up WIF requires the following steps in the GCP Console:
      --role="roles/iam.serviceAccountTokenCreator"
    ```
 
-   Replace `SA_EMAIL`, `PROJECT_NUMBER`, and `POOL_ID` with your values. Without this role, viewing or downloading file contents in Data Explorer fails. The Platform backend logs the underlying error as `SigningException: Failed to sign the provided bytes` caused by `Permission 'iam.serviceAccounts.signBlob' denied`. Running pipelines is not affected.
+   Replace `SA_EMAIL`, `PROJECT_NUMBER`, and `POOL_ID` with your values. Without this role, viewing or downloading file contents in Data Explorer fails. Seqera Platform logs the underlying error as `SigningException: Failed to sign the provided bytes` caused by `Permission 'iam.serviceAccounts.signBlob' denied`. Running pipelines is not affected.
 
    As with step 5, you can scope this binding to a specific workspace by replacing `principalSet://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/*` with `principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/subject/org:{ORG_ID}:wsp:{WORKSPACE_ID}:workflow`.
 

--- a/platform-cloud/docs/compute-envs/google-cloud-batch.md
+++ b/platform-cloud/docs/compute-envs/google-cloud-batch.md
@@ -120,7 +120,9 @@ Setting up WIF requires the following steps in the GCP Console:
      --role="roles/iam.serviceAccountTokenCreator"
    ```
 
-   Replace `SA_EMAIL`, `PROJECT_NUMBER`, and `POOL_ID` with your values. Without this role, viewing or downloading file contents in Data Explorer fails with a signing error. Running pipelines is not affected.
+   Replace `SA_EMAIL`, `PROJECT_NUMBER`, and `POOL_ID` with your values. Without this role, viewing or downloading file contents in Data Explorer fails. The Platform backend logs the underlying error as `SigningException: Failed to sign the provided bytes` caused by `Permission 'iam.serviceAccounts.signBlob' denied`. Running pipelines is not affected.
+
+   As with step 5, you can scope this binding to a specific workspace by replacing `principalSet://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/*` with `principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/subject/org:{ORG_ID}:wsp:{WORKSPACE_ID}:workflow`.
 
 After setting up WIF in the GCP Console, you need the following information to create a credential in Seqera Platform:
 

--- a/platform-cloud/docs/compute-envs/google-cloud-batch.md
+++ b/platform-cloud/docs/compute-envs/google-cloud-batch.md
@@ -112,15 +112,15 @@ Setting up WIF requires the following steps in the GCP Console:
   tityPools/{POOL}/providers/{PROVIDER}`. If you specify a custom value, it must match exactly what you enter in the Token audience field when creating the Google WIF credential in Seqera.
 4. Define an attribute mapping and condition. At a minimum set `google.subject=assertion.sub`. This maps the subject claim from Seqera's JWT to GCP's identity space. For more information see [here](https://docs.cloud.google.com/iam/docs/workload-identity-federation-with-other-providers#mappings-and-conditions). You may see a pop-up asking to configure your application and provide an OIDC ID token path. This pop-up can be dismissed.
 5. Grant `roles/iam.workloadIdentityUser` on the service account that WIF will impersonate to the Workload Identity Pool principal. This can be set for all pool identities or for a specific workspace. If you have not yet created a service account do so following the guidelines above.
-6. If you use the same WIF credential for Data Explorer, grant `roles/iam.serviceAccountTokenCreator` on the service account to itself:
+6. If you use the same WIF credential for Data Explorer, grant `roles/iam.serviceAccountTokenCreator` on the service account to the Workload Identity Pool principal:
 
    ```bash
    gcloud iam service-accounts add-iam-policy-binding SA_EMAIL \
-     --member="serviceAccount:SA_EMAIL" \
+     --member="principalSet://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/*" \
      --role="roles/iam.serviceAccountTokenCreator"
    ```
 
-   Replace `SA_EMAIL` with the service account email. Without this role, viewing or downloading file contents in Data Explorer fails with a signing error. Running pipelines is not affected.
+   Replace `SA_EMAIL`, `PROJECT_NUMBER`, and `POOL_ID` with your values. Without this role, viewing or downloading file contents in Data Explorer fails with a signing error. Running pipelines is not affected.
 
 After setting up WIF in the GCP Console, you need the following information to create a credential in Seqera Platform:
 

--- a/platform-enterprise_docs/compute-envs/google-cloud-batch.md
+++ b/platform-enterprise_docs/compute-envs/google-cloud-batch.md
@@ -107,15 +107,15 @@ Workload Identity Federation (WIF) is the recommended authentication method for 
 3. Set the Allowed audiences. If left empty, GCP derives a default audience from the provider resource path in the format `//iam.googleapis.com/projects/{PROJECT}/locations/global/workloadIdentityPools/{POOL}/providers/{PROVIDER}`. If you specify a custom value, it must match exactly what you enter in the Token audience field when creating the Google WIF credential in Seqera.
 4. Define an attribute mapping and condition. At a minimum set `google.subject=assertion.sub`. This maps the subject claim from Seqera's JWT to GCP's identity space. For more information see [here](https://docs.cloud.google.com/iam/docs/workload-identity-federation-with-other-providers#mappings-and-conditions)
 5. Grant `roles/iam.workloadIdentityUser` on the service account created above to the Workload Identity Pool principal. This can be set for all pool identities or for a specific workspace.
-6. If you use the same WIF credential for Data Explorer, grant `roles/iam.serviceAccountTokenCreator` on the service account to itself:
+6. If you use the same WIF credential for Data Explorer, grant `roles/iam.serviceAccountTokenCreator` on the service account to the Workload Identity Pool principal:
 
    ```bash
    gcloud iam service-accounts add-iam-policy-binding SA_EMAIL \
-     --member="serviceAccount:SA_EMAIL" \
+     --member="principalSet://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/*" \
      --role="roles/iam.serviceAccountTokenCreator"
    ```
 
-   Replace `SA_EMAIL` with the service account email. Without this role, viewing or downloading file contents in Data Explorer fails with a signing error. Running pipelines is not affected.
+   Replace `SA_EMAIL`, `PROJECT_NUMBER`, and `POOL_ID` with your values. Without this role, viewing or downloading file contents in Data Explorer fails with a signing error. Running pipelines is not affected.
 
 WIF requires an OIDC signing key and for Seqera Platform's OIDC provider to be configured. See [Cryptographic options](https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview#cryptographic-options).
 

--- a/platform-enterprise_docs/compute-envs/google-cloud-batch.md
+++ b/platform-enterprise_docs/compute-envs/google-cloud-batch.md
@@ -115,7 +115,9 @@ Workload Identity Federation (WIF) is the recommended authentication method for 
      --role="roles/iam.serviceAccountTokenCreator"
    ```
 
-   Replace `SA_EMAIL`, `PROJECT_NUMBER`, and `POOL_ID` with your values. Without this role, viewing or downloading file contents in Data Explorer fails with a signing error. Running pipelines is not affected.
+   Replace `SA_EMAIL`, `PROJECT_NUMBER`, and `POOL_ID` with your values. Without this role, viewing or downloading file contents in Data Explorer fails. The Platform backend logs the underlying error as `SigningException: Failed to sign the provided bytes` caused by `Permission 'iam.serviceAccounts.signBlob' denied`. Running pipelines is not affected.
+
+   As with step 5, you can scope this binding to a specific workspace by replacing `principalSet://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/*` with `principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/subject/org:{ORG_ID}:wsp:{WORKSPACE_ID}:workflow`.
 
 WIF requires an OIDC signing key and for Seqera Platform's OIDC provider to be configured. See [Cryptographic options](https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview#cryptographic-options).
 

--- a/platform-enterprise_docs/compute-envs/google-cloud-batch.md
+++ b/platform-enterprise_docs/compute-envs/google-cloud-batch.md
@@ -107,6 +107,15 @@ Workload Identity Federation (WIF) is the recommended authentication method for 
 3. Set the Allowed audiences. If left empty, GCP derives a default audience from the provider resource path in the format `//iam.googleapis.com/projects/{PROJECT}/locations/global/workloadIdentityPools/{POOL}/providers/{PROVIDER}`. If you specify a custom value, it must match exactly what you enter in the Token audience field when creating the Google WIF credential in Seqera.
 4. Define an attribute mapping and condition. At a minimum set `google.subject=assertion.sub`. This maps the subject claim from Seqera's JWT to GCP's identity space. For more information see [here](https://docs.cloud.google.com/iam/docs/workload-identity-federation-with-other-providers#mappings-and-conditions)
 5. Grant `roles/iam.workloadIdentityUser` on the service account created above to the Workload Identity Pool principal. This can be set for all pool identities or for a specific workspace.
+6. If you use the same WIF credential for Data Explorer, grant `roles/iam.serviceAccountTokenCreator` on the service account to itself:
+
+   ```bash
+   gcloud iam service-accounts add-iam-policy-binding SA_EMAIL \
+     --member="serviceAccount:SA_EMAIL" \
+     --role="roles/iam.serviceAccountTokenCreator"
+   ```
+
+   Replace `SA_EMAIL` with the service account email. Without this role, viewing or downloading file contents in Data Explorer fails with a signing error. Running pipelines is not affected.
 
 WIF requires an OIDC signing key and for Seqera Platform's OIDC provider to be configured. See [Cryptographic options](https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview#cryptographic-options).
 

--- a/platform-enterprise_docs/compute-envs/google-cloud-batch.md
+++ b/platform-enterprise_docs/compute-envs/google-cloud-batch.md
@@ -115,7 +115,7 @@ Workload Identity Federation (WIF) is the recommended authentication method for 
      --role="roles/iam.serviceAccountTokenCreator"
    ```
 
-   Replace `SA_EMAIL`, `PROJECT_NUMBER`, and `POOL_ID` with your values. Without this role, viewing or downloading file contents in Data Explorer fails. The Platform backend logs the underlying error as `SigningException: Failed to sign the provided bytes` caused by `Permission 'iam.serviceAccounts.signBlob' denied`. Running pipelines is not affected.
+   Replace `SA_EMAIL`, `PROJECT_NUMBER`, and `POOL_ID` with your values. Without this role, viewing or downloading file contents in Data Explorer fails. Seqera Platform logs the underlying error as `SigningException: Failed to sign the provided bytes` caused by `Permission 'iam.serviceAccounts.signBlob' denied`. Running pipelines is not affected.
 
    As with step 5, you can scope this binding to a specific workspace by replacing `principalSet://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/*` with `principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/subject/org:{ORG_ID}:wsp:{WORKSPACE_ID}:workflow`.
 


### PR DESCRIPTION
## Summary

- Adds step 6 to the Workload Identity Federation setup in both Cloud and Enterprise Google Cloud Batch docs
- `roles/iam.serviceAccountTokenCreator` is **optional** — required only when the same WIF credential is used for Data Explorer file preview/download
- Running pipelines is not affected; the gap only surfaces when a user views or downloads file contents via Data Explorer

## Why

With a stored SA JSON key, Platform signs presigned URLs locally using the embedded private key. With WIF there is no local private key, so Platform calls the GCP IAM `signBlob` API instead. That API requires `iam.serviceAccounts.signBlob`, which is not included in `roles/iam.workloadIdentityUser`. Without this role, Data Explorer returns an opaque error code on file open/download.

## Changes

- `platform-cloud/docs/compute-envs/google-cloud-batch.md`
- `platform-enterprise_docs/compute-envs/google-cloud-batch.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)