### PR TITLE
docs(aws-cloud): grant Secrets Manager write for pipeline secrets

### DIFF
--- a/platform-cloud/docs/compute-envs/aws-cloud.mdx
+++ b/platform-cloud/docs/compute-envs/aws-cloud.mdx
@@ -508,7 +508,7 @@ In addition to the managed policies, attach the following inline policies:
 }
 ```
 
-**Secrets Manager** — lets Seqera manage the pipeline secrets it stores in AWS Secrets Manager, which are prefixed with `tower-`. Seqera creates each referenced secret when a pipeline launches and removes it on completion; the compute environment reads it at task startup. Required for pipelines that use Seqera pipeline secrets:
+**Secrets Manager** — grants access to the pipeline secrets Seqera stores in AWS Secrets Manager under the `tower-` prefix. Seqera creates each referenced secret when a pipeline launches and deletes it on completion:
 
 ```json
 {

--- a/platform-cloud/docs/compute-envs/aws-cloud.mdx
+++ b/platform-cloud/docs/compute-envs/aws-cloud.mdx
@@ -508,16 +508,27 @@ In addition to the managed policies, attach the following inline policies:
 }
 ```
 
-**Secrets Manager** — grants access to credentials stored in Seqera, which are prefixed with `tower-`:
+**Secrets Manager** — lets Seqera manage the pipeline secrets it stores in AWS Secrets Manager, which are prefixed with `tower-`. Seqera creates each referenced secret when a pipeline launches and removes it on completion; the compute environment reads it at task startup. Required for pipelines that use Seqera pipeline secrets:
 
 ```json
 {
   "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": ["secretsmanager:GetSecretValue", "secretsmanager:ListSecrets"],
-    "Resource": ["arn:aws:secretsmanager:<REGION>:*:secret:tower-*"]
-  }
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:CreateSecret",
+        "secretsmanager:DeleteSecret"
+      ],
+      "Resource": ["arn:aws:secretsmanager:<REGION>:*:secret:tower-*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["secretsmanager:ListSecrets"],
+      "Resource": ["*"]
+    }
+  ]
 }
 ```
 

--- a/platform-enterprise_docs/compute-envs/aws-cloud.md
+++ b/platform-enterprise_docs/compute-envs/aws-cloud.md
@@ -536,16 +536,27 @@ In addition to the managed policies, attach the following inline policies:
 }
 ```
 
-**Secrets Manager** — grants access to credentials stored in Seqera, which are prefixed with `tower-`:
+**Secrets Manager** — lets Seqera manage the pipeline secrets it stores in AWS Secrets Manager, which are prefixed with `tower-`. Seqera creates each referenced secret when a pipeline launches and removes it on completion; the compute environment reads it at task startup. Required for pipelines that use Seqera pipeline secrets:
 
 ```json
 {
   "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": ["secretsmanager:GetSecretValue", "secretsmanager:ListSecrets"],
-    "Resource": ["arn:aws:secretsmanager:<REGION>:*:secret:tower-*"]
-  }
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:CreateSecret",
+        "secretsmanager:DeleteSecret"
+      ],
+      "Resource": ["arn:aws:secretsmanager:<REGION>:*:secret:tower-*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["secretsmanager:ListSecrets"],
+      "Resource": ["*"]
+    }
+  ]
 }
 ```
 

--- a/platform-enterprise_docs/compute-envs/aws-cloud.md
+++ b/platform-enterprise_docs/compute-envs/aws-cloud.md
@@ -536,7 +536,7 @@ In addition to the managed policies, attach the following inline policies:
 }
 ```
 
-**Secrets Manager** — lets Seqera manage the pipeline secrets it stores in AWS Secrets Manager, which are prefixed with `tower-`. Seqera creates each referenced secret when a pipeline launches and removes it on completion; the compute environment reads it at task startup. Required for pipelines that use Seqera pipeline secrets:
+**Secrets Manager** — grants access to the pipeline secrets Seqera stores in AWS Secrets Manager under the `tower-` prefix. Seqera creates each referenced secret when a pipeline launches and deletes it on completion:
 
 ```json
 {


### PR DESCRIPTION
## What

Updates the **Secrets Manager** inline policy in the AWS Cloud / Intelligent Compute IAM setup so that Seqera Platform pipeline secrets work on these compute environments.

Applies to both current pages (versioned snapshots left unchanged):
- `platform-enterprise_docs/compute-envs/aws-cloud.md`
- `platform-cloud/docs/compute-envs/aws-cloud.mdx`

## Why

The documented Secrets Manager inline policy only granted **read** (`GetSecretValue`, `ListSecrets`). But at launch Seqera **creates** each referenced pipeline secret in AWS Secrets Manager (as `tower-<workflowId>/<name>`) and **deletes** it on completion — so the Seqera IAM credential also needs `CreateSecret` and `DeleteSecret`. Without them, pipelines that reference Seqera pipeline secrets fail to launch on AWS Cloud / Intelligent Compute.

This mirrors the scheduler-side change in seqeralabs/sched (the `seqera-aws-cloud-policy` in the CloudFormation stack gains the same grants). The scheduler-created ECS execution role's `GetSecretValue` grant is attached by the scheduler itself and needs no customer-facing change.

## Changes

- Add `secretsmanager:CreateSecret` and `secretsmanager:DeleteSecret` (scoped to `tower-*`) alongside the existing `GetSecretValue`.
- Split `secretsmanager:ListSecrets` into its own statement on `Resource: "*"` — `ListSecrets` does not support resource-level permissions, so scoping it to `tower-*` (as before) silently denied the list call used during secret cleanup.
- Reword the policy description to explain the store/read lifecycle.

## Notes

Draft: the Intelligent Compute pipeline-secrets feature is in preview and the scheduler-side support is not yet released. Merge alongside that release. Ready to flip out of draft on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)