### PR TITLE
Enable system color mode in docs theme toggle.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -480,6 +480,9 @@ export default async function createConfigAsync() {
     ].filter(Boolean),
 
     themeConfig: getSeqeraThemeConfig({
+      colorMode: {
+        respectPrefersColorScheme: true,
+      },
       seqera: {
         docs: {
           versionDropdown: {


### PR DESCRIPTION
Follow OS theme by default and allow cycling system, light, and dark.