### PR TITLE
docs: bump enterprise pins to 26.1.3

### DIFF
--- a/platform-cloud/docs/functionality_matrix/overview.md
+++ b/platform-cloud/docs/functionality_matrix/overview.md
@@ -2,7 +2,7 @@
 title: "Default version compatibility"
 description: "Platform / nf-launcher / Nextflow / Fusion version compatibility"
 date created: "2024-06-20"
-last updated: "2026-06-08"
+last updated: "2026-06-25"
 tags: [compatibility, nextflow, nf-launcher]
 ---
 
@@ -14,6 +14,7 @@ If no Nextflow version is specified in your configuration, Seqera defaults to th
 
 | Platform version | nf-launcher version | Nextflow version | Fusion version | Connect client version|
 | ---------------- | ------------------- | ---------------- | -------------- |-------------- |
+| 26.1.3           | j21-26.04           | 26.04            | 2.4            | 0.12.0        |
 | 26.1.2           | j21-26.04           | 26.04            | 2.4            | 0.12.0        |
 | 26.1.0           | j21-26.04           | 26.04            | 2.4            | 0.12.0        |
 | 25.3.6           | j21-25.10.2         | 25.10.2          | 2.4            | 0.11.0        |

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/docker-compose.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - $HOME/.tower/db/redis:/data
 
   migrate:
-    image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.2
+    image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.3
     platform: linux/amd64
     command: -c "/migrate-db.sh"
     networks:
@@ -64,7 +64,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: cr.seqera.io/enterprise/platform/backend:v26.1.2
+    image: cr.seqera.io/enterprise/platform/backend:v26.1.3
     platform: linux/amd64
     command: -c '/tower.sh'
     networks:
@@ -85,7 +85,7 @@ services:
 
 
   backend:
-    image: cr.seqera.io/enterprise/platform/backend:v26.1.2
+    image: cr.seqera.io/enterprise/platform/backend:v26.1.3
     platform: linux/amd64
     command: -c '/wait-for-it.sh db:3306 -t 60; /tower.sh'
     networks:
@@ -110,7 +110,7 @@ services:
       - cron
 
   frontend:
-    image: cr.seqera.io/enterprise/platform/frontend:v26.1.2
+    image: cr.seqera.io/enterprise/platform/frontend:v26.1.3
     platform: linux/amd64
     networks:
       - frontend

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-cron.yml
@@ -21,7 +21,7 @@ spec:
             name: tower-yml
       initContainers:
         - name: migrate-db
-          image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.2
+          image: cr.seqera.io/enterprise/platform/migrate-db:v26.1.3
           command: ["sh", "-c", "/migrate-db.sh"]
           envFrom:
             - configMapRef:
@@ -32,7 +32,7 @@ spec:
               subPath: tower.yml
       containers:
         - name: backend
-          image: cr.seqera.io/enterprise/platform/backend:v26.1.2
+          image: cr.seqera.io/enterprise/platform/backend:v26.1.3
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-svc.yml
@@ -29,7 +29,7 @@ spec:
         #    secretName: platform-oidc-certs
       containers:
         - name: backend
-          image: cr.seqera.io/enterprise/platform/backend:v26.1.2
+          image: cr.seqera.io/enterprise/platform/backend:v26.1.3
           envFrom:
             - configMapRef:
                 name: tower-backend-cfg
@@ -88,7 +88,7 @@ spec:
         - name: "cr.seqera.io"
       containers:
         - name: frontend
-          image: cr.seqera.io/enterprise/platform/frontend:v26.1.2
+          image: cr.seqera.io/enterprise/platform/frontend:v26.1.3
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/mirroring.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/mirroring.md
@@ -30,9 +30,9 @@ Create a YAML file (`seqera-images.yaml`) to specify which images to sync:
 ```yaml
 cr.seqera.io:
     images-by-semver:
-        enterprise/platform/backend: ">= v26.1.2"
-        enterprise/platform/frontend: ">= v26.1.2"
-        enterprise/platform/migrate-db: ">= v26.1.2"
+        enterprise/platform/backend: ">= v26.1.3"
+        enterprise/platform/frontend: ">= v26.1.3"
+        enterprise/platform/migrate-db: ">= v26.1.3"
 ```
 
 Run the sync:

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-kubernetes.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-kubernetes.md
@@ -145,7 +145,7 @@ spec:
   ...
       containers:
         - name: frontend
-          image: cr.seqera.io/enterprise/platform/frontend:v26.1.2-unprivileged
+          image: cr.seqera.io/enterprise/platform/frontend:v26.1.3-unprivileged
           env:
             - name: NGINX_LISTEN_PORT  # If not defined, defaults to 8000.
               value: 8000

--- a/platform-enterprise_versioned_docs/version-26.1/functionality_matrix/overview.md
+++ b/platform-enterprise_versioned_docs/version-26.1/functionality_matrix/overview.md
@@ -2,7 +2,7 @@
 title: "Default version compatibility"
 description: "Platform / nf-launcher / Nextflow / Fusion version compatibility"
 date created: "2024-06-20"
-last updated: "2026-06-08"
+last updated: "2026-06-25"
 tags: [compatibility, nextflow, nf-launcher]
 ---
 
@@ -14,6 +14,7 @@ If no Nextflow version is specified in your configuration, Seqera defaults to th
 
 | Platform version | nf-launcher version | Nextflow version | Fusion version | Connect client version|
 | ---------------- | ------------------- | ---------------- | -------------- |-------------- |
+| 26.1.3           | j21-26.04           | 26.04            | 2.4            | 0.12.0        |
 | 26.1.2           | j21-26.04           | 26.04            | 2.4            | 0.12.0        |
 | 26.1.0           | j21-26.04           | 26.04            | 2.4            | 0.12.0        |
 | 25.3.6           | j21-25.10.2         | 25.10.2          | 2.4            | 0.11.0        |


### PR DESCRIPTION
## Summary

- Bumps Docker image tags and Kubernetes manifests under `platform-enterprise_versioned_docs/version-26.1/` from `v26.1.2` to `v26.1.3` (docker-compose, tower-cron, tower-svc, platform-kubernetes).
- Updates the skopeo mirror semver constraints in `mirroring.md` to `>= v26.1.3`.
- Adds a `26.1.3` row to the enterprise and cloud functionality matrices (same nf-launcher / Nextflow / Fusion / Connect client values as `26.1.2`).

## Test plan

- [ ] Netlify preview renders the functionality matrices with the new `26.1.3` row in both the enterprise versioned docs and the cloud docs.
- [ ] `grep -rn "v26.1.2" platform-enterprise_versioned_docs/version-26.1/` returns no hits.
- [ ] Skopeo mirror snippet still parses as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)