### PR TITLE
docs: improve Data explorer permissions on AWS using explict IAM policies

### DIFF
--- a/platform-cloud/docs/compute-envs/aws-batch.mdx
+++ b/platform-cloud/docs/compute-envs/aws-batch.mdx
@@ -207,11 +207,11 @@ The policy can be scoped down to limit access to the [specific log group](#advan
 
 ### S3 access (optional)
 
-Seqera automatically attempts to fetch a list of S3 buckets available in the AWS account connected to Platform, to provide them in a drop-down to be used as Nextflow working directory, and make the compute environment creation smoother. This feature is optional, and users can type the bucket name manually when setting up a compute environment. To allow Seqera to fetch the list of buckets in the account, the `s3:ListAllMyBuckets` action can be added, and it must have the `Resource` field set to `*`, as shown in the generic policy at the beginning of this document.
+Seqera automatically attempts to fetch a list of S3 buckets available in the AWS account connected to Platform, to provide them in a drop-down to be used as Nextflow working directory, and make the compute environment creation smoother. This feature is optional, and users can type the bucket name manually when setting up a compute environment. To allow Seqera to fetch the list of buckets in the account, the `s3:ListAllMyBuckets` action can be added, and it must have the `Resource` field set to `*`, as shown in the generic policy at the beginning of this document. The `s3:ListAllMyBuckets` action also allows Data Explorer to auto-discover the data repositories accessible to your workspace credentials.
 
 Seqera offers several products to manipulate data on AWS S3 buckets, such as [Studios](../studios/overview) and [Data Explorer](../data/data-explorer); if these features are not used the related permissions can be omitted.
 
-The IAM policy can be scoped down to only allow limited read/write permissions in certain S3 buckets used by Studios/Data Explorer. In addition, the policy must include permission to check the region and list the content of the S3 bucket used as Nextflow work directory. We also recommend granting the `s3:GetObject` permission on the work directory path to fetch Nextflow log files.
+The IAM policy can be scoped down to only allow limited read/write permissions in certain S3 buckets used by Studios/Data Explorer. For each bucket you want to browse, upload to, or download from with Data Explorer, grant `s3:GetObject` and `s3:PutObject` on the bucket objects, and `s3:ListBucket`, `s3:GetBucketLocation`, `s3:GetBucketPolicy`, and `s3:GetBucketAcl` on the bucket itself. In addition, the policy must include permission to check the region and list the content of the S3 bucket used as Nextflow work directory. We also recommend granting the `s3:GetObject` permission on the work directory path to fetch Nextflow log files.
 
 :::note
 If you opted to create a separate S3 bucket only for Nextflow work directories, there is no need for the IAM user to have read/write access to it. If Seqera is allowed to manage resources (using Batch Forge) the IAM roles automatically created will have the necessary permissions.
@@ -245,9 +245,15 @@ If you set up the compute environment manually, you can create the required IAM 
   "Sid": "S3ReadWriteBucketsForStudiosDataExplorer",
   "Effect": "Allow",
   "Action": [
-    "s3:Get*",
-    "s3:List*",
-    "s3:PutObject"
+    "s3:GetObject",
+    "s3:GetObjectTagging",
+    "s3:GetBucketLocation",
+    "s3:GetBucketPolicy",
+    "s3:GetBucketAcl",
+    "s3:ListBucket",
+    "s3:PutObject",
+    "s3:PutObjectTagging",
+    "s3:DeleteObject"
   ],
   "Resource": [
     "arn:aws:s3:::example-bucket-read-write-studios",
@@ -257,6 +263,10 @@ If you set up the compute environment manually, you can create the required IAM 
   ]
 }
 ```
+
+:::note
+`s3:GetBucketPolicy` and `s3:GetBucketAcl` allow Data Explorer to resolve each bucket's region and access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy above also cover these actions.
+:::
 
 ### IAM roles for AWS Batch (optional)
 

--- a/platform-cloud/docs/compute-envs/aws-batch.mdx
+++ b/platform-cloud/docs/compute-envs/aws-batch.mdx
@@ -265,7 +265,7 @@ If you set up the compute environment manually, you can create the required IAM 
 ```
 
 :::note
-`s3:GetBucketPolicy` and `s3:GetBucketAcl` allow Data Explorer to resolve each bucket's region and access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy above also cover these actions.
+`s3:GetBucketLocation` allows Data Explorer to resolve each bucket's region. `s3:GetBucketPolicy` and `s3:GetBucketAcl` allow it to inspect each bucket's access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy above also cover these actions.
 :::
 
 ### IAM roles for AWS Batch (optional)

--- a/platform-cloud/docs/compute-envs/aws-cloud.mdx
+++ b/platform-cloud/docs/compute-envs/aws-cloud.mdx
@@ -219,7 +219,7 @@ The following permissions are required to remove resources created by Seqera whe
 
 #### Optional permissions
 
-The following permissions enable Seqera to populate values for drop-down fields. If missing, the input fields will not be auto-populated but can still be manually entered. Though optional, these permissions are recommended for a smoother and less error-prone user experience:
+The following permissions enable Seqera to populate values for drop-down fields. If missing, the input fields will not be auto-populated but can still be manually entered. Though optional, these permissions are recommended for a smoother and less error-prone user experience. The `s3:ListAllMyBuckets` action also allows Data Explorer to auto-discover the data repositories accessible to your workspace credentials:
 
 ```json
 {

--- a/platform-cloud/docs/compute-envs/eks.mdx
+++ b/platform-cloud/docs/compute-envs/eks.mdx
@@ -68,11 +68,11 @@ No other permissions are required for the IAM user to launch pipelines on the EK
 
 ### S3 access (optional)
 
-Seqera automatically attempts to fetch a list of S3 buckets available in the AWS account connected to Platform, to provide them in a drop-down to be used as Nextflow working directory, and make the compute environment creation smoother. This feature is optional, and users can type the bucket name manually when setting up a compute environment. To allow Seqera to fetch the list of buckets in the account, the `s3:ListAllMyBuckets` action can be added, and it must have the `Resource` field set to `*`.
+Seqera automatically attempts to fetch a list of S3 buckets available in the AWS account connected to Platform, to provide them in a drop-down to be used as Nextflow working directory, and make the compute environment creation smoother. This feature is optional, and users can type the bucket name manually when setting up a compute environment. To allow Seqera to fetch the list of buckets in the account, the `s3:ListAllMyBuckets` action can be added, and it must have the `Resource` field set to `*`. The `s3:ListAllMyBuckets` action also allows Data Explorer to auto-discover the data repositories accessible to your workspace credentials.
 
 Seqera offers several products to manipulate data on AWS S3 buckets, such as [Studios](../studios/overview) and [Data Explorer](../data/data-explorer); if these features are not needed the related permissions can be omitted.
 
-The IAM policy can be scoped down to only allow limited read/write permissions in certain S3 buckets used by Studios/Data Explorer. In addition, the policy must include permission to check the region and list the content of the S3 bucket used as Nextflow work directory. We also recommend granting the `s3:GetObject` permission on the work directory path to fetch Nextflow log files.
+The IAM policy can be scoped down to only allow limited read/write permissions in certain S3 buckets used by Studios/Data Explorer. For each bucket you want to browse, upload to, or download from with Data Explorer, grant `s3:GetObject` and `s3:PutObject` on the bucket objects, and `s3:ListBucket`, `s3:GetBucketLocation`, `s3:GetBucketPolicy`, and `s3:GetBucketAcl` on the bucket itself. In addition, the policy must include permission to check the region and list the content of the S3 bucket used as Nextflow work directory. We also recommend granting the `s3:GetObject` permission on the work directory path to fetch Nextflow log files.
 
 :::note
 If you opted to create a separate S3 bucket only for Nextflow work directories, the IAM user or the Role it assumes only need read access to it. The IAM role used by the EKS Service Account (detailed in the [separate section](#configure-eks-service-account-iam-role-for-fusion-v2)) must have full read/write access to the work directory bucket to allow Fusion to operate correctly.
@@ -103,9 +103,15 @@ If you opted to create a separate S3 bucket only for Nextflow work directories, 
   "Sid": "S3ReadWriteBucketsForStudiosDataExplorer",
   "Effect": "Allow",
   "Action": [
-    "s3:Get*",
-    "s3:List*",
-    "s3:PutObject"
+    "s3:GetObject",
+    "s3:GetObjectTagging",
+    "s3:GetBucketLocation",
+    "s3:GetBucketPolicy",
+    "s3:GetBucketAcl",
+    "s3:ListBucket",
+    "s3:PutObject",
+    "s3:PutObjectTagging",
+    "s3:DeleteObject"
   ],
   "Resource": [
     "arn:aws:s3:::example-bucket-read-write-studios",
@@ -115,6 +121,10 @@ If you opted to create a separate S3 bucket only for Nextflow work directories, 
   ]
 }
 ```
+
+:::note
+`s3:GetBucketPolicy` and `s3:GetBucketAcl` allow Data Explorer to resolve each bucket's region and access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy also cover these actions.
+:::
 
 ## Create the IAM policy
 

--- a/platform-cloud/docs/compute-envs/eks.mdx
+++ b/platform-cloud/docs/compute-envs/eks.mdx
@@ -123,7 +123,7 @@ If you opted to create a separate S3 bucket only for Nextflow work directories, 
 ```
 
 :::note
-`s3:GetBucketPolicy` and `s3:GetBucketAcl` allow Data Explorer to resolve each bucket's region and access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy also cover these actions.
+`s3:GetBucketLocation` allows Data Explorer to resolve each bucket's region. `s3:GetBucketPolicy` and `s3:GetBucketAcl` allow it to inspect each bucket's access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy also cover these actions.
 :::
 
 ## Create the IAM policy

--- a/platform-cloud/docs/data/data-explorer.md
+++ b/platform-cloud/docs/data/data-explorer.md
@@ -24,6 +24,14 @@ Data Explorer lists public and private data repositories. Repositories accessibl
 
   Private data repositories accessible to the credentials defined in your workspace are listed in Data Explorer automatically. The permissions required for your [AWS](../compute-envs/aws-batch#required-platform-iam-permissions), [Google Cloud](../compute-envs/google-cloud-batch#iam), [Azure Batch](../compute-envs/azure-batch#storage-account), or Amazon S3-compatible API storage credentials allow full Data Explorer functionality.
 
+  For AWS S3, Data Explorer requires the following minimum IAM permissions:
+
+  - `s3:ListAllMyBuckets` (on `*`) to auto-discover the buckets accessible to your workspace credentials.
+  - `s3:ListBucket`, `s3:GetBucketLocation`, `s3:GetBucketPolicy`, and `s3:GetBucketAcl` on each bucket you want to browse, to resolve its region and access configuration.
+  - `s3:GetObject` and `s3:PutObject` on the objects in each bucket, to download and upload files.
+
+  These are a subset of the S3 permissions documented for the [AWS Batch](../compute-envs/aws-batch#required-platform-iam-permissions), [AWS Cloud](../compute-envs/aws-cloud#required-platform-iam-permissions), and [Amazon EKS](../compute-envs/eks#required-platform-iam-permissions) compute environments. For Azure Blob Storage, see the [Azure Cloud data-links permissions](../compute-envs/azure-cloud#data-links).
+
 - **Configure individual data repositories manually**
 
   Select **Add data repository** from the Data Explorer tab to add a link to an individual repository (or prefix within a cloud bucket). Specify the **Provider**, **Path**, **Name**, **Credentials**, and **Description**, then select **Add**. For public cloud buckets, select **Public** from the **Credentials** drop-down.

--- a/platform-enterprise_docs/compute-envs/aws-batch.md
+++ b/platform-enterprise_docs/compute-envs/aws-batch.md
@@ -389,11 +389,11 @@ The policy can be scoped down to limit access to the [specific log group](#advan
 
 ### S3 access (optional)
 
-Seqera automatically attempts to fetch a list of S3 buckets available in the AWS account connected to Platform, to provide them in a drop-down to be used as Nextflow working directory, and make the compute environment creation smoother. This feature is optional, and users can type the bucket name manually when setting up a compute environment. To allow Seqera to fetch the list of buckets in the account, the `s3:ListAllMyBuckets` action can be added, and it must have the `Resource` field set to `*`, as shown in the generic policy at the beginning of this document.
+Seqera automatically attempts to fetch a list of S3 buckets available in the AWS account connected to Platform, to provide them in a drop-down to be used as Nextflow working directory, and make the compute environment creation smoother. This feature is optional, and users can type the bucket name manually when setting up a compute environment. To allow Seqera to fetch the list of buckets in the account, the `s3:ListAllMyBuckets` action can be added, and it must have the `Resource` field set to `*`, as shown in the generic policy at the beginning of this document. The `s3:ListAllMyBuckets` action also allows Data Explorer to auto-discover the data repositories accessible to your workspace credentials.
 
 Seqera offers several products to manipulate data on AWS S3 buckets, such as [Studios](../studios/overview) and [Data Explorer](../data/data-explorer); if these features are not used the related permissions can be omitted.
 
-The IAM policy can be scoped down to only allow limited read/write permissions in certain S3 buckets used by Studios/Data Explorer. In addition, the policy must include permission to check the region and list the content of the S3 bucket used as Nextflow work directory. We also recommend granting the `s3:GetObject` permission on the work directory path to fetch Nextflow log files.
+The IAM policy can be scoped down to only allow limited read/write permissions in certain S3 buckets used by Studios/Data Explorer. For each bucket you want to browse, upload to, or download from with Data Explorer, grant `s3:GetObject` and `s3:PutObject` on the bucket objects, and `s3:ListBucket`, `s3:GetBucketLocation`, `s3:GetBucketPolicy`, and `s3:GetBucketAcl` on the bucket itself. In addition, the policy must include permission to check the region and list the content of the S3 bucket used as Nextflow work directory. We also recommend granting the `s3:GetObject` permission on the work directory path to fetch Nextflow log files.
 
 :::note
 If you opted to create a separate S3 bucket only for Nextflow work directories, there is no need for the IAM user to have read/write access to it. If Seqera is allowed to manage resources (using Batch Forge) the IAM roles automatically created will have the necessary permissions.
@@ -427,9 +427,15 @@ If you set up the compute environment manually, you can create the required IAM 
   "Sid": "S3ReadWriteBucketsForStudiosDataExplorer",
   "Effect": "Allow",
   "Action": [
-    "s3:Get*",
-    "s3:List*",
-    "s3:PutObject"
+    "s3:GetObject",
+    "s3:GetObjectTagging",
+    "s3:GetBucketLocation",
+    "s3:GetBucketPolicy",
+    "s3:GetBucketAcl",
+    "s3:ListBucket",
+    "s3:PutObject",
+    "s3:PutObjectTagging",
+    "s3:DeleteObject"
   ],
   "Resource": [
     "arn:aws:s3:::example-bucket-read-write-studios",
@@ -439,6 +445,10 @@ If you set up the compute environment manually, you can create the required IAM 
   ]
 }
 ```
+
+:::note
+`s3:GetBucketPolicy` and `s3:GetBucketAcl` allow Data Explorer to resolve each bucket's region and access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy above also cover these actions.
+:::
 
 ### IAM roles for AWS Batch (optional)
 

--- a/platform-enterprise_docs/compute-envs/aws-batch.md
+++ b/platform-enterprise_docs/compute-envs/aws-batch.md
@@ -447,7 +447,7 @@ If you set up the compute environment manually, you can create the required IAM 
 ```
 
 :::note
-`s3:GetBucketPolicy` and `s3:GetBucketAcl` allow Data Explorer to resolve each bucket's region and access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy above also cover these actions.
+`s3:GetBucketLocation` allows Data Explorer to resolve each bucket's region. `s3:GetBucketPolicy` and `s3:GetBucketAcl` allow it to inspect each bucket's access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy above also cover these actions.
 :::
 
 ### IAM roles for AWS Batch (optional)

--- a/platform-enterprise_docs/compute-envs/aws-cloud.md
+++ b/platform-enterprise_docs/compute-envs/aws-cloud.md
@@ -207,7 +207,7 @@ The following permissions are required to remove resources created by Seqera whe
 
 #### Optional permissions
 
-The following permissions enable Seqera to populate values for drop-down fields. If missing, the input fields will not be auto-populated but can still be manually entered. Though optional, these permissions are recommended for a smoother and less error-prone user experience:
+The following permissions enable Seqera to populate values for drop-down fields. If missing, the input fields will not be auto-populated but can still be manually entered. Though optional, these permissions are recommended for a smoother and less error-prone user experience. The `s3:ListAllMyBuckets` action also allows Data Explorer to auto-discover the data repositories accessible to your workspace credentials:
 
 ```json
 {

--- a/platform-enterprise_docs/compute-envs/eks.md
+++ b/platform-enterprise_docs/compute-envs/eks.md
@@ -145,7 +145,7 @@ If you opted to create a separate S3 bucket only for Nextflow work directories, 
 ```
 
 :::note
-`s3:GetBucketPolicy` and `s3:GetBucketAcl` allow Data Explorer to resolve each bucket's region and access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy also cover these actions.
+`s3:GetBucketLocation` allows Data Explorer to resolve each bucket's region. `s3:GetBucketPolicy` and `s3:GetBucketAcl` allow it to inspect each bucket's access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy also cover these actions.
 :::
 
 ## Create the IAM policy

--- a/platform-enterprise_docs/compute-envs/eks.md
+++ b/platform-enterprise_docs/compute-envs/eks.md
@@ -90,11 +90,11 @@ No other permissions are required for the IAM user to launch pipelines on the EK
 
 ### S3 access (optional)
 
-Seqera automatically attempts to fetch a list of S3 buckets available in the AWS account connected to Platform, to provide them in a drop-down to be used as Nextflow working directory, and make the compute environment creation smoother. This feature is optional, and users can type the bucket name manually when setting up a compute environment. To allow Seqera to fetch the list of buckets in the account, the `s3:ListAllMyBuckets` action can be added, and it must have the `Resource` field set to `*`.
+Seqera automatically attempts to fetch a list of S3 buckets available in the AWS account connected to Platform, to provide them in a drop-down to be used as Nextflow working directory, and make the compute environment creation smoother. This feature is optional, and users can type the bucket name manually when setting up a compute environment. To allow Seqera to fetch the list of buckets in the account, the `s3:ListAllMyBuckets` action can be added, and it must have the `Resource` field set to `*`. The `s3:ListAllMyBuckets` action also allows Data Explorer to auto-discover the data repositories accessible to your workspace credentials.
 
 Seqera offers several products to manipulate data on AWS S3 buckets, such as [Studios](../studios/overview) and [Data Explorer](../data/data-explorer); if these features are not needed the related permissions can be omitted.
 
-The IAM policy can be scoped down to only allow limited read/write permissions in certain S3 buckets used by Studios/Data Explorer. In addition, the policy must include permission to check the region and list the content of the S3 bucket used as Nextflow work directory. We also recommend granting the `s3:GetObject` permission on the work directory path to fetch Nextflow log files.
+The IAM policy can be scoped down to only allow limited read/write permissions in certain S3 buckets used by Studios/Data Explorer. For each bucket you want to browse, upload to, or download from with Data Explorer, grant `s3:GetObject` and `s3:PutObject` on the bucket objects, and `s3:ListBucket`, `s3:GetBucketLocation`, `s3:GetBucketPolicy`, and `s3:GetBucketAcl` on the bucket itself. In addition, the policy must include permission to check the region and list the content of the S3 bucket used as Nextflow work directory. We also recommend granting the `s3:GetObject` permission on the work directory path to fetch Nextflow log files.
 
 :::note
 If you opted to create a separate S3 bucket only for Nextflow work directories, the IAM user or the Role it assumes only need read access to it. The IAM role used by the EKS Service Account (detailed in the [separate section](#configure-eks-service-account-iam-role-for-fusion-v2)) must have full read/write access to the work directory bucket to allow Fusion to operate correctly.
@@ -125,9 +125,15 @@ If you opted to create a separate S3 bucket only for Nextflow work directories, 
   "Sid": "S3ReadWriteBucketsForStudiosDataExplorer",
   "Effect": "Allow",
   "Action": [
-    "s3:Get*",
-    "s3:List*",
-    "s3:PutObject"
+    "s3:GetObject",
+    "s3:GetObjectTagging",
+    "s3:GetBucketLocation",
+    "s3:GetBucketPolicy",
+    "s3:GetBucketAcl",
+    "s3:ListBucket",
+    "s3:PutObject",
+    "s3:PutObjectTagging",
+    "s3:DeleteObject"
   ],
   "Resource": [
     "arn:aws:s3:::example-bucket-read-write-studios",
@@ -137,6 +143,10 @@ If you opted to create a separate S3 bucket only for Nextflow work directories, 
   ]
 }
 ```
+
+:::note
+`s3:GetBucketPolicy` and `s3:GetBucketAcl` allow Data Explorer to resolve each bucket's region and access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy also cover these actions.
+:::
 
 ## Create the IAM policy
 

--- a/platform-enterprise_docs/data/data-explorer.md
+++ b/platform-enterprise_docs/data/data-explorer.md
@@ -32,6 +32,14 @@ Data Explorer lists public and private data repositories. Repositories accessibl
 
   Private data repositories accessible to the credentials defined in your workspace are listed in Data Explorer automatically. The permissions required for your [AWS](../compute-envs/aws-batch#iam-user-creation), [Google Cloud](../compute-envs/google-cloud-batch#iam), [Azure Batch](../compute-envs/azure-batch#storage-account), or HPC compute environment credentials allow full Data Explorer functionality.
 
+  For AWS S3, Data Explorer requires the following minimum IAM permissions:
+
+  - `s3:ListAllMyBuckets` (on `*`) to auto-discover the buckets accessible to your workspace credentials.
+  - `s3:ListBucket`, `s3:GetBucketLocation`, `s3:GetBucketPolicy`, and `s3:GetBucketAcl` on each bucket you want to browse, to resolve its region and access configuration.
+  - `s3:GetObject` and `s3:PutObject` on the objects in each bucket, to download and upload files.
+
+  These are a subset of the S3 permissions documented for the [AWS Batch](../compute-envs/aws-batch#required-platform-iam-permissions), [AWS Cloud](../compute-envs/aws-cloud#required-permissions), and [Amazon EKS](../compute-envs/eks#required-platform-iam-permissions) compute environments. For Azure Blob Storage, see the [Azure Cloud data-links permissions](../compute-envs/azure-cloud#data-links).
+
 - **Configure individual data repositories manually**
 
   Select **Add data repository** from the Data Explorer tab to add a link to an individual repository (or prefix within a cloud bucket). Specify the **Provider**, **Path**, **Name**, **Credentials**, and **Description**, then select **Add**. For public cloud buckets, select **Public** from the **Credentials** drop-down.

--- a/platform-enterprise_versioned_docs/version-26.1/compute-envs/aws-batch.md
+++ b/platform-enterprise_versioned_docs/version-26.1/compute-envs/aws-batch.md
@@ -389,11 +389,11 @@ The policy can be scoped down to limit access to the [specific log group](#advan
 
 ### S3 access (optional)
 
-Seqera automatically attempts to fetch a list of S3 buckets available in the AWS account connected to Platform, to provide them in a drop-down to be used as Nextflow working directory, and make the compute environment creation smoother. This feature is optional, and users can type the bucket name manually when setting up a compute environment. To allow Seqera to fetch the list of buckets in the account, the `s3:ListAllMyBuckets` action can be added, and it must have the `Resource` field set to `*`, as shown in the generic policy at the beginning of this document.
+Seqera automatically attempts to fetch a list of S3 buckets available in the AWS account connected to Platform, to provide them in a drop-down to be used as Nextflow working directory, and make the compute environment creation smoother. This feature is optional, and users can type the bucket name manually when setting up a compute environment. To allow Seqera to fetch the list of buckets in the account, the `s3:ListAllMyBuckets` action can be added, and it must have the `Resource` field set to `*`, as shown in the generic policy at the beginning of this document. The `s3:ListAllMyBuckets` action also allows Data Explorer to auto-discover the data repositories accessible to your workspace credentials.
 
 Seqera offers several products to manipulate data on AWS S3 buckets, such as [Studios](../studios/overview) and [Data Explorer](../data/data-explorer); if these features are not used the related permissions can be omitted.
 
-The IAM policy can be scoped down to only allow limited read/write permissions in certain S3 buckets used by Studios/Data Explorer. In addition, the policy must include permission to check the region and list the content of the S3 bucket used as Nextflow work directory. We also recommend granting the `s3:GetObject` permission on the work directory path to fetch Nextflow log files.
+The IAM policy can be scoped down to only allow limited read/write permissions in certain S3 buckets used by Studios/Data Explorer. For each bucket you want to browse, upload to, or download from with Data Explorer, grant `s3:GetObject` and `s3:PutObject` on the bucket objects, and `s3:ListBucket`, `s3:GetBucketLocation`, `s3:GetBucketPolicy`, and `s3:GetBucketAcl` on the bucket itself. In addition, the policy must include permission to check the region and list the content of the S3 bucket used as Nextflow work directory. We also recommend granting the `s3:GetObject` permission on the work directory path to fetch Nextflow log files.
 
 :::note
 If you opted to create a separate S3 bucket only for Nextflow work directories, there is no need for the IAM user to have read/write access to it. If Seqera is allowed to manage resources (using Batch Forge) the IAM roles automatically created will have the necessary permissions.
@@ -427,9 +427,15 @@ If you set up the compute environment manually, you can create the required IAM 
   "Sid": "S3ReadWriteBucketsForStudiosDataExplorer",
   "Effect": "Allow",
   "Action": [
-    "s3:Get*",
-    "s3:List*",
-    "s3:PutObject"
+    "s3:GetObject",
+    "s3:GetObjectTagging",
+    "s3:GetBucketLocation",
+    "s3:GetBucketPolicy",
+    "s3:GetBucketAcl",
+    "s3:ListBucket",
+    "s3:PutObject",
+    "s3:PutObjectTagging",
+    "s3:DeleteObject"
   ],
   "Resource": [
     "arn:aws:s3:::example-bucket-read-write-studios",
@@ -439,6 +445,10 @@ If you set up the compute environment manually, you can create the required IAM 
   ]
 }
 ```
+
+:::note
+`s3:GetBucketPolicy` and `s3:GetBucketAcl` allow Data Explorer to resolve each bucket's region and access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy above also cover these actions.
+:::
 
 ### IAM roles for AWS Batch (optional)
 

--- a/platform-enterprise_versioned_docs/version-26.1/compute-envs/aws-batch.md
+++ b/platform-enterprise_versioned_docs/version-26.1/compute-envs/aws-batch.md
@@ -447,7 +447,7 @@ If you set up the compute environment manually, you can create the required IAM 
 ```
 
 :::note
-`s3:GetBucketPolicy` and `s3:GetBucketAcl` allow Data Explorer to resolve each bucket's region and access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy above also cover these actions.
+`s3:GetBucketLocation` allows Data Explorer to resolve each bucket's region. `s3:GetBucketPolicy` and `s3:GetBucketAcl` allow it to inspect each bucket's access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy above also cover these actions.
 :::
 
 ### IAM roles for AWS Batch (optional)

--- a/platform-enterprise_versioned_docs/version-26.1/compute-envs/aws-cloud.md
+++ b/platform-enterprise_versioned_docs/version-26.1/compute-envs/aws-cloud.md
@@ -207,7 +207,7 @@ The following permissions are required to remove resources created by Seqera whe
 
 #### Optional permissions
 
-The following permissions enable Seqera to populate values for drop-down fields. If missing, the input fields will not be auto-populated but can still be manually entered. Though optional, these permissions are recommended for a smoother and less error-prone user experience:
+The following permissions enable Seqera to populate values for drop-down fields. If missing, the input fields will not be auto-populated but can still be manually entered. Though optional, these permissions are recommended for a smoother and less error-prone user experience. The `s3:ListAllMyBuckets` action also allows Data Explorer to auto-discover the data repositories accessible to your workspace credentials:
 
 ```json
 {

--- a/platform-enterprise_versioned_docs/version-26.1/compute-envs/eks.md
+++ b/platform-enterprise_versioned_docs/version-26.1/compute-envs/eks.md
@@ -145,7 +145,7 @@ If you opted to create a separate S3 bucket only for Nextflow work directories, 
 ```
 
 :::note
-`s3:GetBucketPolicy` and `s3:GetBucketAcl` allow Data Explorer to resolve each bucket's region and access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy also cover these actions.
+`s3:GetBucketLocation` allows Data Explorer to resolve each bucket's region. `s3:GetBucketPolicy` and `s3:GetBucketAcl` allow it to inspect each bucket's access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy also cover these actions.
 :::
 
 ## Create the IAM policy

--- a/platform-enterprise_versioned_docs/version-26.1/compute-envs/eks.md
+++ b/platform-enterprise_versioned_docs/version-26.1/compute-envs/eks.md
@@ -90,11 +90,11 @@ No other permissions are required for the IAM user to launch pipelines on the EK
 
 ### S3 access (optional)
 
-Seqera automatically attempts to fetch a list of S3 buckets available in the AWS account connected to Platform, to provide them in a drop-down to be used as Nextflow working directory, and make the compute environment creation smoother. This feature is optional, and users can type the bucket name manually when setting up a compute environment. To allow Seqera to fetch the list of buckets in the account, the `s3:ListAllMyBuckets` action can be added, and it must have the `Resource` field set to `*`.
+Seqera automatically attempts to fetch a list of S3 buckets available in the AWS account connected to Platform, to provide them in a drop-down to be used as Nextflow working directory, and make the compute environment creation smoother. This feature is optional, and users can type the bucket name manually when setting up a compute environment. To allow Seqera to fetch the list of buckets in the account, the `s3:ListAllMyBuckets` action can be added, and it must have the `Resource` field set to `*`. The `s3:ListAllMyBuckets` action also allows Data Explorer to auto-discover the data repositories accessible to your workspace credentials.
 
 Seqera offers several products to manipulate data on AWS S3 buckets, such as [Studios](../studios/overview) and [Data Explorer](../data/data-explorer); if these features are not needed the related permissions can be omitted.
 
-The IAM policy can be scoped down to only allow limited read/write permissions in certain S3 buckets used by Studios/Data Explorer. In addition, the policy must include permission to check the region and list the content of the S3 bucket used as Nextflow work directory. We also recommend granting the `s3:GetObject` permission on the work directory path to fetch Nextflow log files.
+The IAM policy can be scoped down to only allow limited read/write permissions in certain S3 buckets used by Studios/Data Explorer. For each bucket you want to browse, upload to, or download from with Data Explorer, grant `s3:GetObject` and `s3:PutObject` on the bucket objects, and `s3:ListBucket`, `s3:GetBucketLocation`, `s3:GetBucketPolicy`, and `s3:GetBucketAcl` on the bucket itself. In addition, the policy must include permission to check the region and list the content of the S3 bucket used as Nextflow work directory. We also recommend granting the `s3:GetObject` permission on the work directory path to fetch Nextflow log files.
 
 :::note
 If you opted to create a separate S3 bucket only for Nextflow work directories, the IAM user or the Role it assumes only need read access to it. The IAM role used by the EKS Service Account (detailed in the [separate section](#configure-eks-service-account-iam-role-for-fusion-v2)) must have full read/write access to the work directory bucket to allow Fusion to operate correctly.
@@ -125,9 +125,15 @@ If you opted to create a separate S3 bucket only for Nextflow work directories, 
   "Sid": "S3ReadWriteBucketsForStudiosDataExplorer",
   "Effect": "Allow",
   "Action": [
-    "s3:Get*",
-    "s3:List*",
-    "s3:PutObject"
+    "s3:GetObject",
+    "s3:GetObjectTagging",
+    "s3:GetBucketLocation",
+    "s3:GetBucketPolicy",
+    "s3:GetBucketAcl",
+    "s3:ListBucket",
+    "s3:PutObject",
+    "s3:PutObjectTagging",
+    "s3:DeleteObject"
   ],
   "Resource": [
     "arn:aws:s3:::example-bucket-read-write-studios",
@@ -137,6 +143,10 @@ If you opted to create a separate S3 bucket only for Nextflow work directories, 
   ]
 }
 ```
+
+:::note
+`s3:GetBucketPolicy` and `s3:GetBucketAcl` allow Data Explorer to resolve each bucket's region and access configuration when it lists and connects to data repositories. If you prefer not to enumerate individual actions, the `s3:Get*` and `s3:List*` wildcards shown in the full permissive policy also cover these actions.
+:::
 
 ## Create the IAM policy
 

--- a/platform-enterprise_versioned_docs/version-26.1/data/data-explorer.md
+++ b/platform-enterprise_versioned_docs/version-26.1/data/data-explorer.md
@@ -24,6 +24,14 @@ Data Explorer lists public and private data repositories. Repositories accessibl
 
   Private data repositories accessible to the credentials defined in your workspace are listed in Data Explorer automatically. The permissions required for your [AWS](../compute-envs/aws-batch#required-platform-iam-permissions), [Google Cloud](../compute-envs/google-cloud-batch#iam), [Azure Batch](../compute-envs/azure-batch#storage-account), or Amazon S3-compatible API storage credentials allow full Data Explorer functionality.
 
+  For AWS S3, Data Explorer requires the following minimum IAM permissions:
+
+  - `s3:ListAllMyBuckets` (on `*`) to auto-discover the buckets accessible to your workspace credentials.
+  - `s3:ListBucket`, `s3:GetBucketLocation`, `s3:GetBucketPolicy`, and `s3:GetBucketAcl` on each bucket you want to browse, to resolve its region and access configuration.
+  - `s3:GetObject` and `s3:PutObject` on the objects in each bucket, to download and upload files.
+
+  These are a subset of the S3 permissions documented for the [AWS Batch](../compute-envs/aws-batch#required-platform-iam-permissions), [AWS Cloud](../compute-envs/aws-cloud#required-permissions), and [Amazon EKS](../compute-envs/eks#required-platform-iam-permissions) compute environments. For Azure Blob Storage, see the [Azure Cloud data-links permissions](../compute-envs/azure-cloud#data-links).
+
 - **Configure individual data repositories manually**
 
   Select **Add data repository** from the Data Explorer tab to add a link to an individual repository (or prefix within a cloud bucket). Specify the **Provider**, **Path**, **Name**, **Credentials**, and **Description**, then select **Add**. For public cloud buckets, select **Public** from the **Credentials** drop-down.


### PR DESCRIPTION
We lack detailed policies for enabling data explorer functionality correctly in our documentation.

We rely on a wildcard `get*` permission however you may wish to be more explicit , the following documents the required access permissions. 