### PR TITLE
docs: clarify Execution log real-time streaming is cloud/K8s only

### DIFF
--- a/platform-cloud/docs/monitoring/run-details.mdx
+++ b/platform-cloud/docs/monitoring/run-details.mdx
@@ -173,7 +173,7 @@ The **Inputs** and **Outputs** tabs show every input or output consumed by the t
 The **Execution log** tab provides a real-time log of the selected task's execution. Task execution and other logs (such as `stdout` and `stderr`) are available for download if they are still available in your compute environment.
 
 :::note
-Real-time log streaming is available only for compute environments that stream logs from a cloud logging service: AWS Batch, Azure Batch, Google Cloud Batch, Kubernetes, and the AWS Cloud and Azure Cloud environments. For HPC compute environments (such as Slurm, Grid Engine, LSF, and PBS Pro), the log is retrieved from the task work directory rather than streamed, so the **Execution log** tab does not refresh automatically while a task runs. Change tabs or refresh the page to load the latest log content. See [Execution logs don't update in real time for HPC compute environments](../troubleshooting_and_faqs/troubleshooting#execution-logs-dont-update-in-real-time-for-hpc-compute-environments).
+Real-time log streaming is available only for compute environments that stream logs from a cloud logging service: AWS Batch, Azure Batch, Google Cloud Batch, Kubernetes, and the AWS Cloud and Azure Cloud environments. HPC compute environments (such as Slurm, Grid Engine, LSF, and PBS Pro) retrieve the log from the task work directory rather than streaming it. The **Execution log** tab does not refresh automatically while a task runs. Change tabs or refresh the page to load the latest log content. See [Execution logs don't update in real time for HPC compute environments](../troubleshooting_and_faqs/troubleshooting#execution-logs-dont-update-in-real-time-for-hpc-compute-environments).
 :::
 
 #### Data Explorer

--- a/platform-cloud/docs/monitoring/run-details.mdx
+++ b/platform-cloud/docs/monitoring/run-details.mdx
@@ -172,6 +172,10 @@ The **Inputs** and **Outputs** tabs show every input or output consumed by the t
 
 The **Execution log** tab provides a real-time log of the selected task's execution. Task execution and other logs (such as `stdout` and `stderr`) are available for download if they are still available in your compute environment.
 
+:::note
+Real-time log streaming is available only for compute environments that stream logs from a cloud logging service: AWS Batch, Azure Batch, Google Cloud Batch, Kubernetes, and the AWS Cloud and Azure Cloud environments. For HPC compute environments (such as Slurm, Grid Engine, LSF, and PBS Pro), the log is retrieved from the task work directory rather than streamed, so the **Execution log** tab does not refresh automatically while a task runs. Change tabs or refresh the page to load the latest log content. See [Execution logs don't update in real time for HPC compute environments](../troubleshooting_and_faqs/troubleshooting#execution-logs-dont-update-in-real-time-for-hpc-compute-environments).
+:::
+
 #### Data Explorer
 
 If the pipeline work directory is in cloud storage, this tab shows a [Data Explorer](../data/data-explorer) view of the task's work directory location with the files associated with the task.

--- a/platform-cloud/docs/troubleshooting_and_faqs/troubleshooting.md
+++ b/platform-cloud/docs/troubleshooting_and_faqs/troubleshooting.md
@@ -287,8 +287,10 @@ Connect to the head node over SSH and run `ps -p $$` to verify your default shel
 
 #### Execution logs don't update in real time for HPC compute environments
 
-While a task runs on an HPC compute environment (such as Slurm, Grid Engine, LSF, or PBS Pro), the **Execution log** tab on the run details page does not refresh automatically. New log content appears only after you change tabs or refresh the page.
+While a task runs on an HPC compute environment (such as Slurm, Grid Engine, LSF, or PBS Pro), the **Execution log** tab on the run details page does not refresh automatically.
 
-This is expected behavior. Real-time log streaming is supported only for compute environments that stream logs from a cloud logging service: AWS Batch, Azure Batch, Google Cloud Batch, Kubernetes, and the AWS Cloud and Azure Cloud environments. For HPC compute environments, Seqera retrieves the task log from the task work directory (the task's `.command.log` file) instead of streaming it, so the tab is not updated continuously during execution.
+This is expected behavior. Real-time log streaming is supported only for compute environments that stream logs from a cloud logging service: AWS Batch, Azure Batch, Google Cloud Batch, Kubernetes, and the AWS Cloud and Azure Cloud environments. For HPC compute environments, Seqera Platform retrieves the task log from the task work directory (the task's `.command.log` file) instead of streaming it.
 
-Other run details — such as run status, task counters, and metrics — continue to update in real time regardless of the compute environment type.
+To load the latest log content, change tabs or refresh the page.
+
+Other run details, such as run status, task counters, and metrics, update in real time regardless of the compute environment type.

--- a/platform-cloud/docs/troubleshooting_and_faqs/troubleshooting.md
+++ b/platform-cloud/docs/troubleshooting_and_faqs/troubleshooting.md
@@ -284,3 +284,11 @@ Connect to the head node over SSH and run `ps -p $$` to verify your default shel
 1. Check which shells are available: `cat /etc/shells`
 2. Change your shell: `chsh -s /usr/bin/bash` (the path to the binary might differ, depending on your HPC configuration).
 3. If submissions continue to fail after the shell change, ask your Seqera Platform admin to restart the **backend** and **cron** containers, then submit again.
+
+#### Execution logs don't update in real time for HPC compute environments
+
+While a task runs on an HPC compute environment (such as Slurm, Grid Engine, LSF, or PBS Pro), the **Execution log** tab on the run details page does not refresh automatically. New log content appears only after you change tabs or refresh the page.
+
+This is expected behavior. Real-time log streaming is supported only for compute environments that stream logs from a cloud logging service: AWS Batch, Azure Batch, Google Cloud Batch, Kubernetes, and the AWS Cloud and Azure Cloud environments. For HPC compute environments, Seqera retrieves the task log from the task work directory (the task's `.command.log` file) instead of streaming it, so the tab is not updated continuously during execution.
+
+Other run details — such as run status, task counters, and metrics — continue to update in real time regardless of the compute environment type.

--- a/platform-enterprise_docs/monitoring/run-details.mdx
+++ b/platform-enterprise_docs/monitoring/run-details.mdx
@@ -171,6 +171,10 @@ The **Inputs** and **Outputs** tabs show every input or output consumed by the t
 
 The **Execution log** tab provides a real-time log of the selected task's execution. Task execution and other logs (such as `stdout` and `stderr`) are available for download if they are still available in your compute environment.
 
+:::note
+Real-time log streaming is available only for compute environments that stream logs from a cloud logging service: AWS Batch, Azure Batch, Google Cloud Batch, Kubernetes, and the AWS Cloud and Azure Cloud environments. For HPC compute environments (such as Slurm, Grid Engine, LSF, and PBS Pro), the log is retrieved from the task work directory rather than streamed, so the **Execution log** tab does not refresh automatically while a task runs. Change tabs or refresh the page to load the latest log content. See [Execution logs don't update in real time for HPC compute environments](../troubleshooting_and_faqs/troubleshooting#execution-logs-dont-update-in-real-time-for-hpc-compute-environments).
+:::
+
 #### Data Explorer
 
 If the pipeline work directory is in cloud storage, this tab shows a [Data Explorer](../data/data-explorer) view of the task's work directory location with the files associated with the task.

--- a/platform-enterprise_docs/monitoring/run-details.mdx
+++ b/platform-enterprise_docs/monitoring/run-details.mdx
@@ -172,7 +172,7 @@ The **Inputs** and **Outputs** tabs show every input or output consumed by the t
 The **Execution log** tab provides a real-time log of the selected task's execution. Task execution and other logs (such as `stdout` and `stderr`) are available for download if they are still available in your compute environment.
 
 :::note
-Real-time log streaming is available only for compute environments that stream logs from a cloud logging service: AWS Batch, Azure Batch, Google Cloud Batch, Kubernetes, and the AWS Cloud and Azure Cloud environments. For HPC compute environments (such as Slurm, Grid Engine, LSF, and PBS Pro), the log is retrieved from the task work directory rather than streamed, so the **Execution log** tab does not refresh automatically while a task runs. Change tabs or refresh the page to load the latest log content. See [Execution logs don't update in real time for HPC compute environments](../troubleshooting_and_faqs/troubleshooting#execution-logs-dont-update-in-real-time-for-hpc-compute-environments).
+Real-time log streaming is available only for compute environments that stream logs from a cloud logging service: AWS Batch, Azure Batch, Google Cloud Batch, Kubernetes, and the AWS Cloud and Azure Cloud environments. HPC compute environments (such as Slurm, Grid Engine, LSF, and PBS Pro) retrieve the log from the task work directory rather than streaming it. The **Execution log** tab does not refresh automatically while a task runs. Change tabs or refresh the page to load the latest log content. See [Execution logs don't update in real time for HPC compute environments](../troubleshooting_and_faqs/troubleshooting#execution-logs-dont-update-in-real-time-for-hpc-compute-environments).
 :::
 
 #### Data Explorer

--- a/platform-enterprise_docs/troubleshooting_and_faqs/troubleshooting.md
+++ b/platform-enterprise_docs/troubleshooting_and_faqs/troubleshooting.md
@@ -441,3 +441,11 @@ Connect to the head node over SSH and run `ps -p $$` to verify your default shel
 1. Check which shells are available: `cat /etc/shells`
 2. Change your shell: `chsh -s /usr/bin/bash` (the path to the binary might differ, depending on your HPC configuration).
 3. If submissions continue to fail after the shell change, ask your Seqera Platform admin to restart the **backend** and **cron** containers, then submit again.
+
+#### Execution logs don't update in real time for HPC compute environments
+
+While a task runs on an HPC compute environment (such as Slurm, Grid Engine, LSF, or PBS Pro), the **Execution log** tab on the run details page does not refresh automatically. New log content appears only after you change tabs or refresh the page.
+
+This is expected behavior. Real-time log streaming is supported only for compute environments that stream logs from a cloud logging service: AWS Batch, Azure Batch, Google Cloud Batch, Kubernetes, and the AWS Cloud and Azure Cloud environments. For HPC compute environments, Seqera retrieves the task log from the task work directory (the task's `.command.log` file) instead of streaming it, so the tab is not updated continuously during execution.
+
+Other run details — such as run status, task counters, and metrics — continue to update in real time regardless of the compute environment type.

--- a/platform-enterprise_docs/troubleshooting_and_faqs/troubleshooting.md
+++ b/platform-enterprise_docs/troubleshooting_and_faqs/troubleshooting.md
@@ -444,8 +444,10 @@ Connect to the head node over SSH and run `ps -p $$` to verify your default shel
 
 #### Execution logs don't update in real time for HPC compute environments
 
-While a task runs on an HPC compute environment (such as Slurm, Grid Engine, LSF, or PBS Pro), the **Execution log** tab on the run details page does not refresh automatically. New log content appears only after you change tabs or refresh the page.
+While a task runs on an HPC compute environment (such as Slurm, Grid Engine, LSF, or PBS Pro), the **Execution log** tab on the run details page does not refresh automatically.
 
-This is expected behavior. Real-time log streaming is supported only for compute environments that stream logs from a cloud logging service: AWS Batch, Azure Batch, Google Cloud Batch, Kubernetes, and the AWS Cloud and Azure Cloud environments. For HPC compute environments, Seqera retrieves the task log from the task work directory (the task's `.command.log` file) instead of streaming it, so the tab is not updated continuously during execution.
+This is expected behavior. Real-time log streaming is supported only for compute environments that stream logs from a cloud logging service: AWS Batch, Azure Batch, Google Cloud Batch, Kubernetes, and the AWS Cloud and Azure Cloud environments. For HPC compute environments, Seqera Platform retrieves the task log from the task work directory (the task's `.command.log` file) instead of streaming it.
 
-Other run details — such as run status, task counters, and metrics — continue to update in real time regardless of the compute environment type.
+To load the latest log content, change tabs or refresh the page.
+
+Other run details, such as run status, task counters, and metrics, update in real time regardless of the compute environment type.


### PR DESCRIPTION
Jira: [EDU-206](https://seqera.atlassian.net/browse/EDU-206)

## What

The **Execution log** tab on the run details page is documented as providing a "real-time log", but real-time streaming is only supported for compute environments backed by a cloud logging service. For HPC compute environments (Slurm, Grid Engine, LSF, PBS Pro), the task log is fetched from the work directory rather than streamed, so the tab does not refresh automatically while a task runs — you must change tabs or refresh the page. This has been a recurring source of confusion and was not documented anywhere.

## Changes

- **`monitoring/run-details.mdx`** (Cloud + Enterprise): add a `:::note` after the Execution log description clarifying which compute environments support real-time streaming, and linking to the new troubleshooting entry.
- **`troubleshooting_and_faqs/troubleshooting.md`** (Cloud + Enterprise): add an "Execution logs don't update in real time for HPC compute environments" entry under the existing **On-premises HPC** section, explaining the behavior is expected and that status, task counters, and metrics still update live.

## Verification

Behavior confirmed against the current Platform source (`master`):
- HPC/grid and local compute environments use `LogSimpleFetcher`, which reads `.command.log` from the task work directory and explicitly does not support log streaming.
- Streaming (the `pending` log flag the frontend keys off) is implemented only for AWS Batch, AWS Cloud, Azure Batch, Azure Cloud, Google Cloud Batch, and Kubernetes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDU-206]: https://seqera.atlassian.net/browse/EDU-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ