### PR TITLE
docs(azure-cloud): document BYO VNet and subnet configuration

### DIFF
--- a/platform-cloud/docs/compute-envs/azure-cloud.md
+++ b/platform-cloud/docs/compute-envs/azure-cloud.md
@@ -168,7 +168,12 @@ This role definition can be applied as-is for convenience, or it can be broken d
 
 #### Compute environment creation
 
-The following permissions are required to provision resources in the Azure account when first creating the compute environment. If you specify an existing virtual network, `Microsoft.Network/virtualNetworks/write` and `Microsoft.Network/virtualNetworks/subnets/write` can be omitted from this role, as Platform skips network provisioning and never writes to your VNet or its subnets.
+The following permissions are required to provision resources in the Azure account when first creating the compute environment. 
+
+
+- If you specify an existing virtual network:
+    -  `Microsoft.Network/virtualNetworks/write` and `Microsoft.Network/virtualNetworks/subnets/write` can be omitted from this role, as Platform skips network provisioning and never writes to your VNet or its subnets.
+    - `Microsoft.Network/virtualNetworks/delete` and `Microsoft.Network/virtualNetworks/subnets/delete` become optional.
 
 ```json
 {

--- a/platform-cloud/docs/compute-envs/azure-cloud.md
+++ b/platform-cloud/docs/compute-envs/azure-cloud.md
@@ -168,7 +168,7 @@ This role definition can be applied as-is for convenience, or it can be broken d
 
 #### Compute environment creation
 
-The following permissions are required to provision resources in the Azure account when first creating the compute environment. If you specify an existing virtual network, the `virtualNetworks/write`, `subnets/write` permissions are not required, as Seqera skips network provisioning entirely.
+The following permissions are required to provision resources in the Azure account when first creating the compute environment. If you specify an existing virtual network, `Microsoft.Network/virtualNetworks/write` and `Microsoft.Network/virtualNetworks/subnets/write` can be omitted from this role, as Seqera skips network provisioning and never writes to your VNet or its subnets.
 
 ```json
 {

--- a/platform-cloud/docs/compute-envs/azure-cloud.md
+++ b/platform-cloud/docs/compute-envs/azure-cloud.md
@@ -53,6 +53,13 @@ Nextflow_log_CL | where workflowId == "<WORKFLOW_ID>"
 
 The table retains logs for 7 days. Nextflow uploads log files to Azure Storage for long-term storage.
 
+## Networking
+
+Azure Cloud compute environments use a private-only networking model:
+
+- **No public IP**: VMs are launched without a public IP address. All connectivity between Seqera Platform and the VM is routed via private networking. If you specify a BYO VNet, ensure it has outbound connectivity to Azure services (Storage, Entra ID, Log Analytics) and to Seqera Platform.
+- **Entra ID only**: Azure Cloud credentials require Microsoft Entra ID (client ID and client secret). Storage account key–based credentials are not supported. This applies to both the Forge-provisioned VNet and any BYO VNet.
+
 ## Requirements
 
 ### Platform credentials

--- a/platform-cloud/docs/compute-envs/azure-cloud.md
+++ b/platform-cloud/docs/compute-envs/azure-cloud.md
@@ -38,7 +38,7 @@ Seqera will create the following resources in Azure when creating the compute en
 - One log analytics workspace: Used to collect and query execution logs.
 - One data collection rule: To route execution logs to the appropriate Log Analytics table.
 - One data collection endpoint: The endpoint that receives logs, tied to the data collection rule.
-- One virtual network: The network in which virtual machines are launched. This resource is only created when no existing virtual network is specified in **Advanced options**. When you provide your own VNet, Seqera uses it directly and no network resources are provisioned.
+- One virtual network: The network in which virtual machines are launched. This resource is only created when no existing virtual network is specified in **Advanced options**. When you provide your own VNet, Platform uses it directly and no network resources are provisioned.
 
 When virtual machines are launched, other resources are provisioned for each machine and tied to the machine lifecycle:
 
@@ -57,7 +57,7 @@ The table retains logs for 7 days. Nextflow uploads log files to Azure Storage f
 
 Azure Cloud compute environments use a private-only networking model:
 
-- **No public IP**: VMs are launched without a public IP address. All connectivity between Seqera Platform and the VM is routed via private networking. If you specify an existing VNet, ensure it has outbound connectivity to Azure services (Storage, Entra ID, Log Analytics) and to Seqera Platform.
+- **No public IP**: VMs are launched without a public IP address. All connectivity between Platform and the VM is routed via private networking. If you specify an existing VNet, ensure it has outbound connectivity to Azure services (Storage, Entra ID, Log Analytics) and to Platform.
 - **Entra ID only**: Azure Cloud credentials require Microsoft Entra ID (client ID and client secret). Storage account key–based credentials are not supported. This applies to both Forge-provisioned and existing virtual networks.
 
 ## Requirements
@@ -168,7 +168,7 @@ This role definition can be applied as-is for convenience, or it can be broken d
 
 #### Compute environment creation
 
-The following permissions are required to provision resources in the Azure account when first creating the compute environment. If you specify an existing virtual network, `Microsoft.Network/virtualNetworks/write` and `Microsoft.Network/virtualNetworks/subnets/write` can be omitted from this role, as Seqera skips network provisioning and never writes to your VNet or its subnets.
+The following permissions are required to provision resources in the Azure account when first creating the compute environment. If you specify an existing virtual network, `Microsoft.Network/virtualNetworks/write` and `Microsoft.Network/virtualNetworks/subnets/write` can be omitted from this role, as Platform skips network provisioning and never writes to your VNet or its subnets.
 
 ```json
 {
@@ -467,7 +467,7 @@ Create a compute environment in Seqera using the credentials:
 
 - (Optional) **Subscription ID**: The ID of the subscription where resources must be deployed. If not specified, the subscription ID of the credentials is used.
 - **Instance Type**: The virtual machine type used by the compute environment. Choosing the instance type will directly allocate the CPU and memory available for computation. See [virtual machine sizes](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/overview) for a comprehensive list of instance types and their resource limitations.
-- **Virtual network**: An existing Azure virtual network (VNet) in the configured location. The drop-down is populated with VNets discovered in your Azure account for the selected location. When specified, Seqera uses this network for all VMs launched in this compute environment and skips network provisioning. Leave blank to let Seqera provision a dedicated VNet automatically.
+- **Virtual network**: An existing Azure virtual network (VNet) in the configured location. The drop-down is populated with VNets discovered in your Azure account for the selected location. When specified, Platform uses this network for all VMs launched in this compute environment and skips network provisioning. Leave blank to let Platform provision a dedicated VNet automatically.
 
   :::note
   The VNet must exist in the same location as the compute environment. Specifying a VNet that does not exist in the location, or a subnet that does not belong to the selected VNet, causes compute environment creation to fail.

--- a/platform-cloud/docs/compute-envs/azure-cloud.md
+++ b/platform-cloud/docs/compute-envs/azure-cloud.md
@@ -57,8 +57,8 @@ The table retains logs for 7 days. Nextflow uploads log files to Azure Storage f
 
 Azure Cloud compute environments use a private-only networking model:
 
-- **No public IP**: VMs are launched without a public IP address. All connectivity between Seqera Platform and the VM is routed via private networking. If you specify a BYO VNet, ensure it has outbound connectivity to Azure services (Storage, Entra ID, Log Analytics) and to Seqera Platform.
-- **Entra ID only**: Azure Cloud credentials require Microsoft Entra ID (client ID and client secret). Storage account key–based credentials are not supported. This applies to both the Forge-provisioned VNet and any BYO VNet.
+- **No public IP**: VMs are launched without a public IP address. All connectivity between Seqera Platform and the VM is routed via private networking. If you specify an existing VNet, ensure it has outbound connectivity to Azure services (Storage, Entra ID, Log Analytics) and to Seqera Platform.
+- **Entra ID only**: Azure Cloud credentials require Microsoft Entra ID (client ID and client secret). Storage account key–based credentials are not supported. This applies to both Forge-provisioned and existing virtual networks.
 
 ## Requirements
 

--- a/platform-cloud/docs/compute-envs/azure-cloud.md
+++ b/platform-cloud/docs/compute-envs/azure-cloud.md
@@ -2,7 +2,7 @@
 title: "Azure Cloud"
 description: "Instructions to set up an Azure Cloud compute environment in Seqera Platform"
 date created: "2025-09-29"
-last updated: "2026-05-05"
+last updated: "2026-07-22"
 tags: [cloud, vm, azure, compute environments]
 ---
 
@@ -38,7 +38,7 @@ Seqera will create the following resources in Azure when creating the compute en
 - One log analytics workspace: Used to collect and query execution logs.
 - One data collection rule: To route execution logs to the appropriate Log Analytics table.
 - One data collection endpoint: The endpoint that receives logs, tied to the data collection rule.
-- One virtual network: The network in which virtual machines are launched.
+- One virtual network: The network in which virtual machines are launched. This resource is only created when no existing virtual network is specified in **Advanced options**. When you provide your own VNet, Seqera uses it directly and no network resources are provisioned.
 
 When virtual machines are launched, other resources are provisioned for each machine and tied to the machine lifecycle:
 
@@ -460,3 +460,10 @@ Create a compute environment in Seqera using the credentials:
 
 - (Optional) **Subscription ID**: The ID of the subscription where resources must be deployed. If not specified, the subscription ID of the credentials is used.
 - **Instance Type**: The virtual machine type used by the compute environment. Choosing the instance type will directly allocate the CPU and memory available for computation. See [virtual machine sizes](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/overview) for a comprehensive list of instance types and their resource limitations.
+- **Virtual network**: An existing Azure virtual network (VNet) in the configured location. The drop-down is populated with VNets discovered in your Azure account for the selected location. When specified, Seqera uses this network for all VMs launched in this compute environment and skips network provisioning. Leave blank to let Seqera provision a dedicated VNet automatically.
+
+  :::note
+  The VNet must exist in the same location as the compute environment. Specifying a VNet that does not exist in the location, or a subnet that does not belong to the selected VNet, causes compute environment creation to fail.
+  :::
+
+- **Subnets**: One or more subnet names within the selected VNet. VMs are placed in the first listed subnet at launch time. Leave blank to use the first available subnet on the VNet. This field has no effect when no VNet is specified.

--- a/platform-cloud/docs/compute-envs/azure-cloud.md
+++ b/platform-cloud/docs/compute-envs/azure-cloud.md
@@ -168,7 +168,7 @@ This role definition can be applied as-is for convenience, or it can be broken d
 
 #### Compute environment creation
 
-The following permissions are required to provision resources in the Azure account when first creating the compute environment:
+The following permissions are required to provision resources in the Azure account when first creating the compute environment. If you specify an existing virtual network, the `virtualNetworks/write`, `subnets/write` permissions are not required, as Seqera skips network provisioning entirely.
 
 ```json
 {
@@ -473,4 +473,4 @@ Create a compute environment in Seqera using the credentials:
   The VNet must exist in the same location as the compute environment. Specifying a VNet that does not exist in the location, or a subnet that does not belong to the selected VNet, causes compute environment creation to fail.
   :::
 
-- **Subnets**: One or more subnet names within the selected VNet. VMs are placed in the first listed subnet at launch time. Leave blank to use the first available subnet on the VNet. This field has no effect when no VNet is specified.
+- **Subnets**: One or more subnet names within the selected VNet. VMs are placed in the first listed subnet at launch time. Leave blank to use the first available subnet on the VNet. This field has no effect when no VNet is specified. Any [network security groups (NSGs)](https://learn.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview) attached to the selected subnet are applied to VMs launched in this compute environment.


### PR DESCRIPTION
## Summary

Documents the bring-your-own virtual network (BYO VNet) capability added to Azure Cloud compute environments in COMP-1995 / [platform#11709](https://github.com/seqeralabs/platform/pull/11709). Cloud deployments only.

- **Advanced options**: adds **Virtual network** and **Subnets** fields with full behaviour description — blank means Seqera provisions a dedicated VNet; specifying an existing VNet causes Seqera to skip network provisioning entirely
- **Created resources**: clarifies that the VNet resource is only created when no BYO VNet is specified
- Validation behaviour documented inline: VNet must exist in the configured location; subnets must belong to the selected VNet; mismatches fail at CE creation time

No permission changes required — `Microsoft.Network/virtualNetworks/read` and `subnets/join/action` are already present in the existing role definitions.

## Test plan

- [ ] Verify VNet/Subnet fields appear in the Advanced options section of the rendered page
- [ ] Confirm the Created resources caveat reads correctly
- [ ] Check the note on validation failure renders as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)