### PR TITLE
docs(launch): document per-run Output directory field

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,5 +1,30 @@
 # GitHub Actions scripts
 
+## docs-diff-since-release.sh
+
+Lists what has changed in the working Enterprise docs (`platform-enterprise_docs/`) since a frozen release snapshot (`platform-enterprise_versioned_docs/version-<VERSION>/`), so you can see at a glance which pages accumulated changes for the next Enterprise version. The report is derived live from the two trees, so it never goes stale — run it whenever you start assembling content for the next release.
+
+### Usage
+
+```bash
+.github/scripts/docs-diff-since-release.sh [VERSION] [--full]
+```
+
+### Parameters
+
+- `VERSION`: Baseline release to compare against (default: the highest-numbered `version-*` snapshot)
+- `--full`: Also print the unified diff for every changed page
+
+### Examples
+
+```bash
+# Summary of new / removed / changed pages since v26.1
+.github/scripts/docs-diff-since-release.sh 26.1
+
+# Same, plus full unified diffs, saved to a file
+.github/scripts/docs-diff-since-release.sh 26.1 --full > since-26.1.md
+```
+
 ## verify-agent-findings.py
 
 Validates agent output by checking that quoted text actually exists at the claimed line numbers, preventing hallucinations from being reported.

--- a/.github/scripts/docs-diff-since-release.sh
+++ b/.github/scripts/docs-diff-since-release.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Lists what has changed in the working Enterprise docs since a frozen release
+# snapshot, so you can see at a glance which pages need attention when writing
+# content for the next Enterprise version.
+#
+# It diffs the frozen versioned snapshot against the live, non-versioned docs:
+#   platform-enterprise_versioned_docs/version-<VERSION>/   (frozen baseline)
+#   platform-enterprise_docs/                               (working copy -> next release)
+#
+# The report is derived live from the two trees, so it never goes stale.
+#
+# Usage:
+#   .github/scripts/docs-diff-since-release.sh [VERSION] [--full]
+#
+#   VERSION   Baseline release to compare against (default: latest version-* snapshot)
+#   --full    Also print the unified diff for every changed page
+#
+# Examples:
+#   .github/scripts/docs-diff-since-release.sh            # summary vs latest snapshot
+#   .github/scripts/docs-diff-since-release.sh 26.1       # summary vs v26.1
+#   .github/scripts/docs-diff-since-release.sh 26.1 --full > since-26.1.md
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+VERSIONED_DIR="$REPO_ROOT/platform-enterprise_versioned_docs"
+WORK="$REPO_ROOT/platform-enterprise_docs"
+
+VERSION=""
+FULL=false
+for arg in "$@"; do
+  case "$arg" in
+    --full) FULL=true ;;
+    -h|--help) sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    --*) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    *) VERSION="$arg" ;;
+  esac
+done
+
+# Default to the highest-numbered frozen snapshot if no version was given.
+if [[ -z "$VERSION" ]]; then
+  VERSION="$(ls -d "$VERSIONED_DIR"/version-* 2>/dev/null \
+    | sed 's#.*/version-##' | sort -V | tail -1)"
+  [[ -n "$VERSION" ]] || { echo "No version-* snapshots found in $VERSIONED_DIR" >&2; exit 1; }
+fi
+
+BASE="$VERSIONED_DIR/version-$VERSION"
+[[ -d "$BASE" ]] || { echo "No frozen snapshot at $BASE" >&2; exit 1; }
+[[ -d "$WORK" ]] || { echo "No working docs at $WORK" >&2; exit 1; }
+
+# Ignore non-content noise: binary assets, macOS cruft, and Docusaurus sidebars.
+EXCLUDES=( --exclude=_images --exclude='.DS_Store' --exclude='*.json' )
+
+# Strip a leading "$BASE/" or "$WORK/" prefix to get the doc-relative path.
+rel() { local p="$1"; p="${p#"$BASE"/}"; p="${p#"$WORK"/}"; echo "$p"; }
+
+added=()
+removed=()
+changed=()
+
+# `diff -rq` classifies every path as added / removed / changed in one pass.
+while IFS= read -r line; do
+  case "$line" in
+    "Only in $WORK"*)
+      dir="${line#Only in }"; name="${dir##*: }"; dir="${dir%%: *}"
+      added+=( "$(rel "$dir/$name")" ) ;;
+    "Only in $BASE"*)
+      dir="${line#Only in }"; name="${dir##*: }"; dir="${dir%%: *}"
+      removed+=( "$(rel "$dir/$name")" ) ;;
+    "Files "*" differ")
+      f="${line#Files }"; f="${f% and *}"
+      changed+=( "$(rel "$f")" ) ;;
+  esac
+done < <(diff -rq "${EXCLUDES[@]}" "$BASE" "$WORK" 2>/dev/null || true)
+
+echo "# Enterprise docs changed since v$VERSION"
+echo "_Baseline: platform-enterprise_versioned_docs/version-$VERSION/ vs platform-enterprise_docs/_"
+echo
+echo "Summary: ${#added[@]} new, ${#removed[@]} removed, ${#changed[@]} changed"
+echo
+
+if ((${#added[@]})); then
+  echo "## New pages (likely new features) — ${#added[@]}"
+  printf '  + %s\n' $(printf '%s\n' "${added[@]}" | sort)
+  echo
+fi
+
+if ((${#removed[@]})); then
+  echo "## Removed pages — ${#removed[@]}"
+  printf '  - %s\n' $(printf '%s\n' "${removed[@]}" | sort)
+  echo
+fi
+
+if ((${#changed[@]})); then
+  echo "## Changed pages — ${#changed[@]}"
+  while IFS= read -r f; do
+    a=$(diff "$BASE/$f" "$WORK/$f" 2>/dev/null | grep -c '^>' || true)
+    d=$(diff "$BASE/$f" "$WORK/$f" 2>/dev/null | grep -c '^<' || true)
+    printf '  ~ %s  (+%s -%s)\n' "$f" "$a" "$d"
+  done < <(printf '%s\n' "${changed[@]}" | sort)
+  echo
+fi
+
+if $FULL && ((${#changed[@]} + ${#added[@]})); then
+  echo "## Full unified diffs"
+  echo
+  for f in $(printf '%s\n' "${changed[@]}" "${added[@]}" | sort -u); do
+    old="$BASE/$f"; [[ -f "$old" ]] || old=/dev/null
+    echo '```diff'
+    git --no-pager diff --no-index --no-color "$old" "$WORK/$f" 2>/dev/null || true
+    echo '```'
+    echo
+  done
+fi

--- a/changelog/seqera-cloud/v26.1.0_cycle55.md
+++ b/changelog/seqera-cloud/v26.1.0_cycle55.md
@@ -15,15 +15,9 @@ tags: [seqera cloud]
 
 - Exposed dataset file size in version API responses.
 
-### Monitoring
-
-- Added a `getCost` failure metric.
-- Rendered fractional Allocated CPU values on the Run Details metrics card.
-- Added SCIM group audit logs.
-
 ### Pipelines
 
-- Added a Nextflow syntax parser v2 toggle.
+- Added a [Nextflow syntax parser v2 toggle](https://docs.seqera.io/platform-cloud/troubleshooting_and_faqs/nextflow#nextflow-syntax-parser).
 - Added launch-time settings to the workflow configuration tab.
 
 ### Studios
@@ -33,34 +27,7 @@ tags: [seqera cloud]
 - Enabled updating the compute environment on a Studio.
 - Resolved the user on SSH Studio connection attempts.
 
-### Data Explorer
-
-- Cached the impersonated signer for WIF pre-signed URLs.
-
-### General
-
-- Introduced scroll-into-error behavior for the notification container component and unified the placement of message containers across form pages.
-- Collapsed Settings breadcrumbs to two segments.
-- Refined styling for the bordered variant of label values.
-- Improved readability of usage chip icons on dark backgrounds.
-
 ## Bug fixes
-
-### Access control
-
-- Redirected on JWT expiry and stopped the onboarding polling loop.
-- Auto-created organization membership during IdP group reconciliation.
-- Polished the IdP group mapping UI.
-
-### Compute environments
-
-- Validated NVMe and Wave dependencies for Fusion v2.
-- Split Forge disposal into separate resources and credentials phases.
-- Ported the Forge disposal split to Azure and GCP.
-- Clarified `setRemoteAvailableCredits` behavior and floored stale balance updates.
-- Granted lineage store access to the forged AWS Batch role.
-- Bumped the GCP default GPU image family to CUDA 12.9.
-- Resolved the WIF credential owner context inside a read-only transaction.
 
 ### Data Explorer
 
@@ -69,16 +36,8 @@ tags: [seqera cloud]
 ### Pipelines
 
 - Disabled the lineage launch toggle when lineage settings are not configured or when the compute environment does not support lineage.
-- Set the default value for `Launch.syntaxParser` to match the database schema.
-- De-flaked the `PipelineServiceTest` agent revisions check.
 
 ### Studios
 
 - Recovered legacy Studio event names in the usage query.
 - Fell back to baseline Studio capabilities when the manifest is missing or the Studio version is not found in the manifest.
-
-### General
-
-- Pinned the Netty allocator to `pooled` to mitigate Micronaut 4.9 direct memory growth.
-- Stopped `ProviderUnrecoverableException` from hiding JVM errors.
-- Increased the polling timeout for the async audit image bundle test.

--- a/changelog/seqera-cloud/v26.1.0_cycle56.md
+++ b/changelog/seqera-cloud/v26.1.0_cycle56.md
@@ -11,10 +11,6 @@ tags: [seqera cloud]
 - Added a configurable boot disk size for Azure Batch pools.
 - Added `r8idn`, `r8idb`, `m8idn`, and `m8idb` instance families to the NVMe list.
 
-### Monitoring
-
-- Improved the JSON diff component with small refinements.
-
 ### Pipelines
 
 - Added the Lineage ID to the Run Info page.
@@ -26,38 +22,16 @@ tags: [seqera cloud]
 
 ## Bug fixes
 
-### Access control
-
-- Fixed the audit event type for MANUAL-to-SCIM promotion.
-- Kept the infinite-scroll drop-down open when clicking the search input.
-
 ### Compute environments
 
-- Improved Entra robustness by adding `equals`/`hashCode` for credentials and making the managed identity regex case-insensitive.
 - Deduplicated the compute environment entry in the launch drop-down.
 
 ### Data Explorer
 
 - Made credentials a required field in the **Add data repository** form.
-- Fixed the Data Explorer custom bucket E2E test to select credentials.
-
-### Monitoring
-
-- Fixed a referential integrity constraint violation when saving an audit log image bundle in H2.
-- Replaced the word `ID` with `IP` in the audit logs table.
-- Coalesced `setAvailableCredits` calls per organization.
-- Coalesced stop events per organization using a Redis lock.
-- Added a differential TTL and empty-result guard for the Metronome balance cache.
-- Coalesced `handleOrganizationCreditsExpiration` calls per organization.
-- Skipped null balance puts in `listGrantBalance` to avoid a `ConcurrentHashMap` NPE.
 
 ### Pipelines
 
 - Refined `workflow_updated` events that contain no diff.
 - Prevented duplicate GitHub credentials across PAT and GitHub App types.
 - Resolved file paths to the most recent lineage record.
-
-### General
-
-- Fixed the expandable-text overlay to display only when text is truncated.
-- Preserved panel search focus inside `mat-menu`.

--- a/changelog/seqera-cloud/v26.2.0_cycle58.md
+++ b/changelog/seqera-cloud/v26.2.0_cycle58.md
@@ -8,7 +8,7 @@ tags: [seqera cloud]
 
 ### Access control
 
-- Enabled GitHub App credentials for all workspaces.
+- Enabled [GitHub App credentials](https://docs.seqera.io/platform-cloud/git/overview#create-a-new-github-app-from-platform) for all workspaces.
 
 ### Compute environments
 

--- a/changelog/seqera-cloud/v26.2.0_cycle59.md
+++ b/changelog/seqera-cloud/v26.2.0_cycle59.md
@@ -13,7 +13,7 @@ tags: [seqera cloud]
 
 ### Pipelines
 
-- Added a launch output directory option to the launch form.
+- [Added a launch output directory option to the launch form](https://docs.seqera.io/platform-cloud/launch/launchpad#run-parameters).
 - Added a shareable deep link to the task details view.
 - Showed the metrics tab for canceled workflow runs.
 

--- a/platform-cloud/docs/launch/launchpad.md
+++ b/platform-cloud/docs/launch/launchpad.md
@@ -93,6 +93,18 @@ Configure the core settings for your run, including the pipeline source, compute
   :::
 - **Schema**: The [pipeline schema][pipeline-schema] to validate pipeline parameters and prevent runtime failures. Options include **Repository default**, **Repository path**, and **Seqera Platform schema**.
 
+#### Output directory
+
+Set an optional **Output directory** to override the default location for your pipeline's [workflow outputs][nextflow-workflow-outputs]. This is distinct from your pipeline's own output parameter (such as `outdir`) under [Run parameters](#run-parameters).
+
+- Enter an absolute cloud storage path, such as `s3://my-bucket/results`, or select **Browse** to choose a location with [Data Explorer][data-explorer]. Select a **Compute environment** before you browse.
+- Platform passes this value to Nextflow as `-output-dir`.
+- **Output directory** is optional and is not carried over on relaunch. Set it for each launch.
+
+:::note
+The **Output directory** field requires Nextflow 24.10.0 or later and a pipeline that uses the [workflow outputs syntax][nextflow-workflow-outputs]. For older pipelines, use your pipeline output parameter (for example, `params.outdir`) instead.
+:::
+
 ### Run parameters
 
 Enter **Run parameters** in one of four ways before launch:
@@ -107,7 +119,7 @@ If the pipeline includes a `nextflow_schema.json` file in its repository root, S
 Common parameters include:
 
 - **Input data**: If the pipeline defines an input parameter, specify compatible [datasets][datasets] manually or from the drop-down. Select **Browse** to view the available datasets or browse for files in [Data Explorer][data-explorer]. Use the Data Explorer tab to select input datasets that match your [pipeline schema][pipeline-schema] `mimetype` criteria (`text/csv` for CSV files, or `text/tsv` for TSV files).
-- **Output directory**: If the pipeline defines an output directory parameter, specify it manually or select **Browse** to choose a cloud storage directory using [Data Explorer][data-explorer].
+- **Output directory**: Your pipeline's own output directory parameter (for example, `outdir`), if defined in the pipeline schema. Specify it manually or select **Browse** to choose a cloud storage directory using [Data Explorer][data-explorer]. This is separate from the [**Output directory**](#output-directory) field in **General config**, which sets the Nextflow `-output-dir` value for workflow outputs.
 
 ### Advanced settings
 
@@ -241,6 +253,7 @@ The following table lists the supported URL query parameters and their correspon
 [pipeline-versioning]: ../pipelines/versioning
 [pipeline-revision]: ../pipelines/revision
 [nextflow-config-profile]: https://docs.seqera.io/nextflow/config#config-profiles
+[nextflow-workflow-outputs]: https://docs.seqera.io/nextflow/workflow#outputs
 [labels]: ../labels/overview
 [compute-envs]: ../compute-envs/overview
 [pipeline-schema]: ../pipeline-schema/overview

--- a/platform-enterprise_docs/launch/launchpad.md
+++ b/platform-enterprise_docs/launch/launchpad.md
@@ -90,6 +90,18 @@ The drop-down of available config profiles is populated by inspecting the Nextfl
   }
   ```
 
+#### Output directory
+
+Set an optional **Output directory** to override the default location for your pipeline's [workflow outputs][nextflow-workflow-outputs]. This is distinct from your pipeline's own output parameter (such as `outdir`) under [Run parameters](#run-parameters).
+
+- Enter an absolute cloud storage path, such as `s3://my-bucket/results`, or select **Browse** to choose a location with [Data Explorer][data-explorer]. Select a **Compute environment** before you browse.
+- Platform passes this value to Nextflow as `-output-dir`.
+- **Output directory** is optional and is not carried over on relaunch. Set it for each launch.
+
+:::note
+The **Output directory** field requires Nextflow 24.10.0 or later and a pipeline that uses the [workflow outputs syntax][nextflow-workflow-outputs]. For older pipelines, use your pipeline output parameter (for example, `params.outdir`) instead.
+:::
+
 ### Run parameters
 
 There are four ways to enter **Run parameters** prior to launch:
@@ -105,7 +117,7 @@ Seqera uses a `nextflow_schema.json` file in the root of the pipeline repository
 Specify compatible input [datasets][datasets]  manually or from the drop-down. Select **Browse** to view the available datasets or browse for files in [Data Explorer][data-explorer]. The Data Explorer tab allows you to select input datasets that match your [pipeline schema][pipeline-schema] `mimetype` criteria (`text/csv` for CSV files, or `text/tsv` for TSV files).
 
 - **outdir**
-Specify the output directory where run results will be saved manually, or select **Browse** to choose a cloud storage directory using [Data Explorer][data-explorer].
+Your pipeline's own output directory parameter, if defined in the pipeline schema. Specify the output directory where run results will be saved manually, or select **Browse** to choose a cloud storage directory using [Data Explorer][data-explorer]. This is separate from the [**Output directory**](#output-directory) field in **General config**, which sets the Nextflow `-output-dir` value for workflow outputs.
 
 The remaining fields will vary for each pipeline, dependent on the parameters specified in the pipeline schema.
 
@@ -238,6 +250,7 @@ Platform will ignore added percent-encoding characters in form fields, so you do
 [pipeline-versioning]: ../pipelines/versioning
 [pipeline-revision]: ../pipelines/revision
 [nextflow-config-profile]: https://docs.seqera.io/nextflow/config#config-profiles
+[nextflow-workflow-outputs]: https://docs.seqera.io/nextflow/workflow#outputs
 [labels]: ../labels/overview
 [compute-envs]: ../compute-envs/overview
 [pipeline-schema]: ../pipeline-schema/overview


### PR DESCRIPTION
## What

Documents the new per-run **Output directory** field in the pipeline launch form (General config step). This field is distinct from a pipeline's own output parameter (e.g. `outdir`) under **Run parameters**, and maps to Nextflow's `-output-dir`.

Coverage:
- Absolute cloud storage path example + **Browse** via Data Explorer
- Compute-environment-must-be-selected-first prerequisite
- `-output-dir` mapping
- Requirement admonition: Nextflow 24.10.0+ and workflow outputs syntax (older pipelines use their pipeline output parameter instead), aligned to the in-app helper text
- Field is optional and is not carried over on relaunch

The existing **Run parameters** "output directory" bullet is reworded to make clear it's the pipeline's *own* output parameter, and cross-links to the new field so the two aren't conflated.

## Files

- `platform-cloud/docs/launch/launchpad.md` — Cloud
- `platform-enterprise_docs/launch/launchpad.md` — Enterprise (non-versioned working docs)

## Release scope

The field shipped in the **Cloud v26.2.0** line. The latest released Enterprise version is **v26.1**, so this is not in a released Enterprise version yet. It is documented in the non-versioned `platform-enterprise_docs/` so it ships with the next Enterprise release (26.2); it will be captured in the `version-26.2` snapshot when that release is cut. The frozen `version-26.1` snapshot is intentionally left unchanged.

## Also included

`.github/scripts/docs-diff-since-release.sh` — a local authoring helper that lists Enterprise docs pages changed since a frozen release snapshot (diffs `platform-enterprise_versioned_docs/version-<X>/` against `platform-enterprise_docs/`), so in-flight changes destined for the next release don't slip under the radar when assembling content. Derived live, so it never goes stale. Documented in `.github/scripts/README.md`.

Ref: PLAT-4526

🤖 Generated with [Claude Code](https://claude.com/claude-code)
