### PR TITLE
docs(enterprise): fix broken helm-charts links on Platform Helm page

### DIFF
--- a/platform-enterprise_docs/enterprise/platform-helm.md
+++ b/platform-enterprise_docs/enterprise/platform-helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 :::info Prerequisites <span id="prerequisites" />
 Other than the basic requirements [already listed in the Platform installation overview](./install-platform#prerequisites), you will need:
@@ -27,9 +27,9 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
    Now edit the `my-values.yaml` file to set your options, such as internal container image registry, database connection details, license information, and other settings.
 
-   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/platform-0.36.1/platform/examples/kustomize/values.yaml).
+   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/platform-0.36.1/charts/platform/examples/kustomize/values.yaml).
 
-   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform) file.
+   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) file.
 
 1. Install the chart from the public OCI registry in your desired namespace and with the values file customized in the previous step:
 
@@ -45,7 +45,7 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
 ### Installing a Helm chart with Kustomize
 
-Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform/examples/kustomize).
+Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform/examples/kustomize).
 
 ## Upgrading the Helm chart
 

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/platform-helm.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/platform-helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 ## Prerequisites
 
@@ -27,9 +27,9 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
    Now edit the `my-values.yaml` file to set your options, such as internal container image registry, database connection details, license information, and other settings.
 
-   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/0.36.1/platform/examples/kustomize/values.yaml).
+   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/platform-0.36.1/charts/platform/examples/kustomize/values.yaml).
 
-   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform) file.
+   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) file.
 
 1. Install the chart from the public OCI registry in your desired namespace and with the values file customized in the previous step:
 
@@ -45,7 +45,7 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
 ### Installing a Helm chart with Kustomize
 
-Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform/examples/kustomize).
+Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform/examples/kustomize).
 
 ## Upgrading the Helm chart
 

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/platform-helm.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/platform-helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 ## Prerequisites
 
@@ -27,9 +27,9 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
    Now edit the `my-values.yaml` file to set your options, such as internal container image registry, database connection details, license information, and other settings.
 
-   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/0.36.1/platform/examples/kustomize/values.yaml).
+   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/platform-0.36.1/charts/platform/examples/kustomize/values.yaml).
 
-   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform) file.
+   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) file.
 
 1. Install the chart from the public OCI registry in your desired namespace and with the values file customized in the previous step:
 
@@ -45,7 +45,7 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
 ### Installing a Helm chart with Kustomize
 
-Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform/examples/kustomize).
+Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform/examples/kustomize).
 
 ## Upgrading the Helm chart
 

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/platform-helm.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/platform-helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 :::info Prerequisites <span id="prerequisites" />
 Other than the basic requirements [already listed in the Platform installation overview](./install-platform#prerequisites), you will need:
@@ -27,9 +27,9 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
    Now edit the `my-values.yaml` file to set your options, such as internal container image registry, database connection details, license information, and other settings.
 
-   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/0.36.1/platform/examples/kustomize/values.yaml).
+   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/platform-0.36.1/charts/platform/examples/kustomize/values.yaml).
 
-   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform) file.
+   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) file.
 
 1. Install the chart from the public OCI registry in your desired namespace and with the values file customized in the previous step:
 
@@ -45,7 +45,7 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
 ### Installing a Helm chart with Kustomize
 
-Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform/examples/kustomize).
+Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform/examples/kustomize).
 
 ## Upgrading the Helm chart
 

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-helm.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 :::info Prerequisites <span id="prerequisites" />
 Other than the basic requirements [already listed in the Platform installation overview](./install-platform#prerequisites), you will need:
@@ -27,9 +27,9 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
    Now edit the `my-values.yaml` file to set your options, such as internal container image registry, database connection details, license information, and other settings.
 
-   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/0.36.1/platform/examples/kustomize/values.yaml).
+   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/platform-0.36.1/charts/platform/examples/kustomize/values.yaml).
 
-   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform) file.
+   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) file.
 
 1. Install the chart from the public OCI registry in your desired namespace and with the values file customized in the previous step:
 
@@ -45,7 +45,7 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
 ### Installing a Helm chart with Kustomize
 
-Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform/examples/kustomize).
+Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform/examples/kustomize).
 
 ## Upgrading the Helm chart
 


### PR DESCRIPTION
## Problem

A customer reported (FD-7794) that the **example values file** link on
[Platform Helm](https://docs.seqera.io/platform-enterprise/enterprise/platform-helm) returns a 404.

They were right, and it's not the only one — **all four** `helm-charts` links on that page are broken.

## Root cause

The `seqeralabs/helm-charts` repo was restructured. Two changes broke these links:

1. Charts moved from `<root>/platform/` to `<root>/charts/platform/`.
2. Platform chart tags were renamed from bare `0.36.1` to prefixed `platform-0.36.1` (there is no `0.36.1` tag anymore).

## Fix

| Link text | Before (404) | After (200) |
|---|---|---|
| Helm chart | `tree/0.36.1/platform` | `tree/platform-0.36.1/charts/platform` |
| example values file | `blob/0.36.1/platform/examples/kustomize/values.yaml` | `blob/platform-0.36.1/charts/platform/examples/kustomize/values.yaml` |
| README | `tree/0.36.1/platform` | `tree/platform-0.36.1/charts/platform` |
| Kustomize example directory | `tree/0.36.1/platform/examples/kustomize` | `tree/platform-0.36.1/charts/platform/examples/kustomize` |

Applied to all five copies of the page — the current doc set plus `version-26.1`, `version-25.3`, `version-25.2`, and `version-25.1`. (`version-24.2` and earlier don't have this page.) 20 changed lines, URLs only, no prose changes.

Note that the current doc set already had the `platform-` tag prefix on all four links but was still missing `charts/`, so it was 404ing too.

## Verified

Every URL in the diff status-checked at `200`; a `grep` for the old forms (`helm-charts/{blob,tree}/0.36.1` and `platform-0.36.1/platform`) now returns nothing across both docs trees.

The `helm-charts` links in `studios-helm.md`, `groundswell-helm.md`, `install-groundswell.md`, `co-scientist/prerequisites.md`, and `install-seqera-coscientist.mdx` were also checked and all return `200` — their tags predate the restructure or already point at `master/charts/...` — so they are intentionally untouched.

## Out of scope (flagging for the docs team)

- **Chart version pin.** The page pins `0.36.1` throughout, including in the `helm show values` / `helm install --version` examples. Latest is `platform-0.38.0`. I deliberately did not bump it — that's a content-freshness call, not a link fix, and a released version's docs arguably shouldn't move. Worth a look for the current doc set though.
- **CI gap.** The weekly `Links` workflow globs `'./**/*.mdx'` only, so the 1,896 `.md` files in this repo — including every `platform-helm.md` — are never link-checked, which is why this went unnoticed. Follow-up PR opened separately against `.github/workflows/links.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
