### PR TITLE
[Studios] Correct GitHub Copilot guidance for VS Code in AI coding assistants FAQ [EDU-1204]

### DIFF
--- a/platform-cloud/docs/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-cloud/docs/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -14,11 +14,11 @@ In your interactive analysis environment, open a new terminal and type `ls -la /
 
 ## Enabling AI coding assistants in Studios
 
-VS Code, RStudio, and Jupyter environments natively integrate with [GitHub Copilot][gh-copilot]. Enabling it requires a GitHub Account and an active Copilot subscription.
+RStudio and Jupyter environments integrate with [GitHub Copilot][gh-copilot]. Enabling it requires a GitHub account and an active Copilot subscription.
 
-- **VS Code:** To enable GitHub Copilot in your VS Code session, install the extension and then sign in with your GitHub account. [Learn more][vscode-blog].
 - **RStudio:** To enable GitHub Copilot in your RStudio session requires RStudio configuration changes. By default, the Studio session user has root permissions, so configuration changes are possible. You will need to restart the RStudio once the required changes have been made. [Learn more][posit-ghcopilot-guide].
 - **Jupyter:** [Notebook Intelligence (NBI)][nbi] is an AI coding assistant and extensible AI framework for Jupyter. It can use GitHub Copilot or AI models from any other LLM Provider. [Learn more][nbi-blog].
+- **VS Code:** GitHub Copilot **cannot** be installed in the browser-based Studios VS Code session. Studios VS Code is built on [OpenVSCode Server][open-vscode-server], which uses the [Open VSX registry][open-vsx] instead of the Microsoft VS Code Marketplace. GitHub does not publish the Copilot extension to Open VSX, and manual VSIX installation is not supported.
 
 ## Session size limited by compute environment advanced options: Head job CPUs and Head job memory
 
@@ -151,7 +151,8 @@ These are the false positive confirmed findings:
 {/* links */}
 
 [gh-copilot]: https://github.com/features/copilot
-[vscode-blog]: https://code.visualstudio.com/docs/copilot/setup-simplified
+[open-vscode-server]: https://github.com/gitpod-io/openvscode-server
+[open-vsx]: https://open-vsx.org/
 [posit-ghcopilot-guide]: https://docs.posit.co/ide/user/ide/guide/tools/copilot.html
 [nbi]: https://github.com/notebook-intelligence/notebook-intelligence
 [nbi-blog]: https://blog.jupyter.org/introducing-notebook-intelligence-3648c306b91a

--- a/platform-enterprise_docs/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-enterprise_docs/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -14,11 +14,17 @@ In your interactive analysis environment, open a new terminal and type `ls -la /
 
 ## Enabling AI coding assistants in Studios
 
-VS Code, RStudio, and Jupyter environments natively integrate with [GitHub Copilot][gh-copilot]. Enabling it requires a GitHub Account and an active Copilot subscription.
+RStudio and Jupyter environments integrate with [GitHub Copilot][gh-copilot]. Enabling it requires a GitHub account and an active Copilot subscription.
 
-- **VS Code:** To enable GitHub Copilot in your VS Code session, install the extension and then sign in with your GitHub account. [Learn more][vscode-blog].
 - **RStudio:** To enable GitHub Copilot in your RStudio session requires RStudio configuration changes. By default, the Studio session user has root permissions, so configuration changes are possible. You will need to restart the RStudio once the required changes have been made. [Learn more][posit-ghcopilot-guide].
 - **Jupyter:** [Notebook Intelligence (NBI)][nbi] is an AI coding assistant and extensible AI framework for Jupyter. It can use GitHub Copilot or AI models from any other LLM Provider. [Learn more][nbi-blog].
+- **VS Code:** GitHub Copilot **cannot** be installed directly in the browser-based Studios VS Code session. Studios VS Code is built on [OpenVSCode Server][open-vscode-server], which uses the [Open VSX registry][open-vsx] instead of the Microsoft VS Code Marketplace. GitHub does not publish the Copilot extension to Open VSX, and manual VSIX installation is not supported.
+
+    To use Copilot with a Studios VS Code session, connect to the session from your local VS Code (with Copilot already installed and licensed) using the Remote SSH extension. See [Studios SSH configuration](../enterprise/studios-ssh) for setup.
+
+    :::note
+    SSH access requires admin enablement and Platform 25.3.3 or later with Connect server and proxy 0.10.0 or later.
+    :::
 
 ## Session size limited by compute environment advanced options: Head job CPUs and Head job memory
 
@@ -276,7 +282,8 @@ Debug logs include SSH handshake details, authentication attempts, channel lifec
 {/* links */}
 
 [gh-copilot]: https://github.com/features/copilot
-[vscode-blog]: https://code.visualstudio.com/docs/copilot/setup-simplified
+[open-vscode-server]: https://github.com/gitpod-io/openvscode-server
+[open-vsx]: https://open-vsx.org/
 [posit-ghcopilot-guide]: https://docs.posit.co/ide/user/ide/guide/tools/copilot.html
 [nbi]: https://github.com/notebook-intelligence/notebook-intelligence
 [nbi-blog]: https://blog.jupyter.org/introducing-notebook-intelligence-3648c306b91a

--- a/platform-enterprise_versioned_docs/version-25.3/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-enterprise_versioned_docs/version-25.3/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -14,11 +14,17 @@ In your interactive analysis environment, open a new terminal and type `ls -la /
 
 ## Enabling AI coding assistants in Studios
 
-VS Code, RStudio, and Jupyter environments natively integrate with [GitHub Copilot][gh-copilot]. Enabling it requires a GitHub Account and an active Copilot subscription.
+RStudio and Jupyter environments integrate with [GitHub Copilot][gh-copilot]. Enabling it requires a GitHub account and an active Copilot subscription.
 
-- **VS Code:** To enable GitHub Copilot in your VS Code session, install the extension and then sign in with your GitHub account. [Learn more][vscode-blog].
 - **RStudio:** To enable GitHub Copilot in your RStudio session requires RStudio configuration changes. By default, the Studio session user has root permissions, so configuration changes are possible. You will need to restart the RStudio once the required changes have been made. [Learn more][posit-ghcopilot-guide].
 - **Jupyter:** [Notebook Intelligence (NBI)][nbi] is an AI coding assistant and extensible AI framework for Jupyter. It can use GitHub Copilot or AI models from any other LLM Provider. [Learn more][nbi-blog].
+- **VS Code:** GitHub Copilot **cannot** be installed directly in the browser-based Studios VS Code session. Studios VS Code is built on [OpenVSCode Server][open-vscode-server], which uses the [Open VSX registry][open-vsx] instead of the Microsoft VS Code Marketplace. GitHub does not publish the Copilot extension to Open VSX, and manual VSIX installation is not supported.
+
+    To use Copilot with a Studios VS Code session, connect to the session from your local VS Code (with Copilot already installed and licensed) using the Remote SSH extension. See [Studios SSH configuration](../enterprise/studios-ssh) for setup.
+
+    :::note
+    SSH access requires admin enablement and Platform 25.3.3 or later with Connect server and proxy 0.10.0 or later.
+    :::
 
 ## Session size limited by compute environment advanced options: Head job CPUs and Head job memory
 
@@ -262,7 +268,8 @@ Debug logs include SSH handshake details, authentication attempts, channel lifec
 {/* links */}
 
 [gh-copilot]: https://github.com/features/copilot
-[vscode-blog]: https://code.visualstudio.com/docs/copilot/setup-simplified
+[open-vscode-server]: https://github.com/gitpod-io/openvscode-server
+[open-vsx]: https://open-vsx.org/
 [posit-ghcopilot-guide]: https://docs.posit.co/ide/user/ide/guide/tools/copilot.html
 [nbi]: https://github.com/notebook-intelligence/notebook-intelligence
 [nbi-blog]: https://blog.jupyter.org/introducing-notebook-intelligence-3648c306b91a

--- a/platform-enterprise_versioned_docs/version-26.1/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-enterprise_versioned_docs/version-26.1/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -14,11 +14,17 @@ In your interactive analysis environment, open a new terminal and type `ls -la /
 
 ## Enabling AI coding assistants in Studios
 
-VS Code, RStudio, and Jupyter environments natively integrate with [GitHub Copilot][gh-copilot]. Enabling it requires a GitHub Account and an active Copilot subscription.
+RStudio and Jupyter environments integrate with [GitHub Copilot][gh-copilot]. Enabling it requires a GitHub account and an active Copilot subscription.
 
-- **VS Code:** To enable GitHub Copilot in your VS Code session, install the extension and then sign in with your GitHub account. [Learn more][vscode-blog].
 - **RStudio:** To enable GitHub Copilot in your RStudio session requires RStudio configuration changes. By default, the Studio session user has root permissions, so configuration changes are possible. You will need to restart the RStudio once the required changes have been made. [Learn more][posit-ghcopilot-guide].
 - **Jupyter:** [Notebook Intelligence (NBI)][nbi] is an AI coding assistant and extensible AI framework for Jupyter. It can use GitHub Copilot or AI models from any other LLM Provider. [Learn more][nbi-blog].
+- **VS Code:** GitHub Copilot **cannot** be installed directly in the browser-based Studios VS Code session. Studios VS Code is built on [OpenVSCode Server][open-vscode-server], which uses the [Open VSX registry][open-vsx] instead of the Microsoft VS Code Marketplace. GitHub does not publish the Copilot extension to Open VSX, and manual VSIX installation is not supported.
+
+    To use Copilot with a Studios VS Code session, connect to the session from your local VS Code (with Copilot already installed and licensed) using the Remote SSH extension. See [Studios SSH configuration](../enterprise/studios-ssh) for setup.
+
+    :::note
+    SSH access requires admin enablement and Platform 25.3.3 or later with Connect server and proxy 0.10.0 or later.
+    :::
 
 ## Session size limited by compute environment advanced options: Head job CPUs and Head job memory
 
@@ -276,7 +282,8 @@ Debug logs include SSH handshake details, authentication attempts, channel lifec
 {/* links */}
 
 [gh-copilot]: https://github.com/features/copilot
-[vscode-blog]: https://code.visualstudio.com/docs/copilot/setup-simplified
+[open-vscode-server]: https://github.com/gitpod-io/openvscode-server
+[open-vsx]: https://open-vsx.org/
 [posit-ghcopilot-guide]: https://docs.posit.co/ide/user/ide/guide/tools/copilot.html
 [nbi]: https://github.com/notebook-intelligence/notebook-intelligence
 [nbi-blog]: https://blog.jupyter.org/introducing-notebook-intelligence-3648c306b91a


### PR DESCRIPTION
## Summary

- Corrects the AI coding assistants FAQ — Studios VS Code is built on [OpenVSCode Server](https://github.com/gitpod-io/openvscode-server) and uses the [Open VSX registry](https://open-vsx.org/), so the GitHub Copilot extension cannot be installed in the browser-based session (and manual VSIX install also fails).
- On Enterprise (`next`, `version-25.3`, `version-26.1`), directs users to the supported workaround: connect their local VS Code (with Copilot already installed and licensed) via Remote SSH — links to [Studios SSH configuration](https://docs.seqera.io/platform-enterprise/enterprise/studios-ssh) and notes the admin/version prerequisites (Platform 25.3.3+, Connect 0.10.0+).
- On Cloud, states the Open VSX limitation only (no Studios SSH page exists for Cloud).
- Versioned snapshots `version-25.1` and `version-25.2` are intentionally left as-is — they predate Studios SSH support, so the workaround doesn't apply there.

### Files changed

- `platform-enterprise_docs/troubleshooting_and_faqs/studios_troubleshooting.md`
- `platform-enterprise_versioned_docs/version-26.1/troubleshooting_and_faqs/studios_troubleshooting.md`
- `platform-enterprise_versioned_docs/version-25.3/troubleshooting_and_faqs/studios_troubleshooting.md`
- `platform-cloud/docs/troubleshooting_and_faqs/studios_troubleshooting.md`

## Test plan

- [ ] Check Netlify deploy preview for the AI coding assistants section on enterprise (next + 26.1 + 25.3) and cloud
- [ ] Verify the [Studios SSH configuration](https://docs.seqera.io/platform-enterprise/enterprise/studios-ssh) link resolves on each enterprise version
- [ ] Confirm the `:::note` admonition renders on enterprise versions