### PR TITLE
Document tower.yml allowed-workspaces for Studios on 25.3 [EDU-1065]

### DIFF
--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/install-studios.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/install-studios.md
@@ -47,7 +47,43 @@ Studios uses the following set of domains and subdomains:
 
 ## Studios workspace availability
 
-You can configure which organizational workspaces have access to Studios by setting the `TOWER_DATA_STUDIO_ALLOWED_WORKSPACES` environment variable on the backend containers. By default, all workspaces have access to Studios. To restrict access to specific workspaces, set `TOWER_DATA_STUDIO_ALLOWED_WORKSPACES` to a comma-separated list of workspace names. For example, `TOWER_DATA_STUDIO_ALLOWED_WORKSPACES="12345,67890"` allows only the workspaces named `12345` and `67890` to access Studios. To disable access to Studios for all workspaces, set `TOWER_DATA_STUDIO_ALLOWED_WORKSPACES=""` (an empty string).
+Configure which organizational workspaces have access to Studios in the `tower.yml` configuration file. The `tower.data-studio.allowed-workspaces` field supports the following options:
+
+- `allowed-workspaces: []`: Disables Studios. This is the default if the `allowed-workspaces` field is not specified.
+- `allowed-workspaces: [ <WORKSPACE_ID>,<WORKSPACE_ID> ]`: Enables Studios for the comma-separated list of organizational workspace IDs.
+- `allowed-workspaces: null`: Enables Studios for all organizational workspaces.
+
+For example, to enable Studios for all workspaces in your Platform instance:
+
+```yaml
+tower:
+  data-studio:
+    allowed-workspaces: null
+```
+
+To enable Studios for specific workspaces only:
+
+```yaml
+tower:
+  data-studio:
+    allowed-workspaces: [12345,67890]
+```
+
+In the Platform Helm chart, set the desired configuration in the `platform.YAMLConfigFileContent` field. For example, to enable Studios for workspaces 12345 and 67890:
+
+```yaml
+platform:
+  YAMLConfigFileContent: |-
+    tower:
+      data-studio:
+        allowed-workspaces: [12345,67890]
+```
+
+Alternatively, configure workspace availability with the `TOWER_DATA_STUDIO_ALLOWED_WORKSPACES` environment variable on the backend containers. Set it to a comma-separated list of workspace IDs (for example, `TOWER_DATA_STUDIO_ALLOWED_WORKSPACES="12345,67890"`), or to an empty string (`TOWER_DATA_STUDIO_ALLOWED_WORKSPACES=""`) to disable Studios.
+
+:::note
+From Seqera Platform 26.1, Studios is enabled for all workspaces by default. On earlier versions, you must opt in explicitly using either the `tower.yml` configuration or the environment variable.
+:::
 
 ## Available Studios environment images
 


### PR DESCRIPTION
## Summary

[Fixes https://seqera.atlassian.net/browse/EDU-1220](https://seqera.atlassian.net/browse/EDU-1065)

- The 25.3 versioned `install-studios.md` only documented the `TOWER_DATA_STUDIO_ALLOWED_WORKSPACES` env var and claimed Studios was enabled for all workspaces by default. Recent troubleshooting on 25.3.1 and 25.3.4 showed that Studios is not active until `tower.yml` sets `tower.data-studio.allowed-workspaces: null` — the same approach already documented for 25.2.
- Adds the `tower.yml` configuration (with Helm `YAMLConfigFileContent` example) and clarifies that the default-on behavior only applies from 26.1.
- Keeps the env var as an alternative.

## Test plan

- [ ] Confirm wording of the 26.1 default-on note with engineering
- [ ] Confirm the env var alternative still works in 25.3
- [ ] Build the docs site preview and check formatting of the new admonition and YAML blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)