### PR TITLE
docs: document GCP Batch infrastructure retry for Fusion Snapshots

### DIFF
--- a/fusion_docs/guide/snapshots/configuration.md
+++ b/fusion_docs/guide/snapshots/configuration.md
@@ -106,7 +106,7 @@ google.batch.maxSpotAttempts = 5
 google.batch.autoRetryExitCodes = [50001, 50002, 50003]
 ```
 
-Google Batch runs these retries on a new instance. This lets a Fusion snapshot restore after the interruption. Add codes from the `50006`–`59999` range if you consistently observe transient infrastructure failures. Avoid retrying `50004` and `50005`. A task that reached a time or runtime limit fails again on retry.
+Google Batch runs these retries on a new instance that is the same type as originally used. This allows a Fusion snapshot to be restored after the interruption. Add codes from the `50006`–`59999` range if you consistently observe transient infrastructure failures. Avoid retrying `50004` and `50005`. A task that reached a time or runtime limit fails again on retry.
 
 :::note
 You can also configure a Nextflow [`errorStrategy`](https://docs.seqera.io/nextflow/reference/process#errorstrategy) keyed on `task.exitStatus`. However, Google Cloud Batch does not always report infrastructure exit codes in the `50001`–`59999` range to Nextflow as the task exit status. As a result, `errorStrategy` conditions based on these codes may not trigger reliably. A future Nextflow release improves how these exit codes are reported. Until then, use `google.batch.autoRetryExitCodes` to retry infrastructure failures.

--- a/fusion_docs/guide/snapshots/configuration.md
+++ b/fusion_docs/guide/snapshots/configuration.md
@@ -83,6 +83,35 @@ process {
 
 See [`errorStrategy`](https://docs.seqera.io/nextflow/reference/process#errorstrategy) for more configuration options.
 
+### Retrying Google Cloud Batch infrastructure failures
+
+On Google Cloud Batch, Spot reclamation is only one of several infrastructure events that can interrupt a task. Google Batch reserves exit codes in the `50001`–`59999` range for these events:
+
+| Exit code | Description |
+|-----------|-------------|
+| 50001 | Spot instance was reclaimed |
+| 50002 | VM became unresponsive (host event or crash) |
+| 50003 | VM unexpectedly rebooted during task execution |
+| 50004 | Task reached the unresponsive time limit and could not be cancelled |
+| 50005 | Task exceeded the maximum allowed runtime |
+
+Exit codes `50006`–`59999` indicate other infrastructure failures.
+
+By default, Google Batch retries only exit code `50001` (Spot reclamation), and only when `google.batch.maxSpotAttempts` is greater than `0`. When Fusion Snapshots are enabled, Nextflow sets `maxSpotAttempts` to a non-zero value automatically, and Google Batch retries `50001` without extra configuration. By default, Google Batch does not retry other infrastructure exit codes. On Spot-based runs, this can cause high failure rates.
+
+To retry additional infrastructure exit codes, extend `google.batch.autoRetryExitCodes` and keep `maxSpotAttempts` greater than `0`:
+
+```groovy
+google.batch.maxSpotAttempts = 5
+google.batch.autoRetryExitCodes = [50001, 50002, 50003]
+```
+
+Google Batch runs these retries on a new instance. This lets a Fusion snapshot restore after the interruption. Add codes from the `50006`–`59999` range if you consistently observe transient infrastructure failures. Avoid retrying `50004` and `50005`. A task that reached a time or runtime limit fails again on retry.
+
+:::note
+You can also configure a Nextflow [`errorStrategy`](https://docs.seqera.io/nextflow/reference/process#errorstrategy) keyed on `task.exitStatus`. However, Google Cloud Batch does not always report infrastructure exit codes in the `50001`–`59999` range to Nextflow as the task exit status. As a result, `errorStrategy` conditions based on these codes may not trigger reliably. A future Nextflow release improves how these exit codes are reported. Until then, use `google.batch.autoRetryExitCodes` to retry infrastructure failures.
+:::
+
 ## TCP connection handling
 
 By default, Fusion Snapshots use `established` mode to preserve TCP connections during checkpoint operations. This works well for plain TCP connections. If your application uses SSL/TLS connections (HTTPS, SSH, etc.), you need to configure TCP close mode because CRIU cannot preserve encrypted connections.

--- a/fusion_docs/guide/snapshots/gcp.md
+++ b/fusion_docs/guide/snapshots/gcp.md
@@ -25,6 +25,8 @@ Fusion Snapshots require the following Seqera Platform compute environment confi
 
 :::tip Configuration
 You must set the number of spot retries you want to attempt to a sensible number. The default is 0. For configuration options, see [Advanced configuration](./configuration.md).
+
+If your runs encounter Google Cloud Batch infrastructure failures beyond Spot reclamation, see [Retrying Google Cloud Batch infrastructure failures](./configuration.md#retrying-google-cloud-batch-infrastructure-failures).
 :::
 
 ## Incremental snapshots


### PR DESCRIPTION
Jira: [EDU-1143](https://seqera.atlassian.net/browse/EDU-1143)

## What

The Fusion Snapshots retry documentation only covered Spot reclamation (exit code `50001`) and `errorStrategy`. Google Cloud Batch surfaces a broader set of infrastructure failures as exit codes in the `50001`–`59999` range, and by default only `50001` is auto-retried. On Spot-based snapshot runs, the other codes cause avoidable failures, and this configuration requirement was undocumented.

## Changes

- **`fusion_docs/guide/snapshots/configuration.md`**: add a "Retrying Google Cloud Batch infrastructure failures" subsection under **Retry handling** — the exit-code range table, how to extend `google.batch.autoRetryExitCodes` (with `maxSpotAttempts`), guidance on which codes to retry, and a note on why `errorStrategy` keyed on `task.exitStatus` is unreliable for these codes.
- **`fusion_docs/guide/snapshots/gcp.md`**: add a one-line pointer from the GCP snapshots page to the new section.

## Verification

Confirmed against the current Nextflow source (`nf-google`, v26.04.3):
- HPC/grid and local executors aside, Google Batch retry is governed by `google.batch.maxSpotAttempts` plus `google.batch.autoRetryExitCodes` (default `[50001]`); Fusion Snapshots set a non-zero `maxSpotAttempts` automatically.
- Exit codes `>= 50000` are read from the task exit file, so `errorStrategy` conditions on `task.exitStatus` do not reliably match infrastructure codes — hence the `autoRetryExitCodes`-first guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDU-1143]: https://seqera.atlassian.net/browse/EDU-1143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ