### PR TITLE
Fix SIC IAM policy CloudWatch Logs scope for /seqera/platform

### DIFF
--- a/platform-cloud/docs/compute-envs/_policies/aws-cloud-intelligent-compute-policy.json
+++ b/platform-cloud/docs/compute-envs/_policies/aws-cloud-intelligent-compute-policy.json
@@ -103,7 +103,7 @@
         "logs:GetLogEvents",
         "logs:TagResource"
       ],
-      "Resource": "arn:aws:logs:*:*:log-group:/seqera/sched*"
+      "Resource": "arn:aws:logs:*:*:log-group:/seqera/*"
     },
     {
       "Sid": "EC2NetworkDiscovery",

--- a/platform-cloud/docs/compute-envs/intelligent-compute.mdx
+++ b/platform-cloud/docs/compute-envs/intelligent-compute.mdx
@@ -31,7 +31,7 @@ When you enable Intelligent Compute on an AWS Cloud compute environment, Seqera 
 - ECS capacity providers (Managed Instances or Auto Scaling Groups)
 - ECS task definitions per container image and resource shape
 - IAM roles for ECS task execution, EC2 instance profiles, and infrastructure management
-- CloudWatch log groups under `/seqera/sched`
+- CloudWatch log groups under `/seqera` (for example, `/seqera/platform`)
 
 All managed resources use the `seqera-sched-` prefix. Seqera creates them on first use and removes them automatically when no longer needed.
 
@@ -65,7 +65,7 @@ Intelligent Compute requires **two IAM policies** attached to the same IAM user 
 | `IAMRoleManagement` | Create, update, and delete IAM roles and instance profiles scoped to `seqera-sched-*`. Seqera creates four role types on first use: execution role, infrastructure role, per-cluster instance role, and per-cluster task role. |
 | `PassRoleToECS` | Pass `seqera-sched-*` and `TowerForge-*` roles to ECS, ECS tasks, and EC2. Required to attach roles to ECS infrastructure and task definitions. |
 | `ServiceLinkedRoles` | Create service-linked roles for ECS, autoscaling, and Spot. Required only if these roles do not already exist in your account. |
-| `CloudWatchLogs` | Create and manage log groups under `/seqera/sched`, and read log events. Task stdout and stderr are written to CloudWatch. |
+| `CloudWatchLogs` | Create and manage log groups under `/seqera` (for example, `/seqera/platform`), and read log events. Task stdout and stderr are written to CloudWatch. |
 | `EC2NetworkDiscovery` | Describe VPCs, subnets, security groups, and route tables. Create security groups and VPC endpoints. Used for VPC auto-discovery and network setup. |
 | `ECRAccess` | Authorize ECR and pull container images. ECS tasks pull images from ECR. |
 | `S3Access` | Read objects and list buckets. Used to read Fusion trace files and pipeline work directory content. |

--- a/platform-enterprise_docs/compute-envs/aws-cloud.md
+++ b/platform-enterprise_docs/compute-envs/aws-cloud.md
@@ -249,7 +249,7 @@ Seqera Intelligent Compute is in private preview. [Contact us](https://seqera.io
 
 To enable Seqera Intelligent Compute, attach an additional IAM policy (beyond the [Required permissions](#required-permissions)) to the same IAM user or role that Seqera uses to access your AWS account.
 
-The policy scopes every ARN-eligible action to the `seqera-sched-*` prefix. The remaining `Resource: "*"` entries correspond to AWS APIs that do not support resource-level permissions, such as EC2 `Describe*`, ECR authorization tokens, and Cost Explorer.
+The policy scopes ARN-eligible actions to the `seqera-sched-*` resource prefix, except for CloudWatch Logs actions, which are scoped to the `/seqera/*` log-group prefix (Seqera writes logs to groups such as `/seqera/platform`). The remaining `Resource: "*"` entries correspond to AWS APIs that do not support resource-level permissions, such as EC2 `Describe*`, ECR authorization tokens, and Cost Explorer.
 
 <details>
 <summary>Seqera Intelligent Compute policy</summary>
@@ -360,7 +360,7 @@ The policy scopes every ARN-eligible action to the `seqera-sched-*` prefix. The 
         "logs:GetLogEvents",
         "logs:TagResource"
       ],
-      "Resource": "arn:aws:logs:*:*:log-group:/seqera/sched*"
+      "Resource": "arn:aws:logs:*:*:log-group:/seqera/*"
     },
     {
       "Sid": "EC2NetworkDiscovery",

--- a/platform-enterprise_versioned_docs/version-26.1/compute-envs/aws-cloud.md
+++ b/platform-enterprise_versioned_docs/version-26.1/compute-envs/aws-cloud.md
@@ -249,7 +249,7 @@ Seqera Intelligent Compute is in private preview. [Contact us](https://seqera.io
 
 To enable Seqera Intelligent Compute, attach an additional IAM policy (beyond the [Required permissions](#required-permissions)) to the same IAM user or role that Seqera uses to access your AWS account.
 
-The policy scopes every ARN-eligible action to the `seqera-sched-*` prefix. The remaining `Resource: "*"` entries correspond to AWS APIs that do not support resource-level permissions, such as EC2 `Describe*`, ECR authorization tokens, and Cost Explorer.
+The policy scopes ARN-eligible actions to the `seqera-sched-*` resource prefix, except for CloudWatch Logs actions, which are scoped to the `/seqera/*` log-group prefix (Seqera writes logs to groups such as `/seqera/platform`). The remaining `Resource: "*"` entries correspond to AWS APIs that do not support resource-level permissions, such as EC2 `Describe*`, ECR authorization tokens, and Cost Explorer.
 
 <details>
 <summary>Seqera Intelligent Compute policy</summary>
@@ -360,7 +360,7 @@ The policy scopes every ARN-eligible action to the `seqera-sched-*` prefix. The 
         "logs:GetLogEvents",
         "logs:TagResource"
       ],
-      "Resource": "arn:aws:logs:*:*:log-group:/seqera/sched*"
+      "Resource": "arn:aws:logs:*:*:log-group:/seqera/*"
     },
     {
       "Sid": "EC2NetworkDiscovery",


### PR DESCRIPTION
## Problem

A recent `sched` release ([seqeralabs/sched#622](https://github.com/seqeralabs/sched/pull/622)) moved AWS Cloud cluster-creation logging to the `/seqera/platform` CloudWatch log group. The documented **Seqera Intelligent Compute** IAM policy scopes CloudWatch Logs actions to `/seqera/sched*`, which does not cover the new log group. Cluster creation now fails with:

```
User: arn:aws:iam::...:user/seqera-intelligent-compute-user is not authorized to perform:
logs:CreateLogGroup on resource: arn:aws:logs:us-east-1:...:log-group:/seqera/platform
because no identity-based policy allows the logs:CreateLogGroup action
```

This is an undocumented breaking change affecting everyone using Seqera Intelligent Compute (SIC), including private-preview customers. Reported in [Slack](https://seqera.slack.com/archives/C070C9WN65D/p1783520752038709).

## Fix

Broaden the `CloudWatchLogs` statement's log-group resource scope from `/seqera/sched*` to `/seqera/*`, so the policy covers both task logs (`/seqera/sched`) and cluster-creation logs (`/seqera/platform`). Prose describing the log-group scope is updated to match.

## Files changed

- `platform-cloud/docs/compute-envs/_policies/aws-cloud-intelligent-compute-policy.json` — policy resource scope
- `platform-cloud/docs/compute-envs/intelligent-compute.mdx` — prose references
- `platform-enterprise_docs/compute-envs/aws-cloud.md` — inline SIC policy + prose
- `platform-enterprise_versioned_docs/version-26.1/compute-envs/aws-cloud.md` — same (current release snapshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)