### PR TITLE
Restore JVM memory guidance lost from 26.x docs (EDU-858)

### DIFF
--- a/platform-enterprise_docs/enterprise/_templates/docker/tower.env
+++ b/platform-enterprise_docs/enterprise/_templates/docker/tower.env
@@ -4,6 +4,9 @@ TOWER_JWT_SECRET=<Replace This With A Secret String containing at least 35 chara
 TOWER_CRYPTO_SECRETKEY=<Replace This With Another Secret String>
 TOWER_LICENSE=<YOUR TOWER LICENSE KEY>
 
+# Configuration to optimize JVM memory settings. See https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview#backend-memory-requirements
+JAVA_OPTS="-Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144"
+
 # Compute environment settings
 TOWER_ENABLE_PLATFORMS="altair-platform,awsbatch-platform,awscloud-platform,azbatch-platform,azcloud-platform,eks-platform,gke-platform,googlebatch-platform,googlecloud-platform,k8s-platform,lsf-platform,moab-platform,slurm-platform,uge-platform"
 

--- a/platform-enterprise_docs/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/tower-cron.yml
@@ -43,8 +43,17 @@ spec:
           env:
             - name: MICRONAUT_ENVIRONMENTS
               value: "prod,redis,cron"
+            # Configuration to optimize JVM memory settings. See https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview#backend-memory-requirements
+            - name: JAVA_OPTS
+              value: "-Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144"
           ports:
             - containerPort: 8080
+          resources:
+            requests:
+              cpu: "1"
+              memory: "4Gi"
+            limits:
+              memory: "4Gi"
           readinessProbe:
             httpGet:
               path: /health

--- a/platform-enterprise_docs/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_docs/enterprise/_templates/k8s/tower-svc.yml
@@ -36,6 +36,9 @@ spec:
           env:
             - name: MICRONAUT_ENVIRONMENTS
               value: "prod,redis,ha"
+            # Configuration to optimize JVM memory settings. See https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview#backend-memory-requirements
+            - name: JAVA_OPTS
+              value: "-Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144"
             # TLS certificate for Studios
             #- name: TOWER_OIDC_PEM_PATH
             #  value: '/data/certs/oidc.pem'

--- a/platform-enterprise_docs/enterprise/configuration/overview.mdx
+++ b/platform-enterprise_docs/enterprise/configuration/overview.mdx
@@ -420,7 +420,7 @@ These default memory allocation limits are included in the Kubernetes manifest t
 For production deployments, configure JVM memory parameters with the `JAVA_OPTS` environment variable. This baseline configuration suits most deployments:
 
 ```bash
-JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
+JAVA_OPTS="-Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144"
 ```
 
 The `JAVA_TOOL_OPTIONS` environment variable is a supported alternative to `JAVA_OPTS`. The JVM reads it directly at startup and confirms pickup with a `Picked up JAVA_TOOL_OPTIONS` line in the service logs. Set one variable or the other, not both. Options passed on the command line (which is how `JAVA_OPTS` is applied) take precedence over `JAVA_TOOL_OPTIONS` when the same flag appears in both.

--- a/platform-enterprise_docs/enterprise/configuration/overview.mdx
+++ b/platform-enterprise_docs/enterprise/configuration/overview.mdx
@@ -453,7 +453,7 @@ Increase heap memory (`-Xmx`) if you observe:
 For deployments running 200 or more concurrent workflows, increase the heap and direct memory limits:
 
 ```bash
-JAVA_OPTS: -Xms1000M -Xmx3000M -XX:MaxDirectMemorySize=1600m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
+JAVA_OPTS="-Xms1000M -Xmx3000M -XX:MaxDirectMemorySize=1600m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144"
 ```
 
 Set the container or pod memory limit higher than the JVM limits to accommodate non-heap memory usage.

--- a/platform-enterprise_docs/enterprise/configuration/overview.mdx
+++ b/platform-enterprise_docs/enterprise/configuration/overview.mdx
@@ -388,6 +388,85 @@ With rotation enabled and the previous and new key values set, secret key rotati
 
 The [Admin panel](../../administration/overview.md#encryption) **Encryption** tab displays the status of completed or errored encryption tasks.
 
+## Backend memory requirements
+
+The Platform backend and cron services run on the JVM and require appropriate memory allocation for stable operation under load.
+
+**Minimum memory allocation:**
+- Backend service: 4 GB minimum
+- Cron service: 4 GB minimum
+
+**How to set memory limits:**
+
+**Kubernetes:**
+Set resource limits in your pod specifications:
+```yaml
+resources:
+  limits:
+    memory: "4Gi"
+  requests:
+    memory: "4Gi"
+```
+
+**Docker Compose:**
+Set memory limits in your service definitions:
+```yaml
+services:
+  backend:
+    mem_limit: 4g
+    memswap_limit: 4g
+```
+
+:::note
+These default memory allocation limits are included in the Kubernetes manifest templates ([tower-svc.yml](../_templates/k8s/tower-svc.yml) and [tower-cron.yml](../_templates/k8s/tower-cron.yml)). For Docker Compose, add the `mem_limit` settings to your service definitions as shown above.
+:::
+
+### JVM memory tuning
+
+For production deployments, configure JVM memory parameters via the `JAVA_OPTS` environment variable. The following baseline configuration is suitable for most deployments:
+
+```bash
+JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
+```
+
+The `JAVA_TOOL_OPTIONS` environment variable is a supported alternative to `JAVA_OPTS`: the JVM reads it directly at startup and confirms pickup with a `Picked up JAVA_TOOL_OPTIONS` line in the service logs. Set one variable or the other, not both — options passed on the command line (which is how `JAVA_OPTS` is applied) take precedence over `JAVA_TOOL_OPTIONS` when the same flag appears in both.
+
+:::note
+These default JVM memory settings are included in the configuration templates provided in these docs:
+- Kubernetes: [tower-svc.yml](../_templates/k8s/tower-svc.yml) and [tower-cron.yml](../_templates/k8s/tower-cron.yml)
+- Docker Compose: [tower.env](../_templates/docker/tower.env)
+:::
+
+**Parameter descriptions:**
+- **Heap memory** (`-Xms`/`-Xmx`): Memory pool for Java objects. Set initial (`Xms`) and maximum (`Xmx`) heap size.
+- **Direct memory** (`MaxDirectMemorySize`): Off-heap memory used for NIO operations, network buffers, and file I/O. Critical for handling concurrent workflow API operations.
+- **Netty memory accounting** (`io.netty.maxDirectMemory=0`): Disables Netty's internal tracking; relies on JVM direct memory limits instead.
+- **Buffer caching** (`jdk.nio.maxCachedBufferSize`): Limits size of cached NIO buffers to prevent excessive memory retention.
+
+**When to adjust these values:**
+
+Increase `MaxDirectMemorySize` if you observe:
+- `OutOfMemoryError: Direct buffer memory` in logs
+- High concurrent workflow launch rates (>100 simultaneous workflows)
+- Large configuration payloads or extensive API usage
+
+Increase heap memory (`-Xmx`) if you observe:
+- `OutOfMemoryError: Java heap space` in logs
+- Garbage collection pauses affecting performance
+- Growing memory usage under sustained load
+
+**Example: High-concurrency deployment**
+For deployments running 200+ concurrent workflows:
+```bash
+JAVA_OPTS: -Xms1000M -Xmx3000M -XX:MaxDirectMemorySize=1600m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
+```
+
+Ensure container/pod memory limits are set higher than JVM limits to accommodate non-heap memory usage.
+
+:::warning
+These are starting recommendations. Monitor your deployment's actual memory usage and adjust based on your specific workload patterns. Undersized memory allocation can cause OOM failures and service instability.
+:::
+
 ## Compute environments
 
 Configuration values to enable computing platforms and customize Batch Forge resource naming.

--- a/platform-enterprise_docs/enterprise/configuration/overview.mdx
+++ b/platform-enterprise_docs/enterprise/configuration/overview.mdx
@@ -390,16 +390,10 @@ The [Admin panel](../../administration/overview.md#encryption) **Encryption** ta
 
 ## Backend memory requirements
 
-The Platform backend and cron services run on the JVM and require appropriate memory allocation for stable operation under load.
+The Platform backend and cron services run on the Java Virtual Machine (JVM). Allocate at least 4 GB of memory to each service for stable operation under load.
 
-**Minimum memory allocation:**
-- Backend service: 4 GB minimum
-- Cron service: 4 GB minimum
+For Kubernetes, set resource limits in your pod specifications:
 
-**How to set memory limits:**
-
-**Kubernetes:**
-Set resource limits in your pod specifications:
 ```yaml
 resources:
   limits:
@@ -408,8 +402,8 @@ resources:
     memory: "4Gi"
 ```
 
-**Docker Compose:**
-Set memory limits in your service definitions:
+For Docker Compose, set memory limits in your service definitions:
+
 ```yaml
 services:
   backend:
@@ -423,13 +417,13 @@ These default memory allocation limits are included in the Kubernetes manifest t
 
 ### JVM memory tuning
 
-For production deployments, configure JVM memory parameters via the `JAVA_OPTS` environment variable. The following baseline configuration is suitable for most deployments:
+For production deployments, configure JVM memory parameters with the `JAVA_OPTS` environment variable. This baseline configuration suits most deployments:
 
 ```bash
 JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
 ```
 
-The `JAVA_TOOL_OPTIONS` environment variable is a supported alternative to `JAVA_OPTS`: the JVM reads it directly at startup and confirms pickup with a `Picked up JAVA_TOOL_OPTIONS` line in the service logs. Set one variable or the other, not both — options passed on the command line (which is how `JAVA_OPTS` is applied) take precedence over `JAVA_TOOL_OPTIONS` when the same flag appears in both.
+The `JAVA_TOOL_OPTIONS` environment variable is a supported alternative to `JAVA_OPTS`. The JVM reads it directly at startup and confirms pickup with a `Picked up JAVA_TOOL_OPTIONS` line in the service logs. Set one variable or the other, not both. Options passed on the command line (which is how `JAVA_OPTS` is applied) take precedence over `JAVA_TOOL_OPTIONS` when the same flag appears in both.
 
 :::note
 These default JVM memory settings are included in the configuration templates provided in these docs:
@@ -437,34 +431,35 @@ These default JVM memory settings are included in the configuration templates pr
 - Docker Compose: [tower.env](../_templates/docker/tower.env)
 :::
 
-**Parameter descriptions:**
-- **Heap memory** (`-Xms`/`-Xmx`): Memory pool for Java objects. Set initial (`Xms`) and maximum (`Xmx`) heap size.
-- **Direct memory** (`MaxDirectMemorySize`): Off-heap memory used for NIO operations, network buffers, and file I/O. Critical for handling concurrent workflow API operations.
-- **Netty memory accounting** (`io.netty.maxDirectMemory=0`): Disables Netty's internal tracking; relies on JVM direct memory limits instead.
-- **Buffer caching** (`jdk.nio.maxCachedBufferSize`): Limits size of cached NIO buffers to prevent excessive memory retention.
+| Parameter | Description |
+| --- | --- |
+| `-Xms` / `-Xmx` | Initial and maximum heap size — the memory pool for Java objects. |
+| `-XX:MaxDirectMemorySize` | Off-heap memory for NIO operations, network buffers, and file I/O. Handles concurrent workflow API operations. |
+| `-Dio.netty.maxDirectMemory=0` | Disables Netty's internal memory tracking and relies on the JVM direct memory limit instead. |
+| `-Djdk.nio.maxCachedBufferSize` | Limits the size of cached NIO buffers to prevent excessive memory retention. |
 
-**When to adjust these values:**
+Adjust these baseline values based on the symptoms you observe.
 
-Increase `MaxDirectMemorySize` if you observe:
-- `OutOfMemoryError: Direct buffer memory` in logs
-- High concurrent workflow launch rates (>100 simultaneous workflows)
-- Large configuration payloads or extensive API usage
+Increase `-XX:MaxDirectMemorySize` if you observe:
+- `OutOfMemoryError: Direct buffer memory` in the logs
+- High concurrent workflow launch rates (more than 100 simultaneous workflows)
+- Large configuration payloads or heavy API usage
 
 Increase heap memory (`-Xmx`) if you observe:
-- `OutOfMemoryError: Java heap space` in logs
-- Garbage collection pauses affecting performance
+- `OutOfMemoryError: Java heap space` in the logs
+- Garbage collection pauses that affect performance
 - Growing memory usage under sustained load
 
-**Example: High-concurrency deployment**
-For deployments running 200+ concurrent workflows:
+For deployments running 200 or more concurrent workflows, increase the heap and direct memory limits:
+
 ```bash
 JAVA_OPTS: -Xms1000M -Xmx3000M -XX:MaxDirectMemorySize=1600m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
 ```
 
-Ensure container/pod memory limits are set higher than JVM limits to accommodate non-heap memory usage.
+Set the container or pod memory limit higher than the JVM limits to accommodate non-heap memory usage.
 
 :::warning
-These are starting recommendations. Monitor your deployment's actual memory usage and adjust based on your specific workload patterns. Undersized memory allocation can cause OOM failures and service instability.
+These are starting values. Monitor your deployment's memory usage and adjust for your workload. Undersized memory allocation can cause out-of-memory (OOM) failures and service instability.
 :::
 
 ## Compute environments

--- a/platform-enterprise_docs/enterprise/upgrade.md
+++ b/platform-enterprise_docs/enterprise/upgrade.md
@@ -162,6 +162,17 @@ The database volume is persistent on the local machine by default if you use the
 1. Download the latest versions of your deployment templates and update your Seqera container versions:
     - [docker-compose.yml](./_templates/docker/docker-compose.yml) for Docker Compose deployments
     - [tower-cron.yml](./_templates/k8s/tower-cron.yml) and [tower-svc.yml](./_templates/k8s/tower-svc.yml) for Kubernetes deployments
+1. **JVM memory configuration defaults (recommended)**: The following `JAVA_OPTS` environment variable is included in the deployment templates downloaded in the preceding step, to optimize JVM memory settings:
+
+    ```bash
+    JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
+    ```
+
+    These baseline values are suitable for most deployments running moderate concurrent workflow loads.
+
+    :::tip
+    These are starting recommendations that may require tuning based on your deployment's workload. See [Backend memory requirements](./configuration/overview.mdx#backend-memory-requirements) for detailed guidance on when and how to adjust these values for your environment.
+    :::
 1. If you're using Studios, download and apply the latest versions of the Kubernetes manifests:
     - [proxy.yml](./_templates/k8s/data_studios/proxy.yml)
     - [server.yml](./_templates/k8s/data_studios/server.yml)

--- a/platform-enterprise_docs/enterprise/upgrade.md
+++ b/platform-enterprise_docs/enterprise/upgrade.md
@@ -162,16 +162,16 @@ The database volume is persistent on the local machine by default if you use the
 1. Download the latest versions of your deployment templates and update your Seqera container versions:
     - [docker-compose.yml](./_templates/docker/docker-compose.yml) for Docker Compose deployments
     - [tower-cron.yml](./_templates/k8s/tower-cron.yml) and [tower-svc.yml](./_templates/k8s/tower-svc.yml) for Kubernetes deployments
-1. **JVM memory configuration defaults (recommended)**: The following `JAVA_OPTS` environment variable is included in the deployment templates downloaded in the preceding step, to optimize JVM memory settings:
+1. **JVM memory defaults (recommended)**: The deployment templates you downloaded in the previous step include the following `JAVA_OPTS` environment variable to tune JVM memory settings:
 
     ```bash
     JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
     ```
 
-    These baseline values are suitable for most deployments running moderate concurrent workflow loads.
+    These baseline values suit most deployments with moderate concurrent workflow loads.
 
     :::tip
-    These are starting recommendations that may require tuning based on your deployment's workload. See [Backend memory requirements](./configuration/overview.mdx#backend-memory-requirements) for detailed guidance on when and how to adjust these values for your environment.
+    These are starting values that may need tuning for your workload. See [Backend memory requirements](./configuration/overview.mdx#backend-memory-requirements) for when and how to adjust them.
     :::
 1. If you're using Studios, download and apply the latest versions of the Kubernetes manifests:
     - [proxy.yml](./_templates/k8s/data_studios/proxy.yml)

--- a/platform-enterprise_docs/enterprise/upgrade.md
+++ b/platform-enterprise_docs/enterprise/upgrade.md
@@ -165,7 +165,7 @@ The database volume is persistent on the local machine by default if you use the
 1. **JVM memory defaults (recommended)**: The deployment templates you downloaded in the previous step include the following `JAVA_OPTS` environment variable to tune JVM memory settings:
 
     ```bash
-    JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
+    JAVA_OPTS="-Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144"
     ```
 
     These baseline values suit most deployments with moderate concurrent workflow loads.

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/tower.env
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/docker/tower.env
@@ -4,6 +4,9 @@ TOWER_JWT_SECRET=<Replace This With A Secret String containing at least 35 chara
 TOWER_CRYPTO_SECRETKEY=<Replace This With Another Secret String>
 TOWER_LICENSE=<YOUR TOWER LICENSE KEY>
 
+# Configuration to optimize JVM memory settings. See https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview#backend-memory-requirements
+JAVA_OPTS="-Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144"
+
 # Compute environment settings
 TOWER_ENABLE_PLATFORMS="altair-platform,awsbatch-platform,awscloud-platform,azbatch-platform,azcloud-platform,eks-platform,gke-platform,googlebatch-platform,googlecloud-platform,k8s-platform,lsf-platform,moab-platform,slurm-platform,uge-platform"
 

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-cron.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-cron.yml
@@ -43,8 +43,17 @@ spec:
           env:
             - name: MICRONAUT_ENVIRONMENTS
               value: "prod,redis,cron"
+            # Configuration to optimize JVM memory settings. See https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview#backend-memory-requirements
+            - name: JAVA_OPTS
+              value: "-Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144"
           ports:
             - containerPort: 8080
+          resources:
+            requests:
+              cpu: "1"
+              memory: "4Gi"
+            limits:
+              memory: "4Gi"
           readinessProbe:
             httpGet:
               path: /health

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-svc.yml
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/_templates/k8s/tower-svc.yml
@@ -36,6 +36,9 @@ spec:
           env:
             - name: MICRONAUT_ENVIRONMENTS
               value: "prod,redis,ha"
+            # Configuration to optimize JVM memory settings. See https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview#backend-memory-requirements
+            - name: JAVA_OPTS
+              value: "-Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144"
             # TLS certificate for Studios
             #- name: TOWER_OIDC_PEM_PATH
             #  value: '/data/certs/oidc.pem'

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/overview.mdx
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/overview.mdx
@@ -420,7 +420,7 @@ These default memory allocation limits are included in the Kubernetes manifest t
 For production deployments, configure JVM memory parameters with the `JAVA_OPTS` environment variable. This baseline configuration suits most deployments:
 
 ```bash
-JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
+JAVA_OPTS="-Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144"
 ```
 
 The `JAVA_TOOL_OPTIONS` environment variable is a supported alternative to `JAVA_OPTS`. The JVM reads it directly at startup and confirms pickup with a `Picked up JAVA_TOOL_OPTIONS` line in the service logs. Set one variable or the other, not both. Options passed on the command line (which is how `JAVA_OPTS` is applied) take precedence over `JAVA_TOOL_OPTIONS` when the same flag appears in both.

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/overview.mdx
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/overview.mdx
@@ -453,7 +453,7 @@ Increase heap memory (`-Xmx`) if you observe:
 For deployments running 200 or more concurrent workflows, increase the heap and direct memory limits:
 
 ```bash
-JAVA_OPTS: -Xms1000M -Xmx3000M -XX:MaxDirectMemorySize=1600m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
+JAVA_OPTS="-Xms1000M -Xmx3000M -XX:MaxDirectMemorySize=1600m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144"
 ```
 
 Set the container or pod memory limit higher than the JVM limits to accommodate non-heap memory usage.

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/overview.mdx
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/overview.mdx
@@ -388,6 +388,85 @@ With rotation enabled and the previous and new key values set, secret key rotati
 
 The [Admin panel](../../administration/overview.md#encryption) **Encryption** tab displays the status of completed or errored encryption tasks.
 
+## Backend memory requirements
+
+The Platform backend and cron services run on the JVM and require appropriate memory allocation for stable operation under load.
+
+**Minimum memory allocation:**
+- Backend service: 4 GB minimum
+- Cron service: 4 GB minimum
+
+**How to set memory limits:**
+
+**Kubernetes:**
+Set resource limits in your pod specifications:
+```yaml
+resources:
+  limits:
+    memory: "4Gi"
+  requests:
+    memory: "4Gi"
+```
+
+**Docker Compose:**
+Set memory limits in your service definitions:
+```yaml
+services:
+  backend:
+    mem_limit: 4g
+    memswap_limit: 4g
+```
+
+:::note
+These default memory allocation limits are included in the Kubernetes manifest templates ([tower-svc.yml](../_templates/k8s/tower-svc.yml) and [tower-cron.yml](../_templates/k8s/tower-cron.yml)). For Docker Compose, add the `mem_limit` settings to your service definitions as shown above.
+:::
+
+### JVM memory tuning
+
+For production deployments, configure JVM memory parameters via the `JAVA_OPTS` environment variable. The following baseline configuration is suitable for most deployments:
+
+```bash
+JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
+```
+
+The `JAVA_TOOL_OPTIONS` environment variable is a supported alternative to `JAVA_OPTS`: the JVM reads it directly at startup and confirms pickup with a `Picked up JAVA_TOOL_OPTIONS` line in the service logs. Set one variable or the other, not both — options passed on the command line (which is how `JAVA_OPTS` is applied) take precedence over `JAVA_TOOL_OPTIONS` when the same flag appears in both.
+
+:::note
+These default JVM memory settings are included in the configuration templates provided in these docs:
+- Kubernetes: [tower-svc.yml](../_templates/k8s/tower-svc.yml) and [tower-cron.yml](../_templates/k8s/tower-cron.yml)
+- Docker Compose: [tower.env](../_templates/docker/tower.env)
+:::
+
+**Parameter descriptions:**
+- **Heap memory** (`-Xms`/`-Xmx`): Memory pool for Java objects. Set initial (`Xms`) and maximum (`Xmx`) heap size.
+- **Direct memory** (`MaxDirectMemorySize`): Off-heap memory used for NIO operations, network buffers, and file I/O. Critical for handling concurrent workflow API operations.
+- **Netty memory accounting** (`io.netty.maxDirectMemory=0`): Disables Netty's internal tracking; relies on JVM direct memory limits instead.
+- **Buffer caching** (`jdk.nio.maxCachedBufferSize`): Limits size of cached NIO buffers to prevent excessive memory retention.
+
+**When to adjust these values:**
+
+Increase `MaxDirectMemorySize` if you observe:
+- `OutOfMemoryError: Direct buffer memory` in logs
+- High concurrent workflow launch rates (>100 simultaneous workflows)
+- Large configuration payloads or extensive API usage
+
+Increase heap memory (`-Xmx`) if you observe:
+- `OutOfMemoryError: Java heap space` in logs
+- Garbage collection pauses affecting performance
+- Growing memory usage under sustained load
+
+**Example: High-concurrency deployment**
+For deployments running 200+ concurrent workflows:
+```bash
+JAVA_OPTS: -Xms1000M -Xmx3000M -XX:MaxDirectMemorySize=1600m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
+```
+
+Ensure container/pod memory limits are set higher than JVM limits to accommodate non-heap memory usage.
+
+:::warning
+These are starting recommendations. Monitor your deployment's actual memory usage and adjust based on your specific workload patterns. Undersized memory allocation can cause OOM failures and service instability.
+:::
+
 ## Compute environments
 
 Configuration values to enable computing platforms and customize Batch Forge resource naming.

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/overview.mdx
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/overview.mdx
@@ -390,16 +390,10 @@ The [Admin panel](../../administration/overview.md#encryption) **Encryption** ta
 
 ## Backend memory requirements
 
-The Platform backend and cron services run on the JVM and require appropriate memory allocation for stable operation under load.
+The Platform backend and cron services run on the Java Virtual Machine (JVM). Allocate at least 4 GB of memory to each service for stable operation under load.
 
-**Minimum memory allocation:**
-- Backend service: 4 GB minimum
-- Cron service: 4 GB minimum
+For Kubernetes, set resource limits in your pod specifications:
 
-**How to set memory limits:**
-
-**Kubernetes:**
-Set resource limits in your pod specifications:
 ```yaml
 resources:
   limits:
@@ -408,8 +402,8 @@ resources:
     memory: "4Gi"
 ```
 
-**Docker Compose:**
-Set memory limits in your service definitions:
+For Docker Compose, set memory limits in your service definitions:
+
 ```yaml
 services:
   backend:
@@ -423,13 +417,13 @@ These default memory allocation limits are included in the Kubernetes manifest t
 
 ### JVM memory tuning
 
-For production deployments, configure JVM memory parameters via the `JAVA_OPTS` environment variable. The following baseline configuration is suitable for most deployments:
+For production deployments, configure JVM memory parameters with the `JAVA_OPTS` environment variable. This baseline configuration suits most deployments:
 
 ```bash
 JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
 ```
 
-The `JAVA_TOOL_OPTIONS` environment variable is a supported alternative to `JAVA_OPTS`: the JVM reads it directly at startup and confirms pickup with a `Picked up JAVA_TOOL_OPTIONS` line in the service logs. Set one variable or the other, not both — options passed on the command line (which is how `JAVA_OPTS` is applied) take precedence over `JAVA_TOOL_OPTIONS` when the same flag appears in both.
+The `JAVA_TOOL_OPTIONS` environment variable is a supported alternative to `JAVA_OPTS`. The JVM reads it directly at startup and confirms pickup with a `Picked up JAVA_TOOL_OPTIONS` line in the service logs. Set one variable or the other, not both. Options passed on the command line (which is how `JAVA_OPTS` is applied) take precedence over `JAVA_TOOL_OPTIONS` when the same flag appears in both.
 
 :::note
 These default JVM memory settings are included in the configuration templates provided in these docs:
@@ -437,34 +431,35 @@ These default JVM memory settings are included in the configuration templates pr
 - Docker Compose: [tower.env](../_templates/docker/tower.env)
 :::
 
-**Parameter descriptions:**
-- **Heap memory** (`-Xms`/`-Xmx`): Memory pool for Java objects. Set initial (`Xms`) and maximum (`Xmx`) heap size.
-- **Direct memory** (`MaxDirectMemorySize`): Off-heap memory used for NIO operations, network buffers, and file I/O. Critical for handling concurrent workflow API operations.
-- **Netty memory accounting** (`io.netty.maxDirectMemory=0`): Disables Netty's internal tracking; relies on JVM direct memory limits instead.
-- **Buffer caching** (`jdk.nio.maxCachedBufferSize`): Limits size of cached NIO buffers to prevent excessive memory retention.
+| Parameter | Description |
+| --- | --- |
+| `-Xms` / `-Xmx` | Initial and maximum heap size — the memory pool for Java objects. |
+| `-XX:MaxDirectMemorySize` | Off-heap memory for NIO operations, network buffers, and file I/O. Handles concurrent workflow API operations. |
+| `-Dio.netty.maxDirectMemory=0` | Disables Netty's internal memory tracking and relies on the JVM direct memory limit instead. |
+| `-Djdk.nio.maxCachedBufferSize` | Limits the size of cached NIO buffers to prevent excessive memory retention. |
 
-**When to adjust these values:**
+Adjust these baseline values based on the symptoms you observe.
 
-Increase `MaxDirectMemorySize` if you observe:
-- `OutOfMemoryError: Direct buffer memory` in logs
-- High concurrent workflow launch rates (>100 simultaneous workflows)
-- Large configuration payloads or extensive API usage
+Increase `-XX:MaxDirectMemorySize` if you observe:
+- `OutOfMemoryError: Direct buffer memory` in the logs
+- High concurrent workflow launch rates (more than 100 simultaneous workflows)
+- Large configuration payloads or heavy API usage
 
 Increase heap memory (`-Xmx`) if you observe:
-- `OutOfMemoryError: Java heap space` in logs
-- Garbage collection pauses affecting performance
+- `OutOfMemoryError: Java heap space` in the logs
+- Garbage collection pauses that affect performance
 - Growing memory usage under sustained load
 
-**Example: High-concurrency deployment**
-For deployments running 200+ concurrent workflows:
+For deployments running 200 or more concurrent workflows, increase the heap and direct memory limits:
+
 ```bash
 JAVA_OPTS: -Xms1000M -Xmx3000M -XX:MaxDirectMemorySize=1600m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
 ```
 
-Ensure container/pod memory limits are set higher than JVM limits to accommodate non-heap memory usage.
+Set the container or pod memory limit higher than the JVM limits to accommodate non-heap memory usage.
 
 :::warning
-These are starting recommendations. Monitor your deployment's actual memory usage and adjust based on your specific workload patterns. Undersized memory allocation can cause OOM failures and service instability.
+These are starting values. Monitor your deployment's memory usage and adjust for your workload. Undersized memory allocation can cause out-of-memory (OOM) failures and service instability.
 :::
 
 ## Compute environments

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/upgrade.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/upgrade.md
@@ -162,6 +162,17 @@ The database volume is persistent on the local machine by default if you use the
 1. Download the latest versions of your deployment templates and update your Seqera container versions:
     - [docker-compose.yml](./_templates/docker/docker-compose.yml) for Docker Compose deployments
     - [tower-cron.yml](./_templates/k8s/tower-cron.yml) and [tower-svc.yml](./_templates/k8s/tower-svc.yml) for Kubernetes deployments
+1. **JVM memory configuration defaults (recommended)**: The following `JAVA_OPTS` environment variable is included in the deployment templates downloaded in the preceding step, to optimize JVM memory settings:
+
+    ```bash
+    JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
+    ```
+
+    These baseline values are suitable for most deployments running moderate concurrent workflow loads.
+
+    :::tip
+    These are starting recommendations that may require tuning based on your deployment's workload. See [Backend memory requirements](./configuration/overview.mdx#backend-memory-requirements) for detailed guidance on when and how to adjust these values for your environment.
+    :::
 1. If you're using Studios, download and apply the latest versions of the Kubernetes manifests:
     - [proxy.yml](./_templates/k8s/data_studios/proxy.yml)
     - [server.yml](./_templates/k8s/data_studios/server.yml)

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/upgrade.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/upgrade.md
@@ -162,16 +162,16 @@ The database volume is persistent on the local machine by default if you use the
 1. Download the latest versions of your deployment templates and update your Seqera container versions:
     - [docker-compose.yml](./_templates/docker/docker-compose.yml) for Docker Compose deployments
     - [tower-cron.yml](./_templates/k8s/tower-cron.yml) and [tower-svc.yml](./_templates/k8s/tower-svc.yml) for Kubernetes deployments
-1. **JVM memory configuration defaults (recommended)**: The following `JAVA_OPTS` environment variable is included in the deployment templates downloaded in the preceding step, to optimize JVM memory settings:
+1. **JVM memory defaults (recommended)**: The deployment templates you downloaded in the previous step include the following `JAVA_OPTS` environment variable to tune JVM memory settings:
 
     ```bash
     JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
     ```
 
-    These baseline values are suitable for most deployments running moderate concurrent workflow loads.
+    These baseline values suit most deployments with moderate concurrent workflow loads.
 
     :::tip
-    These are starting recommendations that may require tuning based on your deployment's workload. See [Backend memory requirements](./configuration/overview.mdx#backend-memory-requirements) for detailed guidance on when and how to adjust these values for your environment.
+    These are starting values that may need tuning for your workload. See [Backend memory requirements](./configuration/overview.mdx#backend-memory-requirements) for when and how to adjust them.
     :::
 1. If you're using Studios, download and apply the latest versions of the Kubernetes manifests:
     - [proxy.yml](./_templates/k8s/data_studios/proxy.yml)

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/upgrade.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/upgrade.md
@@ -165,7 +165,7 @@ The database volume is persistent on the local machine by default if you use the
 1. **JVM memory defaults (recommended)**: The deployment templates you downloaded in the previous step include the following `JAVA_OPTS` environment variable to tune JVM memory settings:
 
     ```bash
-    JAVA_OPTS: -Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144
+    JAVA_OPTS="-Xms1000M -Xmx2000M -XX:MaxDirectMemorySize=800m -Dio.netty.maxDirectMemory=0 -Djdk.nio.maxCachedBufferSize=262144"
     ```
 
     These baseline values suit most deployments with moderate concurrent workflow loads.


### PR DESCRIPTION
## Summary

The "Backend memory requirements" section in the Enterprise configuration overview, the `JAVA_OPTS` entries in the deployment templates, the `tower-cron.yml` resources block, and the upgrade-guide JVM step were lost from the 26.x docs. The content was added by EDU-858 (#891) and re-added to the 25.3 versioned docs by #956, but the unversioned tree — which became the 26.x docs — was reverted by the 25.3 release-branch merge (#874) and never re-fixed.

Net effect today: the current docs and the live 26.1 docs carry no JVM memory guidance at all, and a cron pod built from the 26.x k8s template runs with no memory requests/limits.

## Changes

Restores the 25.3 (#956) content to **both** `platform-enterprise_docs/` and `platform-enterprise_versioned_docs/version-26.1/`:

- `enterprise/configuration/overview.mdx`: "Backend memory requirements" + "JVM memory tuning" section
- `enterprise/_templates/k8s/tower-svc.yml` and `tower-cron.yml`: `JAVA_OPTS` env entry on the backend container
- `enterprise/_templates/k8s/tower-cron.yml`: resources requests/limits block (requests cpu 1 / 4Gi, limits 4Gi)
- `enterprise/_templates/docker/tower.env`: `JAVA_OPTS` entry
- `enterprise/upgrade.md`: "JVM memory configuration defaults (recommended)" step (as added by #956)

The commit is purely additive (210 insertions, 0 deletions); 26.x-era image tags and template content are untouched.

## Deliberate deviations from the 25.3 reference

- The first note in the restored section previously claimed the memory limits are included in the `docker-compose.yml` template. That template has never set `mem_limit`, so the note now directs Docker Compose users to add it themselves.
- New short paragraph documenting `JAVA_TOOL_OPTIONS` as a supported alternative to `JAVA_OPTS` (read directly by the JVM, which logs `Picked up JAVA_TOOL_OPTIONS`), with the caveat that command-line options — how `JAVA_OPTS` is applied — take precedence for duplicate flags. Verified against the `backend:v26.1.2` image.
- Template comments link the unversioned docs URL in both trees (the `/26.1/` path 404s while 26.1 is the live version, and the unversioned form matches every neighboring template comment).

## Not restored (on purpose)

#956 also re-added the #890/EDU-817 database guidance to 25.3. That content was **not** lost from 26.x: the install-docs refactor (#984) carried it forward deliberately (DB support matrix incl. the Aurora Serverless warning in `upgrade.md`, pool sizing in the config tables), so nothing to do there.

## Verification

- All four modified k8s YAML templates parse
- Restored section diffed word-for-word against the version-25.3 reference; no drift beyond the deviations above
- `#backend-memory-requirements` anchor and all relative template links resolve in both trees; admonition blocks and code fences balanced
- Both trees' new content is identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)