### PR TITLE
docs: add Secret Manager role to Google Batch service account permissions

### DIFF
--- a/platform-cloud/docs/compute-envs/google-cloud-batch.md
+++ b/platform-cloud/docs/compute-envs/google-cloud-batch.md
@@ -64,6 +64,7 @@ By default, Google Cloud Batch uses the default Compute Engine service account t
 - Logs Writer (`roles/logging.logWriter`) on the project (to let jobs generate logs in Cloud Logging)
 - Logs Viewer (`roles/logging.logViewer`) on the project (to view and retrieve logs from Cloud Logging)
 - Service Account User (`roles/iam.serviceAccountUser`)
+- Secret Manager Secret Accessor (`roles/secretmanager.secretAccessor`) on the project (required if your pipelines use Seqera secrets; the head job and tasks read secrets from GCP Secret Manager)
 
 If your Google Cloud project does not require access restrictions on any of its Cloud Storage buckets, you can grant project Storage Admin (`roles/storage.admin`) permissions to your service account to simplify setup. To grant access only to specific buckets, add the service account as a principal on each bucket individually. See [Cloud Storage bucket](#cloud-storage-bucket) below.
 

--- a/platform-enterprise_docs/compute-envs/google-cloud-batch.md
+++ b/platform-enterprise_docs/compute-envs/google-cloud-batch.md
@@ -64,6 +64,7 @@ By default, Google Cloud Batch uses the default Compute Engine service account t
 * Logs Writer (`roles/logging.logWriter`) on the project (to let jobs generate logs in Cloud Logging)
 * Service Account User (`roles/iam.serviceAccountUser`)
 * Service Usage Consumer (`roles/serviceusage.serviceUsageConsumer`)
+* Secret Manager Secret Accessor (`roles/secretmanager.secretAccessor`) on the project (required if your pipelines use Seqera secrets; the head job and tasks read secrets from GCP Secret Manager)
 
 If your Google Cloud project does not require access restrictions on any of its Cloud Storage buckets, you can grant project Storage Admin (`roles/storage.admin`) permissions to your service account to simplify setup. To grant access only to specific buckets, add the service account as a principal on each bucket individually. See [Cloud Storage bucket](#cloud-storage-bucket) below.
 


### PR DESCRIPTION
## Summary

- Add **Secret Manager Secret Accessor** (`roles/secretmanager.secretAccessor`) to the custom service account permissions list on the Google Cloud Batch compute environment setup page.
- The role is required when pipelines use Seqera/Nextflow secrets on Google Batch: both task-level env-var secrets and config-scope `secrets.*` resolution during head-job config parse read from GCP Secret Manager.
- Applied identically to `platform-cloud/docs/compute-envs/google-cloud-batch.md` and `platform-enterprise_docs/compute-envs/google-cloud-batch.md`, matching each file's existing bullet style. Versioned enterprise snapshots under `platform-enterprise_versioned_docs/` are not modified.

## Test plan

- [ ] Confirm the new bullet renders in the **Service account permissions** section on both the Cloud and Enterprise pages in the Netlify deploy preview.
- [ ] Confirm the role name, id, and phrasing match the existing "role name (role/id) on the project" style used by adjacent bullets.
- [ ] Confirm no other roles were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)