### PR TITLE
docs(compute-envs): backfill VNet/VPC networking Advanced options for Enterprise Cloud CEs

### DIFF
--- a/platform-cloud/docs/compute-envs/google-cloud.md
+++ b/platform-cloud/docs/compute-envs/google-cloud.md
@@ -190,5 +190,14 @@ If WIF authentication fails at runtime, verify that:
 - **Image**: The image defining the operating system and pre-installed software for the VM. Currently only [Ubuntu LTS](https://cloud.google.com/compute/docs/images/os-details#ubuntu_lts) Google public image project images are available and supported. For GPU-enabled instances, a Deep Learning VM base image with CUDA pre-installed is automatically selected (See [Google Deep Learning VM Images](https://cloud.google.com/deep-learning-vm/docs/images#base_versions) for more details). Optimized, Seqera-owned custom images will be available in a future release.
 - **Boot disk size**: The size of the boot disk for the Compute Engine instance. A standard persistent disk (`pd-standard`) is used. If undefined, a default 50 GB volume will be used.
 - **Zone**: The [zone](https://cloud.google.com/compute/docs/regions-zones) within the selected region where the VM will be provisioned (defaults to the first zone in the alphabetical list).
+- **VPC**: An existing VPC network in your Google Cloud project. The drop-down is populated with networks discovered in your project. When specified, Platform uses this network for all VMs launched in this compute environment. Leave blank to use the project's default network. Free-form values are also accepted for Shared VPC or fully qualified network references.
+
+  :::note
+  Specifying a subnet that does not exist in the compute environment region, or that does not belong to the selected VPC, causes compute environment creation to fail.
+  :::
+
+- **Subnets**: One or more subnet names within the selected VPC and the compute environment region. Single-instance execution places VMs in the first listed subnet; Intelligent Compute may distribute worker VMs across all listed subnets, in order. Leave blank to let Platform select the first available subnet on the network. This field has no effect when no VPC is specified.
+- **Network tags**: Network tags applied to launched VMs for firewall rule targeting. Tags must be lowercase and contain only letters, numbers, and hyphens (1–63 characters). This field has no effect when no VPC is specified.
+- **Use private address**: Select this option to launch VMs without a public IP address. The selected VPC must provide outbound internet access through Cloud NAT and Private Google Access.
 
 [data-explorer]: ../data/data-explorer

--- a/platform-enterprise_docs/compute-envs/azure-cloud.md
+++ b/platform-enterprise_docs/compute-envs/azure-cloud.md
@@ -419,3 +419,10 @@ Create a compute environment in Seqera using the credentials:
 
 - (Optional) **Subscription ID**: The ID of the subscription where resources must be deployed. If not specified, the subscription ID of the credentials is used.
 - **Instance Type**: The virtual machine type used by the compute environment. Choosing the instance type will directly allocate the CPU and memory available for computation. See [virtual machine sizes](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/overview) for a comprehensive list of instance types and their resource limitations.
+- **Virtual network**: An existing Azure virtual network (VNet) in the configured location. The drop-down is populated with VNets discovered in your Azure account for the selected location. When specified, Platform uses this network for all VMs launched in this compute environment and skips network provisioning. Leave blank to let Platform provision a dedicated VNet automatically.
+
+  :::note
+  The VNet must exist in the same location as the compute environment. Specifying a VNet that does not exist in the location, or a subnet that does not belong to the selected VNet, causes compute environment creation to fail.
+  :::
+
+- **Subnets**: One or more subnet names within the selected VNet. VMs are placed in the first listed subnet at launch time. Leave blank to use the first available subnet on the VNet. This field has no effect when no VNet is specified. Any [network security groups (NSGs)](https://learn.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview) attached to the selected subnet are applied to VMs launched in this compute environment.

--- a/platform-enterprise_docs/compute-envs/google-cloud.md
+++ b/platform-enterprise_docs/compute-envs/google-cloud.md
@@ -103,3 +103,12 @@ If your Google Cloud project does not require access restrictions on any of its 
 - **Image**: The image defining the operating system and pre-installed software for the VM. Currently only [Ubuntu LTS](https://cloud.google.com/compute/docs/images/os-details#ubuntu_lts) Google public image project images are available and supported. For GPU-enabled instances, a Deep Learning VM base image with CUDA pre-installed is automatically selected (See [Google Deep Learning VM Images](https://cloud.google.com/deep-learning-vm/docs/images#base_versions) for more details). Optimized, Seqera-owned custom images will be available in a future release.
 - **Boot disk size**: The size of the boot disk for the Compute Engine instance. A standard persistent disk (`pd-standard`) is used. If undefined, a default 50 GB volume will be used.
 - **Zone**: The [zone](https://cloud.google.com/compute/docs/regions-zones) within the selected region where the VM will be provisioned (defaults to the first zone in the alphabetical list).
+- **VPC**: An existing VPC network in your Google Cloud project. The drop-down is populated with networks discovered in your project. When specified, Platform uses this network for all VMs launched in this compute environment. Leave blank to use the project's default network. Free-form values are also accepted for Shared VPC or fully qualified network references.
+
+  :::note
+  Specifying a subnet that does not exist in the compute environment region, or that does not belong to the selected VPC, causes compute environment creation to fail.
+  :::
+
+- **Subnets**: One or more subnet names within the selected VPC and the compute environment region. Single-instance execution places VMs in the first listed subnet; Intelligent Compute may distribute worker VMs across all listed subnets, in order. Leave blank to let Platform select the first available subnet on the network. This field has no effect when no VPC is specified.
+- **Network tags**: Network tags applied to launched VMs for firewall rule targeting. Tags must be lowercase and contain only letters, numbers, and hyphens (1–63 characters). This field has no effect when no VPC is specified.
+- **Use private address**: Select this option to launch VMs without a public IP address. The selected VPC must provide outbound internet access through Cloud NAT and Private Google Access.

--- a/platform-enterprise_versioned_docs/version-26.1/compute-envs/azure-cloud.md
+++ b/platform-enterprise_versioned_docs/version-26.1/compute-envs/azure-cloud.md
@@ -430,3 +430,10 @@ Create a compute environment in Seqera using the credentials:
 
 - (Optional) **Subscription ID**: The ID of the subscription where resources must be deployed. If not specified, the subscription ID of the credentials is used.
 - **Instance Type**: The virtual machine type used by the compute environment. Choosing the instance type will directly allocate the CPU and memory available for computation. See [virtual machine sizes](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/overview) for a comprehensive list of instance types and their resource limitations.
+- **Virtual network**: An existing Azure virtual network (VNet) in the configured location. The drop-down is populated with VNets discovered in your Azure account for the selected location. When specified, Platform uses this network for all VMs launched in this compute environment and skips network provisioning. Leave blank to let Platform provision a dedicated VNet automatically.
+
+  :::note
+  The VNet must exist in the same location as the compute environment. Specifying a VNet that does not exist in the location, or a subnet that does not belong to the selected VNet, causes compute environment creation to fail.
+  :::
+
+- **Subnets**: One or more subnet names within the selected VNet. VMs are placed in the first listed subnet at launch time. Leave blank to use the first available subnet on the VNet. This field has no effect when no VNet is specified. Any [network security groups (NSGs)](https://learn.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview) attached to the selected subnet are applied to VMs launched in this compute environment.

--- a/platform-enterprise_versioned_docs/version-26.1/compute-envs/google-cloud.md
+++ b/platform-enterprise_versioned_docs/version-26.1/compute-envs/google-cloud.md
@@ -103,3 +103,12 @@ If your Google Cloud project does not require access restrictions on any of its 
 - **Image**: The image defining the operating system and pre-installed software for the VM. Currently only [Ubuntu LTS](https://cloud.google.com/compute/docs/images/os-details#ubuntu_lts) Google public image project images are available and supported. For GPU-enabled instances, a Deep Learning VM base image with CUDA pre-installed is automatically selected (See [Google Deep Learning VM Images](https://cloud.google.com/deep-learning-vm/docs/images#base_versions) for more details). Optimized, Seqera-owned custom images will be available in a future release.
 - **Boot disk size**: The size of the boot disk for the Compute Engine instance. A standard persistent disk (`pd-standard`) is used. If undefined, a default 50 GB volume will be used.
 - **Zone**: The [zone](https://cloud.google.com/compute/docs/regions-zones) within the selected region where the VM will be provisioned (defaults to the first zone in the alphabetical list).
+- **VPC**: An existing VPC network in your Google Cloud project. The drop-down is populated with networks discovered in your project. When specified, Platform uses this network for all VMs launched in this compute environment. Leave blank to use the project's default network. Free-form values are also accepted for Shared VPC or fully qualified network references.
+
+  :::note
+  Specifying a subnet that does not exist in the compute environment region, or that does not belong to the selected VPC, causes compute environment creation to fail.
+  :::
+
+- **Subnets**: One or more subnet names within the selected VPC and the compute environment region. Single-instance execution places VMs in the first listed subnet; Intelligent Compute may distribute worker VMs across all listed subnets, in order. Leave blank to let Platform select the first available subnet on the network. This field has no effect when no VPC is specified.
+- **Network tags**: Network tags applied to launched VMs for firewall rule targeting. Tags must be lowercase and contain only letters, numbers, and hyphens (1–63 characters). This field has no effect when no VPC is specified.
+- **Use private address**: Select this option to launch VMs without a public IP address. The selected VPC must provide outbound internet access through Cloud NAT and Private Google Access.


### PR DESCRIPTION
## What

Backfills the network-configuration **Advanced options** that were already documented on the Seqera Cloud compute environment pages but missing from the Enterprise (and versioned 26.1) equivalents. Covers two providers:

### Azure Cloud CE — custom VNet (Stefano's feature)
The Cloud page (`platform-cloud/.../azure-cloud.md`, done by Michael) documents **Virtual network** + **Subnets**, but both Enterprise pages stopped at **Instance Type**. Ported verbatim:
- `platform-enterprise_docs/compute-envs/azure-cloud.md`
- `platform-enterprise_versioned_docs/version-26.1/compute-envs/azure-cloud.md`

### Google Cloud CE — VPC networking
Documents the VPC options from [seqeralabs/platform#11805](https://github.com/seqeralabs/platform/pull/11805) (COMP-2106) — **VPC**, **Subnets**, **Network tags**, **Use private address**. This turned out to be a pre-existing docs gap for the Google Cloud CE, filled across:
- `platform-cloud/docs/compute-envs/google-cloud.md`
- `platform-enterprise_docs/compute-envs/google-cloud.md`
- `platform-enterprise_versioned_docs/version-26.1/compute-envs/google-cloud.md`

## Notes

- Azure content is copied 1:1 from the existing Cloud page for consistency; no rewording.
- Google Cloud wording mirrors the Azure Cloud page's structure (dropdown-discovery framing, `:::note` for validation failure, "leave blank" defaults). One intentional divergence: the GCP **Subnets** bullet notes Intelligent Compute may spread workers across all listed subnets, reflecting the #11805 implementation.
- Text-only changes; no screenshots affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)