### PR TITLE
docs(cloud): port Studios SSH user content from enterprise

### DIFF
--- a/platform-cloud/docs/limits/overview.md
+++ b/platform-cloud/docs/limits/overview.md
@@ -1,8 +1,9 @@
 ---
 title: "Usage limits"
 description: "An overview of Seqera Cloud usage limits"
-date: "19 Feb 2025"
-tags: [limits]
+date created: "2025-02-19"
+last updated: "2026-06-24"
+tags: [limits, usage]
 ---
 
 Seqera Platform elements and features have default limits per organization and workspace.

--- a/platform-cloud/docs/limits/overview.md
+++ b/platform-cloud/docs/limits/overview.md
@@ -7,6 +7,10 @@ tags: [limits]
 
 Seqera Platform elements and features have default limits per organization and workspace.
 
+:::info
+Academic institutions and commercial organizations evaluating Seqera Platform are subject to custom usage limits. [Contact us](https://seqera.io/contact-us/) for more information.
+:::
+
 ### Organizations
 
 | Description               | Basic | Cloud Pro + Enterprise |
@@ -17,11 +21,11 @@ Seqera Platform elements and features have default limits per organization and w
 | Run history               | 250   | 250, or per license    |
 | Active runs               | 3     | 100, or per license    |
 | Running Studio sessions   | 1     | 1000, or per license   |
-| Seqera Compute: Storage   | 25 GB per month | Unlimited              |
+| Seqera Compute: Storage   | 25 GB per month | Unlimited    |
 | Seqera Compute: CPU cores | 100   | 1000                   |
 
-:::info
-Academic institutions and commercial organizations evaluating Seqera Platform are subject to custom usage limits. [Contact us](https://seqera.io/contact-us/) for more information.
+:::note
+Studios data egress is currently throttled at 100GB per 24h per IP address and 1TB per `user_id` per month to prevent unbounded usage.
 :::
 
 ### Workspaces

--- a/platform-cloud/docs/studios/managing.md
+++ b/platform-cloud/docs/studios/managing.md
@@ -247,6 +247,7 @@ There might be errors reported by the session itself but these will be overwritt
 - Your SSH public key added to your Seqera Platform user profile
 - **SSH Connection** toggle enabled when adding the Studio
 - The Studio is in a **running** state.
+- **Connect client**: Version 0.10.0 or later
 :::
 
 Direct SSH connections to running Studio containers support standard SSH clients, terminal access, and [VS Code Remote SSH](https://code.visualstudio.com/docs/remote/ssh). JupyterLab, R-IDE, VS Code, and Xpra container templates are supported.

--- a/platform-cloud/docs/studios/managing.md
+++ b/platform-cloud/docs/studios/managing.md
@@ -252,7 +252,7 @@ There might be errors reported by the session itself but these will be overwritt
 Direct SSH connections to running Studio containers support standard SSH clients, terminal access, and [VS Code Remote SSH](https://code.visualstudio.com/docs/remote/ssh). JupyterLab, R-IDE, VS Code, and Xpra container templates are supported.
 
 :::note
-Enabling SSH can only be done on Studio creation. If you didn't enable SSH when you initially added your Studio, you will need to duplicate and modify it. Stop the Studio, select **Start as New**, and enable **SSH Connection** for the new Studio.
+If you didn't enable SSH when you initially added your Studio, stop the Studio, select **Start as New**, and enable **SSH Connection**.
 :::
 
 ### Terminal access

--- a/platform-cloud/docs/studios/managing.md
+++ b/platform-cloud/docs/studios/managing.md
@@ -253,7 +253,7 @@ There might be errors reported by the session itself but these will be overwritt
 Direct SSH connections to running Studio containers support standard SSH clients, terminal access, and [VS Code Remote SSH](https://code.visualstudio.com/docs/remote/ssh). JupyterLab, R-IDE, VS Code, and Xpra container templates are supported.
 
 :::note
-If you didn't enable SSH when you initially added your Studio, stop the Studio, select **Start as New**, and enable **SSH Connection**.
+If you didn't enable SSH when you initially added your Studio, stop and enable **SSH Connection** before restarting the Studio.
 :::
 
 ### Terminal access

--- a/platform-cloud/docs/studios/managing.md
+++ b/platform-cloud/docs/studios/managing.md
@@ -240,6 +240,96 @@ Sessions have the following possible statuses:
 There might be errors reported by the session itself but these will be overwritten with a **running** status if the session is still running.
 :::
 
+## Connect to a Studio via SSH (public preview)
+
+:::info[**Prerequisites**]
+- SSH access enabled for your workspace
+- Your SSH public key added to your Seqera Platform user profile
+- **SSH Connection** toggle enabled when adding the Studio
+- The Studio is in a **running** state.
+:::
+
+Direct SSH connections to running Studio containers support standard SSH clients, terminal access, and [VS Code Remote SSH](https://code.visualstudio.com/docs/remote/ssh). JupyterLab, R-IDE, VS Code, and Xpra container templates are supported.
+
+:::note
+Enabling SSH can only be done on Studio creation. If you didn't enable SSH when you initially added your Studio, you will need to duplicate and modify it. Stop the Studio, select **Start as New**, and enable **SSH Connection** for the new Studio.
+:::
+
+### Terminal access
+
+Connect to a Studio using standard SSH:
+
+```bash
+ssh <username>@<studio-session-id>@<connect-domain> -p 2222
+```
+
+**Example:**
+
+```bash
+ssh alice@a01ac8894@connect.example.com -p 2222
+```
+
+Where:
+- `<username>`: Your Seqera Platform username
+- `<studio-session-id>`: The Studio session ID (visible in the Studios list)
+- `<connect-domain>`: Your connect proxy domain
+- Port: `2222` (default SSH proxy port)
+
+The session ID is displayed in the Studio details page and the Studios list.
+
+### VS Code Remote SSH
+
+Connect to a Studio using VS Code Remote SSH:
+
+1. Install the [Remote - SSH extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) in VS Code.
+
+2. **Required:** Disable local server mode in your VS Code settings:
+
+   - Open VS Code Settings (Code > Preferences > Settings or Cmd+,)
+   - Search for `remote.SSH.useLocalServer`
+   - Set to `false`
+
+   Alternatively, add this to your `settings.json`:
+
+   ```json
+   {
+     "remote.SSH.useLocalServer": false,
+     "remote.SSH.enableRemoteCommand": true,
+     "remote.SSH.useLocalServer": false,
+     "remote.SSH.preconnect": ""
+   }
+   ```
+
+   :::warning
+   VS Code's local server mode (SSH multiplexing over SOCKS) is not supported. Connections will fail if this setting is enabled.
+   :::
+
+3. Connect to the Studio:
+
+   - Open the Command Palette (Cmd+Shift+P or Ctrl+Shift+P)
+   - Run **Remote-SSH: Connect to Host**
+   - Select your configured host or enter the SSH connection string directly
+   - VS Code opens a new window connected to your Studio
+
+Once connected, you can:
+
+- Access the Studio filesystem
+- Open folders and files
+- Use the integrated terminal
+- Install VS Code extensions in the remote environment
+- Debug code running in the Studio
+- Install packages
+
+### SSH authentication
+
+SSH connections use public key authentication:
+
+1. Platform validates your credentials and workspace permissions.
+2. Your SSH client uses your private key for authentication.
+3. The connection is encrypted end-to-end.
+
+For troubleshooting SSH connection issues, see [Studios troubleshooting](../troubleshooting_and_faqs/studios_troubleshooting#ssh-connections-public-preview).
+
 ## Studio session data-links
 
 You can configure a Studio session to mount one or more data-links, where cloud buckets that you have configured in your compute environment are read-only, or read-write available to the session.

--- a/platform-cloud/docs/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-cloud/docs/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -148,6 +148,62 @@ These are the false positive confirmed findings:
 | ini:1.0.0        | CVE-2020-7788⁠       |
 | diff:1.0.0       | GHSA-h6ch-v84p-w6p9⁠ |
 
+## SSH connections (public preview)
+
+### Permission denied (publickey)
+
+```bash
+ssh user@studio-session-id@connect.example.com
+# user@studio-session-id@connect.example.com: Permission denied (publickey).
+```
+
+If you receive a permission denied error, there are several possible causes:
+
+1. Verify the user has the correct role and permissions in the workspace.
+2. Check that the user's SSH public key is configured in their Seqera user profile.
+3. Ensure SSH was enabled when adding the Studio using the **SSH Connection** toggle. The SSH setting persists across stop/start but defaults to disabled for new Studios.
+
+### VS Code Remote SSH not working
+
+If VS Code fails to connect or shows errors when using the Remote SSH extension, disable local server mode in VS Code settings:
+
+```json
+{
+  "remote.SSH.useLocalServer": false
+}
+```
+
+VS Code's local server mode uses SSH multiplexing over SOCKS proxy, which is not supported. See [Connect to a Studio via SSH - VS Code Remote SSH](../studios/managing#vs-code-remote-ssh) for detailed setup instructions.
+
+Additionally, you may need to update your `~/.ssh/config` file to directly connect to the Studio session:
+
+```bash
+Host <connect-domain>
+  HostName <connect-domain>
+  User <username>@<studio-session-id>
+  Port <port>
+```
+
+### SSH connection string format
+
+**Correct format:**
+
+```bash
+ssh <username>@<studio-session-id>@<connect-domain> -p 2222
+```
+
+**Example:**
+
+```bash
+ssh alice@a01ac8894@connect.example.com -p 2222
+```
+
+Where:
+- `<username>`: Your Seqera Platform username
+- `<studio-session-id>`: The Studio session ID (8-character hex string visible in the Studios list)
+- `<connect-domain>`: Your connect proxy domain
+- Port: `2222` (default SSH proxy port)
+
 {/* links */}
 
 [gh-copilot]: https://github.com/features/copilot

--- a/platform-cloud/docs/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-cloud/docs/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -161,7 +161,8 @@ If you receive a permission denied error, there are several possible causes:
 
 1. Verify the user has the correct role and permissions in the workspace.
 2. Check that the user's SSH public key is configured in their Seqera user profile.
-3. Ensure SSH was enabled when adding the Studio using the **SSH Connection** toggle. The SSH setting persists across stop/start but defaults to disabled for new Studios.
+3. Ensure SSH was enabled when starting the Studio using the **SSH Connection** toggle. The SSH setting defaults to disabled for new Studios.
+4. Ensure the Studio is built with Connect Client version 0.10.0 or later
 
 ### VS Code Remote SSH not working
 

--- a/platform-enterprise_docs/enterprise/studios-ssh.md
+++ b/platform-enterprise_docs/enterprise/studios-ssh.md
@@ -2,7 +2,7 @@
 title: "Studios SSH configuration (public preview)"
 description: Configure SSH access for Studios (public preview)
 date created: "2026-02-10"
-last updated: "2026-05-29"
+last updated: "2026-06-24"
 tags: [studios, ssh, kubernetes, advanced]
 ---
 
@@ -17,8 +17,8 @@ SSH access enables direct terminal connections to running Studio sessions using 
 To enable SSH access to running Studio sessions, you need:
 
 - **Seqera Platform**: Version 25.3.3 or later
-- **Connect server and proxy**: Version 0.12.0 or later
-- **Connect client**: Version 0.12.0 or later
+- **Connect server and proxy**: Version 0.10.0 or later
+- **Connect client**: Version 0.10.0 or later
 
 If you have pinned Studio container images to specific versions, you will need to [migrate](../studios/managing#migrate-a-studio-from-an-earlier-container-image-template) them to the required Connect client version.
 

--- a/platform-enterprise_docs/studios/managing.md
+++ b/platform-enterprise_docs/studios/managing.md
@@ -244,16 +244,17 @@ There might be errors reported by the session itself but these will be overwritt
 
 :::info[**Prerequisites**]
 - Enterprise v25.3.3 or later
-- [Studios SSH configuration](../enterprise/studios-ssh) enabled for your workspace during deployment.
+- [Studios SSH configuration](../enterprise/studios-ssh) enabled for your workspace during deployment
 - Your SSH public key added to your Seqera Platform user profile
 - **SSH Connection** toggle enabled when adding the Studio
 - The Studio is in a **running** state.
+- **Connect client**: Version 0.10.0 or later
 :::
 
 Direct SSH connections to running Studio containers support standard SSH clients, terminal access, and [VS Code Remote SSH](https://code.visualstudio.com/docs/remote/ssh). JupyterLab, R-IDE, VS Code, and Xpra container templates are supported.
 
 :::note
-Enabling SSH can only be done on Studio creation. If you didn't enable SSH when you initially added your Studio, you will need to duplicate and modify it. Stop the Studio, select **Start as New**, and enable **SSH Connection** for the new Studio.
+If you didn't enable SSH when you initially added your Studio, stop the Studio, select **Start as New**, and enable **SSH Connection**.
 :::
 
 ### Terminal access

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/studios-ssh.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/studios-ssh.md
@@ -2,7 +2,7 @@
 title: "Studios SSH configuration (public preview)"
 description: Configure SSH access for Studios (public preview)
 date created: "2026-02-10"
-last updated: "2026-05-29"
+last updated: "2026-06-24"
 tags: [studios, ssh, kubernetes, advanced]
 ---
 
@@ -17,8 +17,8 @@ SSH access enables direct terminal connections to running Studio sessions using 
 To enable SSH access to running Studio sessions, you need:
 
 - **Seqera Platform**: Version 25.3.3 or later
-- **Connect server and proxy**: Version 0.12.0 or later
-- **Connect client**: Version 0.12.0 or later
+- **Connect server and proxy**: Version 0.10.0 or later
+- **Connect client**: Version 0.10.0 or later
 
 If you have pinned Studio container images to specific versions, you will need to [migrate](../studios/managing#migrate-a-studio-from-an-earlier-container-image-template) them to the required Connect client version.
 

--- a/platform-enterprise_versioned_docs/version-26.1/studios/managing.md
+++ b/platform-enterprise_versioned_docs/version-26.1/studios/managing.md
@@ -248,12 +248,13 @@ There might be errors reported by the session itself but these will be overwritt
 - Your SSH public key added to your Seqera Platform user profile
 - **SSH Connection** toggle enabled when adding the Studio
 - The Studio is in a **running** state.
+- **Connect client**: Version 0.10.0 or later
 :::
 
 Direct SSH connections to running Studio containers support standard SSH clients, terminal access, and [VS Code Remote SSH](https://code.visualstudio.com/docs/remote/ssh). JupyterLab, R-IDE, VS Code, and Xpra container templates are supported.
 
 :::note
-Enabling SSH can only be done on Studio creation. If you didn't enable SSH when you initially added your Studio, you will need to duplicate and modify it. Stop the Studio, select **Start as New**, and enable **SSH Connection** for the new Studio.
+If you didn't enable SSH when you initially added your Studio, stop the Studio, select **Start as New**, and enable **SSH Connection**.
 :::
 
 ### Terminal access


### PR DESCRIPTION
## Summary

- Ports the user-facing "Connect to a Studio via SSH (public preview)" section from the enterprise Studios managing page to the cloud Studios managing page (terminal access, VS Code Remote SSH setup, SSH authentication).
- Ports the user-facing SSH troubleshooting entries — Permission denied (publickey), VS Code Remote SSH not working, SSH connection string format — to the cloud Studios troubleshooting page.
- Intentionally excludes enterprise admin/deployment material: \`TOWER_\` / \`CONNECT_\` environment variables, SSH key-pair generation and distribution, proxy/network configuration, host-key/proxy-pod admin guidance, and \`CONNECT_LOG_LEVEL\` debug logging. The enterprise-only \`studios-ssh.md\` deployment guide is not ported.
- Prerequisites in the cloud version replace the enterprise version pin and admin-config link with a single "SSH access enabled for your workspace" line.

## Test plan

- [ ] Netlify deploy preview renders both pages without broken links
- [ ] Anchor link from troubleshooting back to managing (`../studios/managing#vs-code-remote-ssh`) resolves
- [ ] Cross-link from managing to troubleshooting (`../troubleshooting_and_faqs/studios_troubleshooting#ssh-connections-public-preview`) resolves

Preview starts here: https://deploy-preview-1608--seqera-docs.netlify.app/platform-cloud/studios/managing#connect-to-a-studio-via-ssh-public-preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)