### PR TITLE
fix: allow batch:TagResource on Batch compute environment in AWS Batch policy

### DIFF
--- a/platform-cloud/docs/compute-envs/_policies/aws-batch-full-policy.json
+++ b/platform-cloud/docs/compute-envs/_policies/aws-batch-full-policy.json
@@ -9,6 +9,7 @@
         "batch:CreateJobQueue",
         "batch:DeleteComputeEnvironment",
         "batch:DeleteJobQueue",
+        "batch:TagResource",
         "batch:UpdateComputeEnvironment",
         "batch:UpdateJobQueue"
       ],

--- a/platform-enterprise_docs/compute-envs/aws-batch.md
+++ b/platform-enterprise_docs/compute-envs/aws-batch.md
@@ -90,6 +90,7 @@ A permissive and broad policy with all the required permissions is provided here
         "batch:CreateJobQueue",
         "batch:DeleteComputeEnvironment",
         "batch:DeleteJobQueue",
+        "batch:TagResource",
         "batch:UpdateComputeEnvironment",
         "batch:UpdateJobQueue"
       ],

--- a/platform-enterprise_versioned_docs/version-24.1/compute-envs/aws-batch.md
+++ b/platform-enterprise_versioned_docs/version-24.1/compute-envs/aws-batch.md
@@ -90,6 +90,7 @@ A permissive and broad policy with all the required permissions is provided here
         "batch:CreateJobQueue",
         "batch:DeleteComputeEnvironment",
         "batch:DeleteJobQueue",
+        "batch:TagResource",
         "batch:UpdateComputeEnvironment",
         "batch:UpdateJobQueue"
       ],

--- a/platform-enterprise_versioned_docs/version-24.2/compute-envs/aws-batch.md
+++ b/platform-enterprise_versioned_docs/version-24.2/compute-envs/aws-batch.md
@@ -90,6 +90,7 @@ A permissive and broad policy with all the required permissions is provided here
         "batch:CreateJobQueue",
         "batch:DeleteComputeEnvironment",
         "batch:DeleteJobQueue",
+        "batch:TagResource",
         "batch:UpdateComputeEnvironment",
         "batch:UpdateJobQueue"
       ],

--- a/platform-enterprise_versioned_docs/version-25.1/compute-envs/aws-batch.md
+++ b/platform-enterprise_versioned_docs/version-25.1/compute-envs/aws-batch.md
@@ -90,6 +90,7 @@ A permissive and broad policy with all the required permissions is provided here
         "batch:CreateJobQueue",
         "batch:DeleteComputeEnvironment",
         "batch:DeleteJobQueue",
+        "batch:TagResource",
         "batch:UpdateComputeEnvironment",
         "batch:UpdateJobQueue"
       ],

--- a/platform-enterprise_versioned_docs/version-25.2/compute-envs/aws-batch.md
+++ b/platform-enterprise_versioned_docs/version-25.2/compute-envs/aws-batch.md
@@ -90,6 +90,7 @@ A permissive and broad policy with all the required permissions is provided here
         "batch:CreateJobQueue",
         "batch:DeleteComputeEnvironment",
         "batch:DeleteJobQueue",
+        "batch:TagResource",
         "batch:UpdateComputeEnvironment",
         "batch:UpdateJobQueue"
       ],

--- a/platform-enterprise_versioned_docs/version-25.3/compute-envs/aws-batch.md
+++ b/platform-enterprise_versioned_docs/version-25.3/compute-envs/aws-batch.md
@@ -90,6 +90,7 @@ A permissive and broad policy with all the required permissions is provided here
         "batch:CreateJobQueue",
         "batch:DeleteComputeEnvironment",
         "batch:DeleteJobQueue",
+        "batch:TagResource",
         "batch:UpdateComputeEnvironment",
         "batch:UpdateJobQueue"
       ],

--- a/platform-enterprise_versioned_docs/version-26.1/compute-envs/aws-batch.md
+++ b/platform-enterprise_versioned_docs/version-26.1/compute-envs/aws-batch.md
@@ -90,6 +90,7 @@ A permissive and broad policy with all the required permissions is provided here
         "batch:CreateJobQueue",
         "batch:DeleteComputeEnvironment",
         "batch:DeleteJobQueue",
+        "batch:TagResource",
         "batch:UpdateComputeEnvironment",
         "batch:UpdateJobQueue"
       ],


### PR DESCRIPTION
## Problem

The full permissive IAM policy for AWS Batch (`aws-batch-full-policy.json`, rendered on the [AWS Batch compute environment docs page](https://docs.seqera.io/platform-cloud/compute-envs/aws-batch)) grants `batch:TagResource` only for job, job-definition, and job-queue resources. It does **not** cover the `compute-environment/TowerForge-*` resource.

Batch Forge tags the compute environment when it creates it. Because the compute-environment ARN is out of scope for `batch:TagResource`, creating a compute environment with a policy copied verbatim from the docs fails with:

```
User: arn:aws:iam::<ACCOUNT_ID>:user/<USER> is not authorized to perform:
batch:TagResource on resource:
arn:aws:batch:<REGION>:<ACCOUNT_ID>:compute-environment/TowerForge-<ID>-head
because no identity-based policy allows the batch:TagResource action
(Service: Batch, Status Code: 403)
```

## Fix

Add `batch:TagResource` to the `BatchEnvironmentManagementCanBeRestricted` statement. That statement already scopes to `compute-environment/TowerForge-*` and `job-queue/TowerForge-*`, and tagging the compute environment is part of environment creation — so this is the natural home for the action.

The existing `batch:TagResource` in `BatchJobsManagementCanBeRestricted` (job/job-definition/job-queue scope) is unchanged and still covers job submission.

## Change

```diff
   "Sid": "BatchEnvironmentManagementCanBeRestricted",
   "Action": [
     "batch:CreateComputeEnvironment",
     "batch:CreateJobQueue",
     "batch:DeleteComputeEnvironment",
     "batch:DeleteJobQueue",
+    "batch:TagResource",
     "batch:UpdateComputeEnvironment",
     "batch:UpdateJobQueue"
   ],
   "Resource": [
     "arn:aws:batch:*:*:compute-environment/TowerForge-*",
     "arn:aws:batch:*:*:job-queue/TowerForge-*"
   ]
```
