### PR TITLE
docs: Move AWS Spot interruption management tutorial

### DIFF
--- a/platform-cloud/cloud-sidebar.json
+++ b/platform-cloud/cloud-sidebar.json
@@ -10,8 +10,7 @@
           "getting-started/rnaseq",
           "getting-started/proteinfold",
           "getting-started/studios",
-          "getting-started/quickstart-demo/comm-showcase",
-          "tutorials/retry-strategy"
+          "getting-started/quickstart-demo/comm-showcase"
           ]
       },
       {
@@ -91,6 +90,7 @@
             "label": "Advanced options",
             "items":[
               "enterprise/advanced-topics/manual-aws-batch-setup",
+              "compute-envs/aws-spot-interruptions",
               "enterprise/advanced-topics/manual-azure-batch-setup"
             ]
           }

--- a/platform-cloud/docs/compute-envs/aws-spot-interruptions.md
+++ b/platform-cloud/docs/compute-envs/aws-spot-interruptions.md
@@ -1,5 +1,5 @@
 ---
-title: "Manage AWS Spot interruptions in Seqera Platform"
+title: "AWS Spot interruption management"
 description: "Managing AWS Spot Interruptions in Seqera Platform."
 date: "16 Jul 2024"
 tags: [aws, spot, platform, fusion, retry]

--- a/platform-cloud/docs/troubleshooting_and_faqs/aws_troubleshooting.md
+++ b/platform-cloud/docs/troubleshooting_and_faqs/aws_troubleshooting.md
@@ -68,6 +68,12 @@ process {
 }
 ```
 
+## Spot instances
+
+**Tasks fail with exit code `143`, or no exit code, and the log contains `Host EC2 (instance i-xxxxxxxxx) terminated`**
+
+AWS reclaimed the Spot instance running the task. See [Manage AWS Spot interruptions](../compute-envs/aws-spot-interruptions) for retry and fallback strategies.
+
 ## Storage
 
 **Enable pipelines to write to S3 buckets that enforces AES256 server-side encryption**

--- a/platform-enterprise_docs/compute-envs/aws-spot-interruptions.md
+++ b/platform-enterprise_docs/compute-envs/aws-spot-interruptions.md
@@ -1,5 +1,5 @@
 ---
-title: "Manage AWS Spot interruptions in Seqera Platform"
+title: "AWS Spot interruption management"
 description: "Managing AWS Spot Interruptions in Seqera Platform."
 date: "16 Jul 2024"
 tags: [aws, spot, platform, fusion, retry]

--- a/platform-enterprise_docs/enterprise-sidebar.json
+++ b/platform-enterprise_docs/enterprise-sidebar.json
@@ -136,8 +136,7 @@
       "items": [
         "getting-started/rnaseq",
         "getting-started/proteinfold",
-        "getting-started/studios",
-        "tutorials/retry-strategy"
+        "getting-started/studios"
       ]
     },
     {
@@ -211,6 +210,7 @@
             "label": "Advanced options",
             "items":[
               "enterprise/advanced-topics/manual-aws-batch-setup",
+              "compute-envs/aws-spot-interruptions",
               "enterprise/advanced-topics/manual-azure-batch-setup"
             ]
           }

--- a/platform-enterprise_docs/getting-started/production-checklist.md
+++ b/platform-enterprise_docs/getting-started/production-checklist.md
@@ -158,9 +158,9 @@ Spot reclamation interrupts pipeline execution when cloud providers reclaim capa
 
 **Pipeline developer configuration**
 
-- `aws.batch.maxSpotAttempts` controls how many times a task is retried at the AWS Batch level before Nextflow sees it as a failure. See [Handle retries in AWS](../tutorials/retry-strategy#handle-retries-in-aws-by-setting-awsbatchmaxspotattempts).
-- `errorStrategy` and `maxRetries` in Nextflow handle failures that survive all AWS-native retries. See [Handle retries in Nextflow](../tutorials/retry-strategy#handle-retries-in-nextflow-by-setting-errorstrategy-and-maxretries).
-- Spot to On-Demand fallback logic should be implemented for tasks where interruption is unacceptable. See [Spot to On-Demand fallback](../tutorials/retry-strategy#implement-spot-to-on-demand-fallback-logic).
+- `aws.batch.maxSpotAttempts` controls how many times a task is retried at the AWS Batch level before Nextflow sees it as a failure. See [Handle retries in AWS](../compute-envs/aws-spot-interruptions#handle-retries-in-aws-by-setting-awsbatchmaxspotattempts).
+- `errorStrategy` and `maxRetries` in Nextflow handle failures that survive all AWS-native retries. See [Handle retries in Nextflow](../compute-envs/aws-spot-interruptions#handle-retries-in-nextflow-by-setting-errorstrategy-and-maxretries).
+- Spot to On-Demand fallback logic should be implemented for tasks where interruption is unacceptable. See [Spot to On-Demand fallback](../compute-envs/aws-spot-interruptions#implement-spot-to-on-demand-fallback-logic).
 
 :::note
 `aws.batch.maxSpotAttempts` and Nextflow's `maxRetries` operate at independent layers. AWS-native Spot retries happen silently — Nextflow only sees the task as failed after all AWS retries are exhausted. Pipeline developers must set both values intentionally; neither is configured by Platform automatically.

--- a/platform-enterprise_docs/troubleshooting_and_faqs/aws_troubleshooting.md
+++ b/platform-enterprise_docs/troubleshooting_and_faqs/aws_troubleshooting.md
@@ -68,6 +68,12 @@ process {
 }
 ```
 
+## Spot instances
+
+**Tasks fail with exit code `143`, or no exit code, and the log contains `Host EC2 (instance i-xxxxxxxxx) terminated`**
+
+AWS reclaimed the Spot instance running the task. See [Manage AWS Spot interruptions](../compute-envs/aws-spot-interruptions) for retry and fallback strategies.
+
 ## Storage
 
 **Enable pipelines to write to S3 buckets that enforces AES256 server-side encryption**

--- a/platform-enterprise_docs/troubleshooting_and_faqs/nextflow.md
+++ b/platform-enterprise_docs/troubleshooting_and_faqs/nextflow.md
@@ -226,7 +226,7 @@ If you rely on silent Spot retries (the previous default behavior), you may now 
 - **AWS**: Generic failure with `exit code 1`. You may see messages indicating the host machine was terminated.
 - **Google**: Spot reclamation typically produces a specific code, but is now surfaced as a recognizable task failure in Nextflow logs.
 
-Since the default for Spot retries is now zero, you must actively enable a retry strategy if you want Nextflow to handle reclaimed Spot instances automatically. For more information, see [manage Spot interruptions](../tutorials/retry-strategy).
+Since the default for Spot retries is now zero, you must actively enable a retry strategy if you want Nextflow to handle reclaimed Spot instances automatically. For more information, see [manage Spot interruptions](../compute-envs/aws-spot-interruptions).
 
 ### Nextflow syntax parser
 

--- a/platform-enterprise_versioned_docs/version-25.1/tutorials/retry-strategy.md
+++ b/platform-enterprise_versioned_docs/version-25.1/tutorials/retry-strategy.md
@@ -1,5 +1,5 @@
 ---
-title: "Manage AWS Spot interruptions in Seqera Platform"
+title: "AWS Spot interruption management"
 description: "Managing AWS Spot Interruptions in Seqera Platform."
 date: "16 Jul 2024"
 tags: [aws, spot, platform, fusion, retry]

--- a/platform-enterprise_versioned_docs/version-25.2/tutorials/retry-strategy.md
+++ b/platform-enterprise_versioned_docs/version-25.2/tutorials/retry-strategy.md
@@ -1,5 +1,5 @@
 ---
-title: "Manage AWS Spot interruptions in Seqera Platform"
+title: "AWS Spot interruption management"
 description: "Managing AWS Spot Interruptions in Seqera Platform."
 date: "16 Jul 2024"
 tags: [aws, spot, platform, fusion, retry]

--- a/platform-enterprise_versioned_docs/version-25.3/tutorials/retry-strategy.md
+++ b/platform-enterprise_versioned_docs/version-25.3/tutorials/retry-strategy.md
@@ -1,5 +1,5 @@
 ---
-title: "Manage AWS Spot interruptions in Seqera Platform"
+title: "AWS Spot interruption management"
 description: "Managing AWS Spot Interruptions in Seqera Platform."
 date: "16 Jul 2024"
 tags: [aws, spot, platform, fusion, retry]

--- a/platform-enterprise_versioned_docs/version-26.1/tutorials/retry-strategy.md
+++ b/platform-enterprise_versioned_docs/version-26.1/tutorials/retry-strategy.md
@@ -1,5 +1,5 @@
 ---
-title: "Manage AWS Spot interruptions in Seqera Platform"
+title: "AWS Spot interruption management"
 description: "Managing AWS Spot Interruptions in Seqera Platform."
 date: "16 Jul 2024"
 tags: [aws, spot, platform, fusion, retry]

--- a/static/_redirects
+++ b/static/_redirects
@@ -68,6 +68,7 @@
 /platform-enterprise/enterprise/configuration/authentication   /platform-enterprise/enterprise/configuration/authentication/overview   301
 /platform-enterprise/enterprise/install-co-scientist   /platform-enterprise/co-scientist/installation   301
 /platform-enterprise/enterprise/install-seqera-ai      /platform-enterprise/enterprise/install-seqera-coscientist   301
+/platform-enterprise/tutorials/retry-strategy          /platform-enterprise/compute-envs/aws-spot-interruptions     301
 
 # These redirects reverse the existing 301's
 # See https://moz.com/blog/can-you-reverse-a-301-redirect
@@ -109,8 +110,9 @@
 /platform-cloud/administration/overview      /platform-cloud/orgs-and-teams/organizations   301
 
 # Renamed and moved pages
-/platform-cloud/monitoring/tasks   /platform-cloud/monitoring/run-details   301
-/platform-cloud/launch/relaunch    /platform-cloud/launch/cache-resume      301
+/platform-cloud/monitoring/tasks           /platform-cloud/monitoring/run-details                 301
+/platform-cloud/launch/relaunch            /platform-cloud/launch/cache-resume                    301
+/platform-cloud/tutorials/retry-strategy   /platform-cloud/compute-envs/aws-spot-interruptions    301
 
 # These redirects reverse the existing 301's
 /platform-cloud/platform-cloud /platform-cloud 301


### PR DESCRIPTION
Moved the AWS Spot interruption management tutorial out of the headline tutorials and moved it to the compute section as an advanced option. Also linked to troubleshooting. 