### PR TITLE
docs: Specify that OIDC env vars need to be mounted on backend only

### DIFF
--- a/platform-enterprise_docs/enterprise/configuration/authentication/oidc.mdx
+++ b/platform-enterprise_docs/enterprise/configuration/authentication/oidc.mdx
@@ -123,7 +123,7 @@ Connection strings can differ based on the issuer type. Verify the issuer URL vi
 
 ## Configure Seqera
 
-Add the following environment variables to your Seqera configuration:
+Add the following environment variables to your Seqera backend service configuration:
 
 | Variable | Description |
 | :------- | :---------- |

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/authentication/oidc.mdx
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/configuration/authentication/oidc.mdx
@@ -123,7 +123,7 @@ Connection strings can differ based on the issuer type. Verify the issuer URL vi
 
 ## Configure Seqera
 
-Add the following environment variables to your Seqera configuration:
+Add the following environment variables to your Seqera backend service configuration:
 
 | Variable | Description |
 | :------- | :---------- |


### PR DESCRIPTION
Follow up of #1654 since I noticed customers specifying the vars on cron deployments too.