### PR TITLE
docs: add Enterprise v26.1.3 release notes

### DIFF
--- a/changelog/seqera-enterprise/v26.1.3.md
+++ b/changelog/seqera-enterprise/v26.1.3.md
@@ -4,16 +4,6 @@ date: 2026-06-25
 tags: [seqera enterprise]
 ---
 
-<!--
-REVIEW BEFORE MERGE
-- Date is set to 2026-06-25 (placeholder — confirm actual release date).
-- Excluded #11387 (chore/Renovate Docker image digest bump) and #11343 (PLAT-5417 internal refactor of #11285 with no user-facing change). Confirm exclusions.
-- #11285 (PLAT-5412) entry includes fields gated by PIPELINE_VERSIONING_ENABLED (pipeline version) and LINEAGE_ENABLED (lineage). Confirm wording reflects "shown when enabled" correctly.
-- No release notes files exist for v26.1.1 or v26.1.2 — flagged separately to the docs reviewer.
--->
-
-
-
 ## Feature updates and improvements
 
 :::info

--- a/changelog/seqera-enterprise/v26.1.3.md
+++ b/changelog/seqera-enterprise/v26.1.3.md
@@ -1,0 +1,39 @@
+---
+title: Seqera Enterprise v26.1.3
+date: 2026-06-25
+tags: [seqera enterprise]
+---
+
+<!--
+REVIEW BEFORE MERGE
+- Date is set to 2026-06-25 (placeholder — confirm actual release date).
+- Excluded #11387 (chore/Renovate Docker image digest bump) and #11343 (PLAT-5417 internal refactor of #11285 with no user-facing change). Confirm exclusions.
+- #11285 (PLAT-5412) entry includes fields gated by PIPELINE_VERSIONING_ENABLED (pipeline version) and LINEAGE_ENABLED (lineage). Confirm wording reflects "shown when enabled" correctly.
+- No release notes files exist for v26.1.1 or v26.1.2 — flagged separately to the docs reviewer.
+-->
+
+
+
+## Feature updates and improvements
+
+:::info
+The legacy distribution endpoint at `cr.seqera.io/private` is deprecated. Only bug fixes for existing major releases will continue to be published there. New major releases of Seqera Platform are available from `cr.seqera.io/enterprise`. Seqera will provide updated credentials for the new endpoint — [contact your Seqera representative](https://support.seqera.io) if you need access.
+:::
+
+### Pipelines
+
+- Added pipeline schema, commit ID, head job CPUs, and head job memory to the workflow launch form summary, plus pipeline version and lineage fields when those features are active.
+
+## Bug fixes
+
+### Compute environments
+
+- Fixed AWS credential validation failing for credentials using `assumeRoleArn` when `TOWER_ALLOW_INSTANCE_CREDENTIALS=true` without an explicit role mode.
+
+### Pipelines
+
+- Fixed duplicate credential detection to block GitHub App creation when a personal access token credential already exists for the same repository base URL.
+
+## Upgrade notes
+
+No breaking changes. Standard upgrade procedure applies.


### PR DESCRIPTION
## Summary

Adds [changelog/seqera-enterprise/v26.1.3.md](changelog/seqera-enterprise/v26.1.3.md) covering the three user-facing PRs in the 26.1.3 set.

**Included**

| PR | Section | Entry |
|---|---|---|
| seqeralabs/platform#11285 | Feature updates → Pipelines | Launch form summary surfaces pipeline schema, commit ID, head job CPUs/memory, plus pipeline version and lineage when those features are active |
| seqeralabs/platform#11504 | Bug fixes → Compute environments | AWS STS credential validation now accepts `assumeRoleArn` with `TOWER_ALLOW_INSTANCE_CREDENTIALS=true` and no explicit role mode |
| seqeralabs/platform#11488 | Bug fixes → Pipelines | Duplicate credential detection now blocks GitHub App creation when a personal access token already exists for the same repository base URL |

**Excluded**

- seqeralabs/platform#11343 — internal refactor of #11285 (no user-facing change)
- seqeralabs/platform#11387 — Renovate chore (Docker base-image digest bump)

## Review notes

The file includes a `<!-- REVIEW BEFORE MERGE -->` HTML comment block at the top flagging:

- The release date is a placeholder (2026-06-25). Update before merge if the ship date differs.
- No changelog files exist for v26.1.1 or v26.1.2. Confirm whether those versions shipped without release notes or whether the version skipped directly from 26.1 → 26.1.3.

Strip the `<!-- REVIEW BEFORE MERGE -->` block before merging.

## Test plan

- [ ] Confirm the three entries accurately describe user-facing behavior
- [ ] Update the release date if it differs from 2026-06-25
- [ ] Decide on v26.1.1 / v26.1.2 handling
- [ ] Remove the REVIEW BEFORE MERGE comment block
- [ ] Verify `vale` / docs CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)