### PR TITLE
EDU-159 Expand AWS ECR Public Registry documentation in Platform credentials

### DIFF
--- a/platform-cloud/docs/credentials/aws_registry_credentials.md
+++ b/platform-cloud/docs/credentials/aws_registry_credentials.md
@@ -12,7 +12,7 @@ AWS Elastic Container Registry (ECR) credentials allow the Wave container servic
 Container registry credentials are only used by the Wave container service. Add `wave { enabled=true }` to the **Nextflow config** field on the launch page, or to your `nextflow.config` file, for your pipeline execution to use Wave containers.
 :::
 
-## AWS ECR access
+## AWS ECR Private Registry
 
 Wave requires programmatic access to your private Elastic Container Registry (ECR) via [long-term access keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#create-long-term-access-keys). Create a user with registry read permissions (e.g., a subset of the AWS-managed `AmazonEC2ContainerRegistryReadOnly` policy) for this purpose.
 
@@ -30,7 +30,7 @@ Wave requires programmatic access to your private Elastic Container Registry (EC
 Your credential must be stored in Seqera as a **container registry** credential, even if the same access keys already exist as a workspace credential.
 :::
 
-## Add credentials to Seqera
+## Add private ECR credentials to Seqera
 
 1.  Add your credentials to your organization or personal workspace:
     - From an organization workspace: Go to **Credentials > Add Credentials**.
@@ -41,11 +41,43 @@ Your credential must be stored in Seqera as a **container registry** credential,
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
     - **User name**: Specify your IAM user access key ID. For example, `AKIAIOSFODNN7EXAMPLE`.
-    - **Password**: Specify your IAM user secret access.
-    - **Registry server**: Specify container registry server name. For example, `<aws_account_id>.dkr.ecr.<region>.amazonaws.com`.
+    - **Password**: Specify your IAM user secret access key.
+    - **Registry server**: Specify your private ECR registry URL. For example, `<aws_account_id>.dkr.ecr.<region>.amazonaws.com`.
 
 3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
 
-:::note
-To use the Amazon ECR Public Registry, create a container registry credential with **public.ecr.aws** as the registry server. You can reuse your existing IAM credentials, but ensure that the IAM user has the `AmazonElasticContainerRegistryPublicReadOnly` policy attached.
-:::
+## AWS ECR Public Registry
+
+Amazon ECR Public Gallery (`public.ecr.aws`) hosts publicly accessible container images. While images can be pulled without authentication, AWS applies rate limits to unauthenticated pulls. Authenticating with AWS credentials removes these rate limits and is required when running pipelines at scale.
+
+### Required IAM permissions
+
+The IAM user needs the following permissions to authenticate to ECR Public:
+
+- `ecr-public:GetAuthorizationToken`
+- `ecr-public:BatchCheckLayerAvailability`
+- `ecr-public:GetRepositoryPolicy`
+- `ecr-public:DescribeRepositories`
+- `ecr-public:DescribeImages`
+- `ecr-public:DescribeImageTags`
+- `sts:GetServiceBearerToken`
+
+Attach the AWS managed policy `AmazonElasticContainerRegistryPublicReadOnly` and add the `sts:GetServiceBearerToken` permission. This permission is not included in the managed policy and must be granted separately, or ECR Public authentication will fail.
+
+### Add ECR Public credentials to Seqera
+
+1.  Add your credentials to your organization or personal workspace:
+    - From an organization workspace: Go to **Credentials > Add Credentials**.
+    - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
+
+2.  Complete the following fields:
+
+    - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `ecr-public-creds`.
+    - **Provider**: Select **Container registry**.
+    - **User name**: Specify your IAM user access key ID. For example, `AKIAIOSFODNN7EXAMPLE`.
+    - **Password**: Specify your IAM user secret access key.
+    - **Registry server**: Enter `public.ecr.aws`.
+
+3.  After you've completed all the form fields, select **Add**.
+
+Wave matches the `public.ecr.aws` hostname to these credentials and authenticates ECR Public pulls on your behalf.

--- a/platform-enterprise_docs/credentials/aws_registry_credentials.md
+++ b/platform-enterprise_docs/credentials/aws_registry_credentials.md
@@ -11,7 +11,7 @@ From version 22.3, Seqera Platform supports the configuration of credentials for
 Container registry credentials are only used by the Wave container service. Add `wave { enabled=true }` to the **Nextflow config** field on the launch page, or to your `nextflow.config` file, for your pipeline execution to use Wave containers.
 :::
 
-## AWS ECR access
+## AWS ECR Private Registry
 
 Wave requires programmatic access to your private Elastic Container Registry (ECR) via [long-term access keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#create-long-term-access-keys). Create a user with registry read permissions (e.g., a subset of the AWS-managed `AmazonEC2ContainerRegistryReadOnly` policy) for this purpose.
 
@@ -29,7 +29,7 @@ Wave requires programmatic access to your private Elastic Container Registry (EC
 Your credential must be stored in Seqera as a **container registry** credential, even if the same access keys already exist as a workspace credential.
 :::
 
-## Add credentials to Seqera
+## Add private ECR credentials to Seqera
 
 1.  Add your credentials to your organization or personal workspace:
     - From an organization workspace: Go to **Credentials > Add Credentials**.
@@ -40,11 +40,43 @@ Your credential must be stored in Seqera as a **container registry** credential,
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
     - **User name**: Specify your IAM user access key ID. For example, `AKIAIOSFODNN7EXAMPLE`.
-    - **Password**: Specify your IAM user secret access.
-    - **Registry server**: Specify container registry server name. For example, `<aws_account_id>.dkr.ecr.<region>.amazonaws.com`.
+    - **Password**: Specify your IAM user secret access key.
+    - **Registry server**: Specify your private ECR registry URL. For example, `<aws_account_id>.dkr.ecr.<region>.amazonaws.com`.
 
 3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
 
-:::note
-To use the Amazon ECR Public Registry, create a container registry credential with **public.ecr.aws** as the registry server. You can reuse your existing IAM credentials, but ensure that the IAM user has the `AmazonElasticContainerRegistryPublicReadOnly` policy attached.
-:::
+## AWS ECR Public Registry
+
+Amazon ECR Public Gallery (`public.ecr.aws`) hosts publicly accessible container images. While images can be pulled without authentication, AWS applies rate limits to unauthenticated pulls. Authenticating with AWS credentials removes these rate limits and is required when running pipelines at scale.
+
+### Required IAM permissions
+
+The IAM user needs the following permissions to authenticate to ECR Public:
+
+- `ecr-public:GetAuthorizationToken`
+- `ecr-public:BatchCheckLayerAvailability`
+- `ecr-public:GetRepositoryPolicy`
+- `ecr-public:DescribeRepositories`
+- `ecr-public:DescribeImages`
+- `ecr-public:DescribeImageTags`
+- `sts:GetServiceBearerToken`
+
+Attach the AWS managed policy `AmazonElasticContainerRegistryPublicReadOnly` and add the `sts:GetServiceBearerToken` permission. This permission is not included in the managed policy and must be granted separately, or ECR Public authentication will fail.
+
+### Add ECR Public credentials to Seqera
+
+1.  Add your credentials to your organization or personal workspace:
+    - From an organization workspace: Go to **Credentials > Add Credentials**.
+    - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
+
+2.  Complete the following fields:
+
+    - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `ecr-public-creds`.
+    - **Provider**: Select **Container registry**.
+    - **User name**: Specify your IAM user access key ID. For example, `AKIAIOSFODNN7EXAMPLE`.
+    - **Password**: Specify your IAM user secret access key.
+    - **Registry server**: Enter `public.ecr.aws`.
+
+3.  After you've completed all the form fields, select **Add**.
+
+Wave matches the `public.ecr.aws` hostname to these credentials and authenticates ECR Public pulls on your behalf.

--- a/platform-enterprise_versioned_docs/version-25.3/credentials/aws_registry_credentials.md
+++ b/platform-enterprise_versioned_docs/version-25.3/credentials/aws_registry_credentials.md
@@ -11,7 +11,7 @@ From version 22.3, Seqera Platform supports the configuration of credentials for
 Container registry credentials are only used by the Wave container service. Add `wave { enabled=true }` to the **Nextflow config** field on the launch page, or to your `nextflow.config` file, for your pipeline execution to use Wave containers.
 :::
 
-## AWS ECR access
+## AWS ECR Private Registry
 
 Wave requires programmatic access to your private Elastic Container Registry (ECR) via [long-term access keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#create-long-term-access-keys). Create a user with registry read permissions (e.g., a subset of the AWS-managed `AmazonEC2ContainerRegistryReadOnly` policy) for this purpose.
 
@@ -29,7 +29,7 @@ Wave requires programmatic access to your private Elastic Container Registry (EC
 Your credential must be stored in Seqera as a **container registry** credential, even if the same access keys already exist as a workspace credential.
 :::
 
-## Add credentials to Seqera
+## Add private ECR credentials to Seqera
 
 1.  Add your credentials to your organization or personal workspace:
     - From an organization workspace: Go to **Credentials > Add Credentials**.
@@ -40,11 +40,43 @@ Your credential must be stored in Seqera as a **container registry** credential,
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
     - **User name**: Specify your IAM user access key ID. For example, `AKIAIOSFODNN7EXAMPLE`.
-    - **Password**: Specify your IAM user secret access.
-    - **Registry server**: Specify container registry server name. For example, `<aws_account_id>.dkr.ecr.<region>.amazonaws.com`.
+    - **Password**: Specify your IAM user secret access key.
+    - **Registry server**: Specify your private ECR registry URL. For example, `<aws_account_id>.dkr.ecr.<region>.amazonaws.com`.
 
 3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
 
-:::note
-To use the Amazon ECR Public Registry, create a container registry credential with **public.ecr.aws** as the registry server. You can reuse your existing IAM credentials, but ensure that the IAM user has the `AmazonElasticContainerRegistryPublicReadOnly` policy attached.
-:::
+## AWS ECR Public Registry
+
+Amazon ECR Public Gallery (`public.ecr.aws`) hosts publicly accessible container images. While images can be pulled without authentication, AWS applies rate limits to unauthenticated pulls. Authenticating with AWS credentials removes these rate limits and is required when running pipelines at scale.
+
+### Required IAM permissions
+
+The IAM user needs the following permissions to authenticate to ECR Public:
+
+- `ecr-public:GetAuthorizationToken`
+- `ecr-public:BatchCheckLayerAvailability`
+- `ecr-public:GetRepositoryPolicy`
+- `ecr-public:DescribeRepositories`
+- `ecr-public:DescribeImages`
+- `ecr-public:DescribeImageTags`
+- `sts:GetServiceBearerToken`
+
+Attach the AWS managed policy `AmazonElasticContainerRegistryPublicReadOnly` and add the `sts:GetServiceBearerToken` permission. This permission is not included in the managed policy and must be granted separately, or ECR Public authentication will fail.
+
+### Add ECR Public credentials to Seqera
+
+1.  Add your credentials to your organization or personal workspace:
+    - From an organization workspace: Go to **Credentials > Add Credentials**.
+    - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
+
+2.  Complete the following fields:
+
+    - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `ecr-public-creds`.
+    - **Provider**: Select **Container registry**.
+    - **User name**: Specify your IAM user access key ID. For example, `AKIAIOSFODNN7EXAMPLE`.
+    - **Password**: Specify your IAM user secret access key.
+    - **Registry server**: Enter `public.ecr.aws`.
+
+3.  After you've completed all the form fields, select **Add**.
+
+Wave matches the `public.ecr.aws` hostname to these credentials and authenticates ECR Public pulls on your behalf.

--- a/platform-enterprise_versioned_docs/version-26.1/credentials/aws_registry_credentials.md
+++ b/platform-enterprise_versioned_docs/version-26.1/credentials/aws_registry_credentials.md
@@ -11,7 +11,7 @@ From version 22.3, Seqera Platform supports the configuration of credentials for
 Container registry credentials are only used by the Wave container service. Add `wave { enabled=true }` to the **Nextflow config** field on the launch page, or to your `nextflow.config` file, for your pipeline execution to use Wave containers.
 :::
 
-## AWS ECR access
+## AWS ECR Private Registry
 
 Wave requires programmatic access to your private Elastic Container Registry (ECR) via [long-term access keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#create-long-term-access-keys). Create a user with registry read permissions (e.g., a subset of the AWS-managed `AmazonEC2ContainerRegistryReadOnly` policy) for this purpose.
 
@@ -29,7 +29,7 @@ Wave requires programmatic access to your private Elastic Container Registry (EC
 Your credential must be stored in Seqera as a **container registry** credential, even if the same access keys already exist as a workspace credential.
 :::
 
-## Add credentials to Seqera
+## Add private ECR credentials to Seqera
 
 1.  Add your credentials to your organization or personal workspace:
     - From an organization workspace: Go to **Credentials > Add Credentials**.
@@ -40,11 +40,43 @@ Your credential must be stored in Seqera as a **container registry** credential,
     - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `my-registry-creds`.
     - **Provider**: Select **Container registry**.
     - **User name**: Specify your IAM user access key ID. For example, `AKIAIOSFODNN7EXAMPLE`.
-    - **Password**: Specify your IAM user secret access.
-    - **Registry server**: Specify container registry server name. For example, `<aws_account_id>.dkr.ecr.<region>.amazonaws.com`.
+    - **Password**: Specify your IAM user secret access key.
+    - **Registry server**: Specify your private ECR registry URL. For example, `<aws_account_id>.dkr.ecr.<region>.amazonaws.com`.
 
 3.  After you've completed all the form fields, select **Add**. The new credential is now listed under the **Credentials** tab.
 
-:::note
-To use the Amazon ECR Public Registry, create a container registry credential with **public.ecr.aws** as the registry server. You can reuse your existing IAM credentials, but ensure that the IAM user has the `AmazonElasticContainerRegistryPublicReadOnly` policy attached.
-:::
+## AWS ECR Public Registry
+
+Amazon ECR Public Gallery (`public.ecr.aws`) hosts publicly accessible container images. While images can be pulled without authentication, AWS applies rate limits to unauthenticated pulls. Authenticating with AWS credentials removes these rate limits and is required when running pipelines at scale.
+
+### Required IAM permissions
+
+The IAM user needs the following permissions to authenticate to ECR Public:
+
+- `ecr-public:GetAuthorizationToken`
+- `ecr-public:BatchCheckLayerAvailability`
+- `ecr-public:GetRepositoryPolicy`
+- `ecr-public:DescribeRepositories`
+- `ecr-public:DescribeImages`
+- `ecr-public:DescribeImageTags`
+- `sts:GetServiceBearerToken`
+
+Attach the AWS managed policy `AmazonElasticContainerRegistryPublicReadOnly` and add the `sts:GetServiceBearerToken` permission. This permission is not included in the managed policy and must be granted separately, or ECR Public authentication will fail.
+
+### Add ECR Public credentials to Seqera
+
+1.  Add your credentials to your organization or personal workspace:
+    - From an organization workspace: Go to **Credentials > Add Credentials**.
+    - From your personal workspace: From the user menu, go to **Your credentials > Add credentials**.
+
+2.  Complete the following fields:
+
+    - **Name**: Specify a unique name for the credentials using alphanumeric characters, dashes, or underscores. For example, `ecr-public-creds`.
+    - **Provider**: Select **Container registry**.
+    - **User name**: Specify your IAM user access key ID. For example, `AKIAIOSFODNN7EXAMPLE`.
+    - **Password**: Specify your IAM user secret access key.
+    - **Registry server**: Enter `public.ecr.aws`.
+
+3.  After you've completed all the form fields, select **Add**.
+
+Wave matches the `public.ecr.aws` hostname to these credentials and authenticates ECR Public pulls on your behalf.


### PR DESCRIPTION
## Summary

Expands the AWS ECR credentials pages to properly document ECR Public Registry usage with Wave. Applied across all four affected doc surfaces.

The previous docs had a single-sentence note about `public.ecr.aws` that omitted the key information users need to successfully authenticate.

### Files changed

- `platform-cloud/docs/credentials/aws_registry_credentials.md`
- `platform-enterprise_docs/credentials/aws_registry_credentials.md`
- `platform-enterprise_versioned_docs/version-25.3/credentials/aws_registry_credentials.md`
- `platform-enterprise_versioned_docs/version-26.1/credentials/aws_registry_credentials.md`

All four pages are updated to:

- Split into **AWS ECR Private Registry** and **AWS ECR Public Registry** sections for clarity.
- Add a full IAM permissions list for ECR Public, including `sts:GetServiceBearerToken` — the permission absent from `AmazonElasticContainerRegistryPublicReadOnly` that causes silent auth failures.
- Provide step-by-step **Add ECR Public credentials to Seqera** instructions with `public.ecr.aws` as the registry server value.
- Fix a copy error: "IAM user secret access" → "IAM user secret access key".

### Related

The companion PR in `seqeralabs/wave` adds the same public ECR guidance to the Wave authentication feature page (including self-hosted Wave config):
→ https://github.com/seqeralabs/wave/pull/1066

### Motivation

Support ticket 5013 showed users were not authenticating to ECR Public because:
1. They didn't know to use `public.ecr.aws` as the registry server
2. `sts:GetServiceBearerToken` was not documented as a required separate permission

Key: EDU-159

Co-authored by Claude agent for Jira.