### PR TITLE
chore: remove unused AzureCloud permissions

### DIFF
--- a/platform-cloud/docs/compute-envs/azure-cloud.md
+++ b/platform-cloud/docs/compute-envs/azure-cloud.md
@@ -86,11 +86,6 @@ For granular control over the permissions granted to Seqera, use [Azure custom r
                     "Microsoft.Resources/subscriptions/resourceGroups/read",
                     "Microsoft.Resources/subscriptions/resourceGroups/delete",
 
-                    "Microsoft.Network/publicIPAddresses/read",
-                    "Microsoft.Network/publicIPAddresses/write",
-                    "Microsoft.Network/publicIPAddresses/delete",
-                    "Microsoft.Network/publicIPAddresses/join/action",
-
                     "Microsoft.Network/virtualNetworks/read",
                     "Microsoft.Network/virtualNetworks/write",
                     "Microsoft.Network/virtualNetworks/delete",
@@ -232,11 +227,6 @@ The following permissions are required to launch pipelines and Studios:
                     "Microsoft.Compute/virtualMachines/deallocate/action",
                     "Microsoft.Compute/virtualMachines/attachDetachDataDisks/action",
 
-                    "Microsoft.Network/publicIPAddresses/read",
-                    "Microsoft.Network/publicIPAddresses/write",
-                    "Microsoft.Network/publicIPAddresses/delete",
-                    "Microsoft.Network/publicIPAddresses/join/action",
-
                     "Microsoft.Network/networkInterfaces/read",
                     "Microsoft.Network/networkInterfaces/write",
                     "Microsoft.Network/networkInterfaces/join/action",
@@ -363,7 +353,6 @@ The following permissions are required to delete the resources created for the c
             {
                 "actions": [
                     "Microsoft.Resources/subscriptions/resourceGroups/delete",
-                    "Microsoft.Network/publicIPAddresses/delete",
                     "Microsoft.Network/virtualNetworks/delete",
                     "Microsoft.Network/virtualNetworks/subnets/delete",
                     "Microsoft.Network/networkInterfaces/delete",

--- a/platform-enterprise_docs/compute-envs/azure-cloud.md
+++ b/platform-enterprise_docs/compute-envs/azure-cloud.md
@@ -86,11 +86,6 @@ For granular control over the permissions granted to Seqera, use [Azure custom r
                     "Microsoft.Resources/subscriptions/resourceGroups/read",
                     "Microsoft.Resources/subscriptions/resourceGroups/delete",
 
-                    "Microsoft.Network/publicIPAddresses/read",
-                    "Microsoft.Network/publicIPAddresses/write",
-                    "Microsoft.Network/publicIPAddresses/delete",
-                    "Microsoft.Network/publicIPAddresses/join/action",
-
                     "Microsoft.Network/virtualNetworks/read",
                     "Microsoft.Network/virtualNetworks/write",
                     "Microsoft.Network/virtualNetworks/delete",
@@ -230,11 +225,6 @@ The following permissions are required to launch pipelines and Studios:
                     "Microsoft.Compute/virtualMachines/deallocate/action",
                     "Microsoft.Compute/virtualMachines/attachDetachDataDisks/action",
 
-                    "Microsoft.Network/publicIPAddresses/read",
-                    "Microsoft.Network/publicIPAddresses/write",
-                    "Microsoft.Network/publicIPAddresses/delete",
-                    "Microsoft.Network/publicIPAddresses/join/action",
-
                     "Microsoft.Network/networkInterfaces/read",
                     "Microsoft.Network/networkInterfaces/write",
                     "Microsoft.Network/networkInterfaces/join/action",
@@ -333,7 +323,6 @@ The following permissions are required to delete the resources created for the c
             {
                 "actions": [
                     "Microsoft.Resources/subscriptions/resourceGroups/delete",
-                    "Microsoft.Network/publicIPAddresses/delete",
                     "Microsoft.Network/virtualNetworks/delete",
                     "Microsoft.Network/virtualNetworks/subnets/delete",
                     "Microsoft.Network/networkInterfaces/delete",


### PR DESCRIPTION
Permissions to use Public IPs were added to the permission set during the development of the feature to be able to directly SSH into the machine, but they are not needed to run workflows or studios as per the feature was shipped.