### PR TITLE
docs: clarify Co-Scientist additional credits are purchased (25.3)

### DIFF
--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/authentication.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/authentication.md
@@ -10,10 +10,10 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
+Qualifying Seqera Cloud users receive $100 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
-Seqera AI uses your Seqera Platform account for authentication. This page describes authentication concepts and step-by-step instructions for managing your sessions.
+Co-Scientist uses your Seqera Platform account for authentication. This page describes authentication concepts and step-by-step instructions for managing your sessions.
 
 ## Authenticating Seqera AI
 

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/authentication.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/authentication.md
@@ -1,7 +1,8 @@
 ---
 title: "Authentication"
 description: "Login, logout, and session management for Seqera AI CLI"
-date: "15 Dec 2025"
+date created: "2025-12-15"
+last updated: "2026-07-23"
 tags: [seqera ai, cli, authentication, login]
 ---
 
@@ -13,7 +14,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 Qualifying Seqera Cloud users receive $100 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
-Co-Scientist uses your Seqera Platform account for authentication. This page describes authentication concepts and step-by-step instructions for managing your sessions.
+Seqera AI uses your Seqera Platform account for authentication. This page describes authentication concepts and step-by-step instructions for managing your sessions.
 
 ## Authenticating Seqera AI
 

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/authentication.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/authentication.md
@@ -10,7 +10,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) for additional credits.
+Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 Seqera AI uses your Seqera Platform account for authentication. This page describes authentication concepts and step-by-step instructions for managing your sessions.

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/authentication.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/authentication.md
@@ -10,7 +10,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
+Seqera Cloud users receive $20 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 Seqera AI uses your Seqera Platform account for authentication. This page describes authentication concepts and step-by-step instructions for managing your sessions.

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/command-approval.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/command-approval.md
@@ -10,10 +10,10 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
+Qualifying Seqera Cloud users receive $100 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
-Seqera AI can execute local commands and edit files in your environment. This page explains approval modes that control which operations run automatically versus which require your permission, including dangerous commands, workspace boundaries, and best practices.
+Co-Scientist can execute local commands and edit files in your environment. This page explains approval modes that control which operations run automatically versus which require your permission, including dangerous commands, workspace boundaries, and best practices.
 
 ## Approval prompts
 

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/command-approval.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/command-approval.md
@@ -10,7 +10,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) for additional credits.
+Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 Seqera AI can execute local commands and edit files in your environment. This page explains approval modes that control which operations run automatically versus which require your permission, including dangerous commands, workspace boundaries, and best practices.

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/command-approval.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/command-approval.md
@@ -10,7 +10,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
+Seqera Cloud users receive $20 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 Seqera AI can execute local commands and edit files in your environment. This page explains approval modes that control which operations run automatically versus which require your permission, including dangerous commands, workspace boundaries, and best practices.

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/command-approval.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/command-approval.md
@@ -1,7 +1,8 @@
 ---
 title: "Command approval"
 description: "Control which local commands require user approval in Seqera AI"
-date: "15 Dec 2025"
+date created: "2025-12-15"
+last updated: "2026-07-23"
 tags: [seqera ai, cli, approval, security]
 ---
 
@@ -13,7 +14,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 Qualifying Seqera Cloud users receive $100 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
-Co-Scientist can execute local commands and edit files in your environment. This page explains approval modes that control which operations run automatically versus which require your permission, including dangerous commands, workspace boundaries, and best practices.
+Seqera AI can execute local commands and edit files in your environment. This page explains approval modes that control which operations run automatically versus which require your permission, including dangerous commands, workspace boundaries, and best practices.
 
 ## Approval prompts
 

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/get-started.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/get-started.md
@@ -1,7 +1,8 @@
 ---
 title: "Get started"
 description: "AI-powered assistant for bioinformatics workflows and Seqera Platform"
-date: "2025-12-16"
+date created: "2025-12-16"
+last updated: "2026-07-23"
 tags: [seqera ai, cli, ai]
 ---
 

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/get-started.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/get-started.md
@@ -10,7 +10,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
+Qualifying Seqera Cloud users receive $100 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 ## Get started

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/get-started.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/get-started.md
@@ -10,7 +10,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) for additional credits.
+Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 ## Get started

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/get-started.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/get-started.md
@@ -10,7 +10,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
+Seqera Cloud users receive $20 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 ## Get started

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/index.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/index.md
@@ -10,7 +10,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) for additional credits.
+Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 Seqera AI CLI is an intelligent command-line assistant that helps you build, run, and manage bioinformatics workflows. Powered by advanced AI, it provides an interactive terminal experience for working with Nextflow pipelines and Seqera Platform.

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/index.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/index.md
@@ -1,7 +1,8 @@
 ---
 title: "Seqera AI CLI"
 description: "AI-powered assistant for bioinformatics workflows and Seqera Platform"
-date: "2025-12-15"
+date created: "2025-12-15"
+last updated: "2026-07-23"
 tags: [seqera ai, cli, ai]
 ---
 
@@ -13,7 +14,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 Qualifying Seqera Cloud users receive $100 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
-Seqera CLI is an intelligent command-line assistant that helps you build, run, and manage bioinformatics workflows. Powered by advanced AI, it provides an interactive terminal experience for working with Nextflow pipelines and Seqera Platform.
+Seqera AI CLI is an intelligent command-line assistant that helps you build, run, and manage bioinformatics workflows. Powered by advanced AI, it provides an interactive terminal experience for working with Nextflow pipelines and Seqera Platform.
 
 Seqera AI has access to:
 

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/index.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/index.md
@@ -10,7 +10,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
+Seqera Cloud users receive $20 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 Seqera AI CLI is an intelligent command-line assistant that helps you build, run, and manage bioinformatics workflows. Powered by advanced AI, it provides an interactive terminal experience for working with Nextflow pipelines and Seqera Platform.

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/index.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/index.md
@@ -10,10 +10,10 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
+Qualifying Seqera Cloud users receive $100 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
-Seqera AI CLI is an intelligent command-line assistant that helps you build, run, and manage bioinformatics workflows. Powered by advanced AI, it provides an interactive terminal experience for working with Nextflow pipelines and Seqera Platform.
+Seqera CLI is an intelligent command-line assistant that helps you build, run, and manage bioinformatics workflows. Powered by advanced AI, it provides an interactive terminal experience for working with Nextflow pipelines and Seqera Platform.
 
 Seqera AI has access to:
 

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/installation.mdx
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/installation.mdx
@@ -1,7 +1,8 @@
 ---
 title: "Installation"
 description: "Install and configure Seqera AI CLI"
-date: "15 Dec 2025"
+date created: "2025-12-15"
+last updated: "2026-07-23"
 tags: [seqera ai, cli, installation]
 ---
 

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/installation.mdx
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/installation.mdx
@@ -13,7 +13,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
+Qualifying Seqera Cloud users receive $100 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 ## Requirements

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/installation.mdx
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/installation.mdx
@@ -13,7 +13,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
+Seqera Cloud users receive $20 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 ## Requirements

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/installation.mdx
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/installation.mdx
@@ -13,7 +13,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) for additional credits.
+Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 ## Requirements

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/use-cases.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/use-cases.md
@@ -10,7 +10,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
+Seqera Cloud users receive $20 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 Seqera AI is an intelligent command-line assistant that helps you build, run, and manage bioinformatics workflows. The following sections describe several common use cases.

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/use-cases.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/use-cases.md
@@ -10,10 +10,10 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
+Qualifying Seqera Cloud users receive $100 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
-Seqera AI is an intelligent command-line assistant that helps you build, run, and manage bioinformatics workflows. The following sections describe several common use cases.
+Co-Scientist is an intelligent command-line assistant that helps you build, run, and manage bioinformatics workflows. The following sections describe several common use cases.
 
 ## Work with Nextflow
 

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/use-cases.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/use-cases.md
@@ -10,7 +10,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 :::
 
 :::note
-Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) for additional credits.
+Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
 Seqera AI is an intelligent command-line assistant that helps you build, run, and manage bioinformatics workflows. The following sections describe several common use cases.

--- a/platform-enterprise_versioned_docs/version-25.3/co-scientist/use-cases.md
+++ b/platform-enterprise_versioned_docs/version-25.3/co-scientist/use-cases.md
@@ -1,7 +1,8 @@
 ---
 title: "Use cases"
 description: "Learn how to use Seqera AI CLI for bioinformatics workflows, pipeline development, and data management"
-date: "2025-12-15"
+date created: "2025-12-15"
+last updated: "2026-07-23"
 tags: [seqera ai, cli, ai, use cases]
 ---
 
@@ -13,7 +14,7 @@ Seqera AI CLI is currently in beta. Features and commands may change as we conti
 Qualifying Seqera Cloud users receive $100 in free credits to get started with Co-Scientist. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) to purchase additional credits.
 :::
 
-Co-Scientist is an intelligent command-line assistant that helps you build, run, and manage bioinformatics workflows. The following sections describe several common use cases.
+Seqera AI is an intelligent command-line assistant that helps you build, run, and manage bioinformatics workflows. The following sections describe several common use cases.
 
 ## Work with Nextflow
 


### PR DESCRIPTION
Rewords the Co-Scientist credit note in the frozen `version-25.3` snapshots so the $20 starter credits are not read as implying that *additional* credits are free.

The original link (`https://seqera.io/platform/seqera-ai/request-credits/`) is unchanged.

## Change

Across the 6 `version-25.3/co-scientist/` pages (`authentication`, `index`, `get-started`, `use-cases`, `command-approval`, `installation`):

> Seqera Cloud users receive $20 in free credits to get started with Seqera AI. [Contact us](https://seqera.io/platform/seqera-ai/request-credits/) ~~for~~ **to purchase** additional credits.

## Context

A repo-wide sweep confirmed the **live** docs do not imply additional credits are free — `platform-cloud/docs/co-scientist/credits.md` already frames them as purchased ("Organizations can purchase additional credits") and says nothing about "free." The only spot placing "free" next to the additional-credits ask was the 25.3 snapshots, addressed here. No live pages changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)