### PR TITLE
Replace Azure Cache for Redis with Azure Managed Redis recommendation [EDU-1059]

### DIFF
--- a/personas/devops-persona.md
+++ b/personas/devops-persona.md
@@ -16,7 +16,7 @@ This approach enables us to maintain documentation that serves our intended audi
     - [MySQL on Compute Engine | Google Cloud Documentation](https://docs.cloud.google.com/compute/docs/instances/mysql/discover-mysql)
     - [Memorystore: in-memory Redis compatible data store | Google Cloud](https://cloud.google.com/memorystore?hl=en)
   - Azure
-    - [Azure Cache for Redis | Microsoft Azure](https://azure.microsoft.com/en-us/products/cache)
+    - [Azure Managed Redis | Microsoft Learn](https://learn.microsoft.com/azure/redis/overview)
     - [Azure Database for MySQL documentation | Microsoft Learn](https://learn.microsoft.com/en-us/azure/mysql/)
   - Redis
     - [Install on Kubernetes | Docs](https://redis.io/docs/latest/operate/redisinsight/install/install-on-k8s/)

--- a/platform-enterprise_docs/enterprise/configuration/overview.mdx
+++ b/platform-enterprise_docs/enterprise/configuration/overview.mdx
@@ -174,7 +174,11 @@ GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CR
 
 ### Managed Redis services
 
-Seqera supports managed Redis services such as [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html), [Azure Cache for Redis](https://learn.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-overview), or [Google Memorystore](https://cloud.google.com/memorystore/docs/redis).
+Seqera supports managed Redis services such as [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html), [Azure Managed Redis](https://learn.microsoft.com/azure/redis/overview), or [Google Memorystore](https://cloud.google.com/memorystore/docs/redis).
+
+:::caution
+Microsoft is retiring Azure Cache for Redis. As of April 1, 2026, new customers cannot create instances, and from October 1, 2026, no new instances can be created. For new Azure deployments, use [Azure Managed Redis](https://learn.microsoft.com/azure/redis/overview).
+:::
 
 When using a managed Redis service, you must specify the service IP address or DNS name for the `TOWER_REDIS_URL` as described in the following sections.
 
@@ -190,11 +194,11 @@ TOWER_REDIS_URL=redis://<redis private IP>:6379
 ```
 
 </TabItem>
-<TabItem value="Azure Cache for Redis" label="Azure Cache for Redis" default>
+<TabItem value="Azure Managed Redis" label="Azure Managed Redis" default>
 
 - Use a single-node cluster, as multi-node clusters are not supported
-- Use an instance with at least 6 GB capacity ([C3](https://azure.microsoft.com/en-gb/pricing/details/cache/) or greater)
-- Specify your private Azure Cache for Redis instance in the Seqera environment variables:
+- Choose a production-capable [Azure Managed Redis tier](https://learn.microsoft.com/azure/redis/overview) appropriate for your workload
+- Specify your private Azure Managed Redis instance in the Seqera environment variables:
 
 ```bash
 TOWER_REDIS_URL=redis://<redis private IP>:6379

--- a/platform-enterprise_docs/enterprise/platform-docker-compose.md
+++ b/platform-enterprise_docs/enterprise/platform-docker-compose.md
@@ -63,8 +63,12 @@ The Redisson client embedded in Platform 26.1+ supports Valkey 7 dial schema —
 Use a managed cache service for production:
 
 - [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html) (`cache.m4.large` or larger)
-- [Azure Cache for Redis](https://learn.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-overview) (C3 tier or larger)
+- [Azure Managed Redis](https://learn.microsoft.com/azure/redis/overview) (production-capable tier appropriate for your workload)
 - [Google Memorystore](https://cloud.google.com/memorystore/docs/redis) (M2 tier or larger)
+
+:::caution
+Microsoft is retiring Azure Cache for Redis. As of April 1, 2026, new customers cannot create instances, and from October 1, 2026, no new instances can be created. For new Azure deployments, use [Azure Managed Redis](https://learn.microsoft.com/azure/redis/overview).
+:::
 
 For migration guidance from Redis to Valkey on an existing installation, see [Cache layer changes](./upgrade#cache-layer-changes-redis-eol-and-valkey-support).
 

--- a/platform-enterprise_docs/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_docs/enterprise/platform-kubernetes.md
@@ -69,8 +69,12 @@ The Redisson client embedded in Platform 26.1+ supports Valkey 7 dial schema —
 Use a managed cache service for production:
 
 - [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html) (`cache.m4.large` or larger)
-- [Azure Cache for Redis](https://learn.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-overview) (C3 tier or larger)
+- [Azure Managed Redis](https://learn.microsoft.com/azure/redis/overview) (production-capable tier appropriate for your workload)
 - [Google Memorystore](https://cloud.google.com/memorystore/docs/redis) (M2 tier or larger)
+
+:::caution
+Microsoft is retiring Azure Cache for Redis. As of April 1, 2026, new customers cannot create instances, and from October 1, 2026, no new instances can be created. For new Azure deployments, use [Azure Managed Redis](https://learn.microsoft.com/azure/redis/overview).
+:::
 
 For migration guidance from Redis to Valkey on an existing installation, see [Cache layer changes](./upgrade#cache-layer-changes-redis-eol-and-valkey-support).
 

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/overview.mdx
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/overview.mdx
@@ -174,7 +174,11 @@ GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CR
 
 ### Managed Redis services
 
-Seqera supports managed Redis services such as [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html), [Azure Cache for Redis](https://learn.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-overview), or [Google Memorystore](https://cloud.google.com/memorystore/docs/redis).
+Seqera supports managed Redis services such as [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html), [Azure Managed Redis](https://learn.microsoft.com/azure/redis/overview), or [Google Memorystore](https://cloud.google.com/memorystore/docs/redis).
+
+:::caution
+Microsoft is retiring Azure Cache for Redis. As of April 1, 2026, new customers cannot create instances, and from October 1, 2026, no new instances can be created. For new Azure deployments, use [Azure Managed Redis](https://learn.microsoft.com/azure/redis/overview).
+:::
 
 When using a managed Redis service, you must specify the service IP address or DNS name for the `TOWER_REDIS_URL` as described in the following sections.
 
@@ -190,11 +194,11 @@ TOWER_REDIS_URL=redis://<redis private IP>:6379
 ```
 
 </TabItem>
-<TabItem value="Azure Cache for Redis" label="Azure Cache for Redis" default>
+<TabItem value="Azure Managed Redis" label="Azure Managed Redis" default>
 
 - Use a single-node cluster, as multi-node clusters are not supported
-- Use an instance with at least 6 GB capacity ([C3](https://azure.microsoft.com/en-gb/pricing/details/cache/) or greater)
-- Specify your private Azure Cache for Redis instance in the Seqera environment variables:
+- Choose a production-capable [Azure Managed Redis tier](https://learn.microsoft.com/azure/redis/overview) appropriate for your workload
+- Specify your private Azure Managed Redis instance in the Seqera environment variables:
 
 ```bash
 TOWER_REDIS_URL=redis://<redis private IP>:6379

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-docker-compose.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-docker-compose.md
@@ -63,8 +63,12 @@ The Redisson client embedded in Platform 26.1+ supports Valkey 7 dial schema —
 Use a managed cache service for production:
 
 - [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html) (`cache.m4.large` or larger)
-- [Azure Cache for Redis](https://learn.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-overview) (C3 tier or larger)
+- [Azure Managed Redis](https://learn.microsoft.com/azure/redis/overview) (production-capable tier appropriate for your workload)
 - [Google Memorystore](https://cloud.google.com/memorystore/docs/redis) (M2 tier or larger)
+
+:::caution
+Microsoft is retiring Azure Cache for Redis. As of April 1, 2026, new customers cannot create instances, and from October 1, 2026, no new instances can be created. For new Azure deployments, use [Azure Managed Redis](https://learn.microsoft.com/azure/redis/overview).
+:::
 
 For migration guidance from Redis to Valkey on an existing installation, see [Cache layer changes](./upgrade#cache-layer-changes-redis-eol-and-valkey-support).
 

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-kubernetes.md
@@ -69,8 +69,12 @@ The Redisson client embedded in Platform 26.1+ supports Valkey 7 dial schema —
 Use a managed cache service for production:
 
 - [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html) (`cache.m4.large` or larger)
-- [Azure Cache for Redis](https://learn.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-overview) (C3 tier or larger)
+- [Azure Managed Redis](https://learn.microsoft.com/azure/redis/overview) (production-capable tier appropriate for your workload)
 - [Google Memorystore](https://cloud.google.com/memorystore/docs/redis) (M2 tier or larger)
+
+:::caution
+Microsoft is retiring Azure Cache for Redis. As of April 1, 2026, new customers cannot create instances, and from October 1, 2026, no new instances can be created. For new Azure deployments, use [Azure Managed Redis](https://learn.microsoft.com/azure/redis/overview).
+:::
 
 For migration guidance from Redis to Valkey on an existing installation, see [Cache layer changes](./upgrade#cache-layer-changes-redis-eol-and-valkey-support).
 


### PR DESCRIPTION
## Summary

Fixes https://seqera.atlassian.net/browse/EDU-1059

Microsoft is [retiring Azure Cache for Redis](https://techcommunity.microsoft.com/blog/azure-managed-redis/azure-cache-for-redis-retirement-what-to-know-and-how-to-prepare/4458721):

- **2026-04-01** — new customers can no longer create instances
- **2026-10-01** — no new instances can be created at all

Current Enterprise docs recommend Azure Cache for Redis as a production managed-Redis option. This PR updates the guidance to point to [Azure Managed Redis](https://learn.microsoft.com/azure/redis/overview) and adds a retirement caution next to each managed-Redis recommendation list.

Refs: [EDU-1059](https://seqera.atlassian.net/browse/EDU-1059)

## Scope

Enterprise-only (Cloud is unaffected — customers don't choose the managed Redis backend on Cloud). Applied to unversioned latest and the current released version (26.1). Older versioned snapshots (25.x, 24.x, 23.x) are left as-is.

### Files changed

**Unversioned**
- `platform-enterprise_docs/enterprise/configuration/overview.mdx`
- `platform-enterprise_docs/enterprise/platform-docker-compose.md`
- `platform-enterprise_docs/enterprise/platform-kubernetes.md`

**Version 26.1**
- `platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/overview.mdx`
- `platform-enterprise_versioned_docs/version-26.1/enterprise/platform-docker-compose.md`
- `platform-enterprise_versioned_docs/version-26.1/enterprise/platform-kubernetes.md`

**Persona**
- `personas/devops-persona.md` — link swap only

### Sizing wording

Replaced the C3-tier hint with "production-capable tier appropriate for your workload". Azure Managed Redis uses a different tier naming scheme than Azure Cache for Redis, so pinning a specific tier here would mislead customers. Happy to swap in a concrete tier if an SME has a preference.

## Test plan

- [ ] Netlify preview renders the three `:::caution` admonitions correctly on each affected page
- [ ] Tab label on `configuration/overview.mdx` reads **Azure Managed Redis** (not **Azure Cache for Redis**)
- [ ] External links to `learn.microsoft.com/azure/redis/overview` resolve
- [ ] No remaining unintentional `Azure Cache for Redis` references on the affected pages (the only ones left are inside the retirement caution itself, which is intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDU-1059]: https://seqera.atlassian.net/browse/EDU-1059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ