### PR TITLE
docs: Add Vale terminology linting, scoped to changed documentation

### DIFF
--- a/.github/styles/Seqera/Features.yml
+++ b/.github/styles/Seqera/Features.yml
@@ -1,37 +1,21 @@
-# Seqera Feature Terminology
-# Catches informal abbreviations and suggests full terms
-
+# Seqera feature terminology — unambiguous abbreviations and formatting.
+# Safe to enforce as errors: the corrected form is always right.
 extends: substitution
 message: "Use '%s' instead of '%s'"
 level: error
 ignorecase: true
 swap:
-  # Feature abbreviations - compute environment
+  # compute environment
   "compute env": compute environment
-  "Compute Env": compute environment
   "compute-env": compute environment
-  CE: compute environment
 
   # Credentials
   creds: credentials
-
-  # Repository
-  repo: repository
-  repos: repositories
-
-  # Configuration
-  config: configuration
-  configs: configurations
 
   # UI elements
   "drop down": drop-down
   dropdown: drop-down
   "drop-down menu": drop-down
 
-  # Workspace
+  # Workspace (two words is always wrong)
   "work space": workspace
-  Workspace: workspace
-
-  # Access tokens
-  "API token": access token
-  PAT: personal access token

--- a/.github/styles/Seqera/FeaturesContext.yml
+++ b/.github/styles/Seqera/FeaturesContext.yml
@@ -1,0 +1,24 @@
+# Context-dependent feature terms — flagged as warnings, not errors.
+# These abbreviations are often informal shorthand worth expanding, but
+# each has legitimate uses (CLI flags, file names, generic prose), so they
+# warn rather than block.
+extends: substitution
+message: "Consider '%s' instead of '%s' (verify the context)"
+level: warning
+ignorecase: true
+swap:
+  # CE can match unrelated initialisms
+  CE: compute environment
+
+  # repo/config appear in legitimate technical prose and file names
+  repo: repository
+  repos: repositories
+  config: configuration
+  configs: configurations
+
+  # Workspace capitalization is context-dependent
+  Workspace: workspace
+
+  # Token terminology depends on first-use expansion
+  "API token": access token
+  PAT: personal access token

--- a/.github/styles/Seqera/Products.yml
+++ b/.github/styles/Seqera/Products.yml
@@ -1,17 +1,10 @@
-# Seqera Product Terminology
-# Catches incorrect product names and suggests corrections
-
+# Seqera product names — unambiguous spelling and capitalization.
+# These are safe to enforce as errors: the corrected form is always right.
 extends: substitution
 message: "Use '%s' instead of '%s'"
 level: error
 ignorecase: false
 swap:
-  # Product names - Seqera Platform
-  Tower: Seqera Platform
-  "Nextflow Tower": Seqera Platform
-  "the platform": Seqera Platform
-  "the Platform": Seqera Platform
-
   # Nextflow variants
   NextFlow: Nextflow
   nextFlow: Nextflow
@@ -25,14 +18,10 @@ swap:
   Multiqc: MultiQC
 
   # Wave variants
-  wave: Wave
   WAVE: Wave
 
   # Fusion variants
-  fusion: Fusion
   FUSION: Fusion
 
   # Studios variants
   "Seqera Studios": Studios
-  studio: Studio
-  studios: Studios

--- a/.github/styles/Seqera/ProductsContext.yml
+++ b/.github/styles/Seqera/ProductsContext.yml
@@ -1,0 +1,22 @@
+# Context-dependent product names — flagged as warnings, not errors.
+# These corrections are usually right but have legitimate exceptions
+# (legacy "Tower" references, lowercase words that aren't product names),
+# so they should not block or dominate a review.
+extends: substitution
+message: "Consider '%s' instead of '%s' (verify the context)"
+level: warning
+ignorecase: false
+swap:
+  # Legacy product name — still valid in historical/versioned contexts
+  Tower: Seqera Platform
+  "Nextflow Tower": Seqera Platform
+
+  # "the platform" is often correct generic prose, not the product name
+  "the platform": Seqera Platform
+  "the Platform": Seqera Platform
+
+  # Lowercase product names — usually a capitalization slip, but not always
+  wave: Wave
+  fusion: Fusion
+  studio: Studio
+  studios: Studios

--- a/.github/workflows/docs-review.yml
+++ b/.github/workflows/docs-review.yml
@@ -204,13 +204,34 @@ jobs:
         with:
           ref: ${{ github.event_name == 'issue_comment' && steps.pr-ref.outputs.head_ref || '' }}
 
+      - name: Collect changed docs files
+        id: vale-files
+        run: |
+          # Only lint the docs files changed in this PR (from the paths-filter
+          # in the `changes` job, emitted as a JSON array). This keeps Vale
+          # scoped to changed files; filter_mode below scopes comments to
+          # changed lines.
+          FILES=$(echo '${{ needs.changes.outputs.docs_files }}' | jq -r '.[]')
+          if [ -z "$FILES" ]; then
+            echo "has_files=false" >> "$GITHUB_OUTPUT"
+            echo "No changed docs files — skipping Vale."
+            exit 0
+          fi
+          echo "has_files=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "files<<VALE_EOF"
+            echo "$FILES"
+            echo "VALE_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Vale will check these files:"
+          echo "$FILES" | sed 's/^/  /'
+
       - name: Vale Terminology Check
+        if: steps.vale-files.outputs.has_files == 'true'
         uses: errata-ai/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # v2.1.2
         with:
-          files: |
-            platform-enterprise_docs
-            platform-cloud/docs
-            platform-enterprise_versioned_docs
+          files: ${{ steps.vale-files.outputs.files }}
+          filter_mode: added # Only comment on lines changed in this PR
           reporter: github-pr-review
           fail_on_error: false # Post suggestions without blocking
         env:

--- a/.github/workflows/vale-comment.yml
+++ b/.github/workflows/vale-comment.yml
@@ -1,0 +1,88 @@
+name: Run Vale when requested via comment
+
+# Lightweight, on-demand terminology check. Comment "run vale" on a PR to lint
+# only the changed documentation, with review comments scoped to changed lines.
+# This is the Vale-only subset of the full /editorial-review workflow — fast,
+# free, and no LLM involved.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  vale:
+    runs-on: ubuntu-latest
+    # Only run on PR comments that start with the magic phrase.
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, 'run vale')
+
+    steps:
+      - name: Acknowledge command
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "🔍 Running Vale on the changed documentation in this PR…"
+
+      # The event is an issue comment, so check out the PR head explicitly.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout the PR head
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr checkout ${{ github.event.issue.number }}
+
+      - name: Collect changed docs files
+        id: vale-files
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BASE_REF=$(gh pr view ${{ github.event.issue.number }} --json baseRefName --jq '.baseRefName')
+          git fetch origin "$BASE_REF"
+
+          # Changed .md/.mdx files in the reviewed docs directories. Vale lints
+          # only these; filter_mode below scopes comments to changed lines.
+          FILES=$(git diff --name-only --diff-filter=ACM "origin/${BASE_REF}...HEAD" -- '*.md' '*.mdx' \
+            | grep -E '^(platform-enterprise_docs|platform-cloud/docs|platform-enterprise_versioned_docs)/' || true)
+
+          if [ -z "$FILES" ]; then
+            echo "has_files=false" >> "$GITHUB_OUTPUT"
+            echo "No changed docs files — nothing for Vale to check."
+            exit 0
+          fi
+          echo "has_files=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "files<<VALE_EOF"
+            echo "$FILES"
+            echo "VALE_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Vale will check these files:"
+          echo "$FILES" | sed 's/^/  /'
+
+      - name: Vale Terminology Check
+        if: steps.vale-files.outputs.has_files == 'true'
+        uses: errata-ai/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # v2.1.2
+        with:
+          files: ${{ steps.vale-files.outputs.files }}
+          filter_mode: added # Only comment on lines changed in this PR
+          reporter: github-pr-review
+          fail_on_error: false # Post suggestions without blocking
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Report when nothing changed
+        if: steps.vale-files.outputs.has_files == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "✅ Vale found no changed documentation files to check."

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,47 +1,52 @@
-# Vale configuration for Seqera documentation
-# Minimal setup - only catches terminology issues you care about
+# Vale configuration for Seqera documentation.
+# Catches terminology issues; context-dependent rules warn instead of block.
 
 StylesPath = .github/styles
 
-# Download packages from Vale package hub
+# Download packages from the Vale package hub (run `vale sync` after changes).
 Packages = write-good
 
-# Only check markdown files
+# Treat .mdx as Markdown. Without this, Vale 3.x tries to use the external
+# `mdx2vast` binary and errors out on every .mdx file.
+[formats]
+mdx = md
+
+# Shared settings applied to both .md and .mdx via the sections below.
+#
+# Seqera styles (levels are defined per rule file in .github/styles/Seqera/):
+#   - Products, Features              -> error   (unambiguous fixes)
+#   - ProductsContext, FeaturesContext -> warning (context-dependent)
+#
+# Note: a substitution rule's level applies to the whole rule. To change the
+# level of an individual term, move it between the error and *Context files —
+# you cannot override a single swap from this file.
+
 [*.md]
 BasedOnStyles = Seqera, write-good
 
-# Make context-dependent rules warnings (not blockers)
-Seqera.Features.CE = warning           # CE might match unrelated terms
-Seqera.Features.Workspace = warning    # Workspace capitalization is context-dependent
-Seqera.Features.PAT = warning          # PAT expansion depends on first use
-Seqera.Products.Tower = warning        # Tower is OK in legacy contexts
-
 # Disable noisy write-good rules
-write-good.Weasel = NO                 # "very", "really" sometimes needed
-write-good.ThereIs = NO                # "There is" is fine in technical docs
-write-good.So = NO                     # "So" is fine for transitions
-write-good.Passive = suggestion        # Passive voice is OK sometimes
+write-good.Weasel = NO           # "very", "really" sometimes needed
+write-good.ThereIs = NO          # "There is" is fine in technical docs
+write-good.So = NO               # "So" is fine for transitions
+write-good.E-Prime = NO          # flags every "to be" verb — far too noisy
+write-good.Passive = suggestion  # Passive voice is OK sometimes
+write-good.TooWordy = suggestion # Don't block on wordiness
+write-good.Cliches = suggestion  # Don't block on clichés
 
-# Also check MDX files
+# Ignore inline code, fenced code blocks, and frontmatter
+BlockIgnores = (?s) *(`{3}.*?`{3})
+BlockIgnores = (?s)^---.*?---
+TokenIgnores = (`[^`]+`)
+
 [*.mdx]
 BasedOnStyles = Seqera, write-good
-
-# Same overrides for MDX
-Seqera.Features.CE = warning
-Seqera.Features.Workspace = warning
-Seqera.Features.PAT = warning
-Seqera.Products.Tower = warning
 write-good.Weasel = NO
 write-good.ThereIs = NO
 write-good.So = NO
+write-good.E-Prime = NO
 write-good.Passive = suggestion
-
-# Ignore code blocks entirely
+write-good.TooWordy = suggestion
+write-good.Cliches = suggestion
 BlockIgnores = (?s) *(`{3}.*?`{3})
-TokenIgnores = (`[^`]+`)
-
-# Ignore frontmatter
 BlockIgnores = (?s)^---.*?---
-
-# Paths to check (relative patterns)
-# Vale will check files matching these when run
+TokenIgnores = (`[^`]+`)

--- a/VALE_SETUP.md
+++ b/VALE_SETUP.md
@@ -7,22 +7,54 @@ Complete setup guide for Vale linting integration with editorial workflows.
 - **Vale** - Fast, free terminology checker (catches 80% of issues in 2 seconds)
 - **Claude AI** - Context-aware review (catches nuanced issues Vale can't)
 - **VSCode integration** - Inline feedback as you type
-- **CI integration** - Automated PR reviews
+- **CI integration** - On-demand PR reviews (comment-triggered), scoped to changed lines
+
+## Scope: changed documentation only
+
+Vale only reports issues on the documentation you actually changed:
+
+- **CI** (`docs-review.yml`, `vale-lint` job): Vale runs only on the `.md`/`.mdx`
+  files changed in the PR, and `filter_mode: added` restricts review comments to
+  the lines you added or modified. Editing one section of a long page never
+  surfaces pre-existing issues elsewhere in that file.
+- **Local**: lint the files you changed by passing them to `npm run vale` (see
+  [Command line](#option-2-command-line-manual)). Locally Vale lints whole files
+  rather than only changed lines — line-level filtering needs the PR diff, which
+  only CI provides.
+
+## Rule levels: error vs. warning
+
+Terminology rules are split by confidence (see `.github/styles/Seqera/`):
+
+- **`Products.yml`, `Features.yml`** — `error`. Unambiguous fixes (`NextFlow` →
+  `Nextflow`, `compute env` → `compute environment`).
+- **`ProductsContext.yml`, `FeaturesContext.yml`** — `warning`. Context-dependent
+  terms with legitimate exceptions (`Tower`, `the platform`, `repo`, `config`,
+  `CE`, `Workspace`). These never block and don't dominate a review.
+
+A substitution rule's level applies to the whole file — to change one term's
+level, move it between the error and `*Context` files.
+
+> **MDX note:** `.vale.ini` maps `mdx = md` under `[formats]`. Without this, Vale
+> 3.x tries to use the external `mdx2vast` binary and errors out on every `.mdx`
+> file. Don't remove that mapping.
 
 ## Files created
 
 ```
 docs/
-├── .vale.ini                              # Vale configuration
-├── .pre-commit-config.yaml                # Pre-commit hooks (updated)
-├── .gitignore                             # Updated to ignore .vscode/
+├── .vale.ini                              # Vale configuration (incl. mdx = md)
+├── .pre-commit-config.yaml                # Pre-commit hooks
+├── .gitignore                             # Ignores .vscode/
 ├── .github/
 │   ├── styles/
 │   │   └── Seqera/
-│   │       ├── Products.yml               # Product name rules
-│   │       └── Features.yml               # Feature terminology rules
+│   │       ├── Products.yml               # Product names (error)
+│   │       ├── Features.yml               # Feature terms (error)
+│   │       ├── ProductsContext.yml        # Context-dependent products (warning)
+│   │       └── FeaturesContext.yml        # Context-dependent features (warning)
 │   └── workflows/
-│       └── docs-review.yml                # Updated workflow (Vale + AI)
+│       └── docs-review.yml                # Workflow (Vale changed-lines + AI)
 ```
 
 **Note:** VSCode settings are configured in User Settings (not workspace), so `.vscode/settings.json` is gitignored.
@@ -145,17 +177,15 @@ Vale runs automatically when you:
 ### Option 2: Command line (manual)
 
 ```bash
-# Check single file
-vale platform-enterprise_docs/getting-started.md
+# Download/refresh Vale packages (write-good) — run once after cloning
+npm run vale:sync
 
-# Check directory
-vale platform-enterprise_docs/
+# Check a single file or directory
+npm run vale -- platform-enterprise_docs/getting-started.md
+npm run vale -- platform-enterprise_docs/
 
-# Check all changed files
-git diff --name-only | grep -E '\.(md|mdx)$' | xargs vale
-
-# Check with config explicitly
-vale --config=.vale.ini path/to/file.md
+# Check only the files you changed on this branch
+git diff --name-only --diff-filter=ACM origin/master...HEAD -- '*.md' '*.mdx' | xargs vale --config=.vale.ini
 ```
 
 ### Option 3: Pre-commit (Manual)
@@ -170,12 +200,16 @@ pre-commit run vale
 
 **Note:** Pre-commit Vale hook is set to `manual` stage, so it does NOT run automatically on `git commit`.
 
-### Option 4: CI/CD (Automatic)
+### Option 4: CI/CD (on-demand)
 
-Vale runs automatically on GitHub when:
-- PR is opened
-- PR is updated (new commits)
-- Files in `platform-*` directories are changed
+The `docs-review.yml` workflow is **on-demand**, not automatic on every PR.
+Trigger it by:
+- Commenting `/editorial-review` on a PR, or
+- Manually dispatching the **Documentation Review** workflow from the Actions tab
+
+When it runs, the `vale-lint` job checks only the changed `.md`/`.mdx` files and
+posts review comments only on changed lines (`filter_mode: added`,
+`fail_on_error: false` — suggestions don't block).
 
 ## Validation and testing
 
@@ -262,43 +296,47 @@ git reset HEAD test-vale.md
 
 ### Test 6: CI integration (after merging)
 
-1. Create a test PR with a small change
-2. Push to GitHub
-3. Check PR → Actions tab
-4. Verify Vale job runs and completes
-5. Check PR → Files changed
-6. Look for Vale inline review comments
+1. Create a test PR that changes a docs file with a known issue
+2. Comment `run vale` on the PR (CI does not run Vale automatically)
+3. Check PR → Actions tab and verify the Vale job runs and completes
+4. Check PR → Files changed
+5. Look for Vale inline review comments on the changed lines
 
 ## Vale rules summary
 
-### Product names (Products.yml)
+### Errors (always wrong)
+
+Product names (`Products.yml`):
 
 | Wrong | Correct |
 |-------|---------|
-| Tower | Seqera Platform |
-| NextFlow | Nextflow |
-| wave | Wave |
-| fusion | Fusion |
-| studio/studios | Studio/Studios |
-| multi-qc | MultiQC |
+| NextFlow / nextFlow / next-flow / NEXTFLOW | Nextflow |
+| multi-qc / multiQC / Multi-QC / Multiqc | MultiQC |
+| WAVE | Wave |
+| FUSION | Fusion |
+| Seqera Studios | Studios |
 
-### Feature terms (Features.yml)
+Feature terms (`Features.yml`):
 
 | Wrong | Correct |
 |-------|---------|
-| compute env | compute environment |
+| compute env / compute-env | compute environment |
 | creds | credentials |
-| repo | repository |
-| config | configuration |
-| dropdown | drop-down |
+| dropdown / drop down / drop-down menu | drop-down |
 | work space | workspace |
 
-### write-good package
+### Warnings (context-dependent — verify before applying)
 
-Checks for:
-- Passive voice (suggestions only)
-- Weasel words (disabled - "very", "really" OK)
-- "There is" constructions (disabled - fine for technical docs)
+Products (`ProductsContext.yml`): `Tower`, `Nextflow Tower`, `the platform` →
+Seqera Platform; lowercase `wave`/`fusion`/`studio`/`studios` → capitalized.
+
+Features (`FeaturesContext.yml`): `CE`, `repo`, `config`, `Workspace`,
+`API token`, `PAT`.
+
+### write-good package (suggestions)
+
+- Passive voice, wordiness, clichés — suggestions only (don't block)
+- Disabled as too noisy: Weasel, ThereIs, So, **E-Prime** (flags every "to be")
 
 ## Daily workflow
 
@@ -311,26 +349,25 @@ Open file → See errors inline → Fix → Save → Commit
 ### Option 2: Manual check before commit
 
 ```bash
-# Check specific files
-vale platform-enterprise_docs/getting-started.md
-
-# Or check all changed files
-git diff --name-only | xargs vale
+# Check the files you changed on this branch
+git diff --name-only --diff-filter=ACM origin/master...HEAD -- '*.md' '*.mdx' | xargs vale --config=.vale.ini
 
 # Fix issues, then commit
 git commit -m "Update docs"
 ```
 
-### Option 3: Let CI catch it
+### Option 3: Request a check on the PR
 
-```bash
-# Just commit and push
-git commit -m "Update docs"
-git push
+CI does **not** run Vale automatically on push. After opening a PR, comment one
+of the following to run it on demand:
 
-# Vale runs in CI, posts inline comments
-# Fix using GitHub "Commit suggestion" button
+```text
+run vale            # Vale only (fast, no LLM) — see vale-comment.yml
+/editorial-review   # Vale + the Claude editorial agents — see docs-review.yml
 ```
+
+Either posts inline review comments on the changed lines, which you can apply
+with the GitHub "Commit suggestion" button.
 
 ## When Vale runs
 
@@ -351,12 +388,16 @@ Vale runs in three different contexts:
 - **Purpose:** Check before pushing (optional)
 - **Note:** Does NOT run automatically on `git commit` (set to manual stage)
 
-### 3. GitHub Actions (Automated)
-- **Trigger:** PR opened/updated to `platform-*` directories
-- **How:** CI workflow runs Vale, then Claude agents
+### 3. GitHub Actions (on-demand)
+- **Trigger:** A PR comment — `run vale` (Vale only) or `/editorial-review`
+  (Vale + Claude agents) — or a manual workflow dispatch. **Not** automatic on
+  PR open/push.
+- **How:** `vale-comment.yml` runs Vale alone; `docs-review.yml` runs Vale then
+  the Claude agents behind a smart-gate
+- **Scope:** Only changed `.md`/`.mdx` files; comments only on changed lines
 - **Feedback:** Inline PR review comments
-- **Speed:** 2 seconds (Vale), then 30 seconds (Claude)
-- **Purpose:** Automated review on PRs
+- **Speed:** ~2 seconds (Vale), then ~30 seconds (Claude, if invoked)
+- **Purpose:** On-demand review without blocking the PR
 
 ## Workflow summary
 
@@ -376,26 +417,21 @@ Local Development
     Standard pre-commit hooks run (trailing whitespace, etc.)
     Vale does NOT run automatically
     ↓
-6. Push to GitHub
+6. Push to GitHub and open a PR
     ↓
-PR Workflow (Automated)
+PR Workflow (on-demand — nothing runs until you ask)
     ↓
-7. PR opened → CI runs
+7. Comment on the PR to trigger a review:
     ↓
-    a. Vale (2 sec, free)
-       - Checks product names, feature terms
+    a. "run vale"  →  Vale only (~2 sec, free)
+       - Checks changed lines in changed docs files
        - Posts inline PR comments
        - Does NOT block (fail_on_error: false)
     ↓
-    b. Claude AI (30 sec, costs tokens)
-       - SKIPS what Vale already checked
-       - Checks formatting, context-dependent issues
-       - Posts inline PR comments
-    ↓
-8. Review Summary Posted
-    - Vale results (Terminology)
-    - AI results (Voice/Tone, Terminology)
-    - Up to 60 inline suggestions
+    b. "/editorial-review"  →  Vale + Claude (~30 sec, costs tokens)
+       - Vale first, then the Claude editorial agents
+       - Smart-gate skips tiny/duplicate runs
+       - Posts inline PR comments + a summary
 ```
 
 ## Token savings
@@ -521,6 +557,6 @@ Cmd+Shift+P → "Vale: Toggle Linting"
 
 ---
 
-**Setup Date**: 2026-02-03
-**Vale Version**: 3.0.7
+**Last updated**: 2026-06-16
+**Vale Version**: 3.13.0
 **write-good Version**: Latest from package hub

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "fetch-docs": "node internal/fetch-docs.mjs",
     "fetch-docs-oss": "node internal/fetch-docs-oss.mjs",
     "sanitize-existing": "node internal/sanitize-existing.mjs",
-    "markdownlint": "markdownlint-cli2 'platform-enterprise_versioned_docs/**/*.mdx' 'platform-cloud/docs/*.mdx' 'wave_docs/**/*.mdx' 'fusion_docs/**/*.mdx' --config .markdownlint-cli2.cjs"
+    "markdownlint": "markdownlint-cli2 'platform-enterprise_versioned_docs/**/*.mdx' 'platform-cloud/docs/*.mdx' 'wave_docs/**/*.mdx' 'fusion_docs/**/*.mdx' --config .markdownlint-cli2.cjs",
+    "vale": "vale --config=.vale.ini",
+    "vale:sync": "vale sync"
   },
   "dependencies": {
     "@docusaurus/faster": "^3.9.2",


### PR DESCRIPTION
Sets up Vale for the docs, scoped so it only flags the documentation you actually changed — not whole files or pre-existing issues elsewhere.

### What changed

**Config (`.vale.ini`)**

- Added `[formats] mdx = md` — without it, Vale 3.x errors on every `.mdx` file (most of the repo).
- Removed dead per-term overrides (`Seqera.Products.Tower = warning`, etc.) that never worked — you can't re-level a single swap inside a substitution rule.
- Disabled `write-good.E-Prime` (flags every "to be" verb) and softened TooWordy/Cliches to suggestions.

**Terminology rules (`.github/styles/Seqera/`)**

- Split into error vs. warning by confidence:
  - `Products.yml` / `Features.yml` — errors, unambiguous fixes (NextFlow → Nextflow, compute env → compute environment).
  - `ProductsContext.yml` / `FeaturesContext.yml` — warnings, context-dependent terms (Tower, the platform, repo, config, CE, Workspace) that have legitimate exceptions and shouldn't block.

**CI (`docs-review.yml`)**

- The `vale-lint` job now lints only the changed `.md`/`.mdx` files and posts comments only on changed lines (`filter_mode: added`).

**New run vale comment trigger (`vale-comment.yml`)**

- Comment run vale on a PR for a fast, Vale-only check (no LLM, no token cost) — the lightweight counterpart to /editorial-review. Report-only, scoped to changed lines.

**Local tooling**

- Added `npm run vale` and `npm run vale:sync` for ad-hoc local checks. To lint just your changed files: `git diff --name-only --diff-filter=ACM origin/master...HEAD -- '*.md' '*.mdx' | xargs vale  --config=.vale.ini`.

**Docs (`VALE_SETUP.md`)**

- Corrected to reflect on-demand triggering (Vale does not run automatically on PR open/push), the error/warning split, and the available commands.

**Notes**

- All workflows are on-demand (comment `run vale` or `/editorial-review`, or manual dispatch) — nothing runs automatically on push.
- run vale only takes effect once this merges to `master` (GitHub runs `issue_comment` workflows from the base branch).