### PR TITLE
docs: Fix 404 helm-charts links on Platform Helm page [EDU-1330]

### DIFF
--- a/platform-enterprise_docs/enterprise/platform-helm.md
+++ b/platform-enterprise_docs/enterprise/platform-helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 :::info Prerequisites <span id="prerequisites" />
 Other than the basic requirements [already listed in the Platform installation overview](./install-platform#prerequisites), you will need:
@@ -27,9 +27,9 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
    Now edit the `my-values.yaml` file to set your options, such as internal container image registry, database connection details, license information, and other settings.
 
-   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/platform-0.36.1/platform/examples/kustomize/values.yaml).
+   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/platform-0.36.1/charts/platform/examples/kustomize/values.yaml).
 
-   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform) file.
+   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) file.
 
 1. Install the chart from the public OCI registry in your desired namespace and with the values file customized in the previous step:
 
@@ -45,7 +45,7 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
 ### Installing a Helm chart with Kustomize
 
-Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform/examples/kustomize).
+Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform/examples/kustomize).
 
 ## Upgrading the Helm chart
 

--- a/platform-enterprise_versioned_docs/version-25.1/enterprise/platform-helm.md
+++ b/platform-enterprise_versioned_docs/version-25.1/enterprise/platform-helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 ## Prerequisites
 
@@ -27,9 +27,9 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
    Now edit the `my-values.yaml` file to set your options, such as internal container image registry, database connection details, license information, and other settings.
 
-   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/0.36.1/platform/examples/kustomize/values.yaml).
+   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/platform-0.36.1/charts/platform/examples/kustomize/values.yaml).
 
-   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform) file.
+   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) file.
 
 1. Install the chart from the public OCI registry in your desired namespace and with the values file customized in the previous step:
 
@@ -45,7 +45,7 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
 ### Installing a Helm chart with Kustomize
 
-Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform/examples/kustomize).
+Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform/examples/kustomize).
 
 ## Upgrading the Helm chart
 

--- a/platform-enterprise_versioned_docs/version-25.2/enterprise/platform-helm.md
+++ b/platform-enterprise_versioned_docs/version-25.2/enterprise/platform-helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 ## Prerequisites
 
@@ -27,9 +27,9 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
    Now edit the `my-values.yaml` file to set your options, such as internal container image registry, database connection details, license information, and other settings.
 
-   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/0.36.1/platform/examples/kustomize/values.yaml).
+   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/platform-0.36.1/charts/platform/examples/kustomize/values.yaml).
 
-   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform) file.
+   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) file.
 
 1. Install the chart from the public OCI registry in your desired namespace and with the values file customized in the previous step:
 
@@ -45,7 +45,7 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
 ### Installing a Helm chart with Kustomize
 
-Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform/examples/kustomize).
+Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform/examples/kustomize).
 
 ## Upgrading the Helm chart
 

--- a/platform-enterprise_versioned_docs/version-25.3/enterprise/platform-helm.md
+++ b/platform-enterprise_versioned_docs/version-25.3/enterprise/platform-helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 :::info Prerequisites <span id="prerequisites" />
 Other than the basic requirements [already listed in the Platform installation overview](./install-platform#prerequisites), you will need:
@@ -27,9 +27,9 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
    Now edit the `my-values.yaml` file to set your options, such as internal container image registry, database connection details, license information, and other settings.
 
-   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/0.36.1/platform/examples/kustomize/values.yaml).
+   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/platform-0.36.1/charts/platform/examples/kustomize/values.yaml).
 
-   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform) file.
+   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) file.
 
 1. Install the chart from the public OCI registry in your desired namespace and with the values file customized in the previous step:
 
@@ -45,7 +45,7 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
 ### Installing a Helm chart with Kustomize
 
-Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform/examples/kustomize).
+Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform/examples/kustomize).
 
 ## Upgrading the Helm chart
 

--- a/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-helm.md
+++ b/platform-enterprise_versioned_docs/version-26.1/enterprise/platform-helm.md
@@ -5,7 +5,7 @@ date created: "2025-11-21"
 tags: [helm, deployment, installation, kubernetes]
 ---
 
-[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
+[Helm](https://helm.sh) is an open-source command line tool used for managing Kubernetes applications. Seqera offers a [Helm chart](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) to deploy Seqera Platform Enterprise on a Kubernetes cluster.
 
 :::info Prerequisites <span id="prerequisites" />
 Other than the basic requirements [already listed in the Platform installation overview](./install-platform#prerequisites), you will need:
@@ -27,9 +27,9 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
    Now edit the `my-values.yaml` file to set your options, such as internal container image registry, database connection details, license information, and other settings.
 
-   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/0.36.1/platform/examples/kustomize/values.yaml).
+   You can drop lines that you don't want to customize to keep the file concise and only include the settings you want to change: this will make it easier to maintain your configuration in the future. The values you don't specify will fall back to the defaults defined in the chart in the `values.yaml` file. For an example of a minimal configuration file, see the [example values file](https://github.com/seqeralabs/helm-charts/blob/platform-0.36.1/charts/platform/examples/kustomize/values.yaml).
 
-   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform) file.
+   You can browse all the available configuration options in a tabular format in the [README](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform) file.
 
 1. Install the chart from the public OCI registry in your desired namespace and with the values file customized in the previous step:
 
@@ -45,7 +45,7 @@ The `values.yaml` file defines a chart's settings, such as container image tags,
 
 ### Installing a Helm chart with Kustomize
 
-Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/0.36.1/platform/examples/kustomize).
+Kustomize can be used to manage Helm chart installations as well and provides further customization options. To install the Seqera Platform Enterprise Helm chart using Kustomize, check out the [Kustomize example directory](https://github.com/seqeralabs/helm-charts/tree/platform-0.36.1/charts/platform/examples/kustomize).
 
 ## Upgrading the Helm chart
 


### PR DESCRIPTION
Fixes [EDU-1330](https://seqera.atlassian.net/browse/EDU-1330). Reported by a customer via FD-7794.

## Problem

All four `seqeralabs/helm-charts` links on the Platform Enterprise Helm installation page 404, in every doc version that carries the page (next, 26.1, 25.3, 25.2, 25.1) — 20 dead links. They've been broken since 2026-07-20.

Two independent upstream changes compounded:

1. **Tag rename.** helm-charts renamed its bare-numeric tags to `<chart>-<version>`. Of 242 tags, only `0.16.1` is still un-prefixed, so `/tree/0.36.1/...` can never resolve — and GitHub doesn't redirect a missing ref, so it fails hard.
2. **Monorepo restructure.** The platform chart moved from `platform/` to `charts/platform/` between `platform-0.20.1` and `platform-0.30.0`. This is why even the `next` docs, which *did* carry the `platform-` prefix, still 404.

#1660 substituted `0.20.1` → `0.36.1` in the URLs and changed nothing else, inheriting both the missing prefix and the pre-monorepo path. It also preserved a pre-existing inconsistency — the `next` copy used `platform-0.20.1` while the versioned copies used bare `0.20.1` — so after the bump the two sets fail for different reasons.

## Change

Adds the tag prefix and the `charts/` path segment:

```diff
- https://github.com/seqeralabs/helm-charts/blob/0.36.1/platform/examples/kustomize/values.yaml
+ https://github.com/seqeralabs/helm-charts/blob/platform-0.36.1/charts/platform/examples/kustomize/values.yaml
```

The studios and pipeline-optimization links are deliberately untouched — those charts kept the `platform/charts/<name>` layout and already resolve, so a repo-wide sweep would have broken them.

## Verification

Status-checked every unique helm-charts URL in the repo before and after. 6 of 15 were 404; all 12 distinct URLs now return 200.

```
grep -rhno "https://github.com/seqeralabs/helm-charts/[a-zA-Z0-9./_-]*" --exclude-dir=.git . \
  | sed 's/^[0-9]*://' | sort -u \
  | while read -r u; do echo "$(curl -s -o /dev/null -w '%{http_code}' "$u")  $u"; done | sort
```

The one remaining 301 is GitHub redirecting `tree` → `blob` for `examples/seqera-ai`, which is a file. Pre-existing and harmless.

## Why CI didn't catch this

Worth flagging separately, because it's the more interesting finding. `links.yml` runs lychee over the docs, but its last output was #440 on **2025-02-08** and all 218 runs in the retained history failed. Three independent defects:

- **No `pull_request` trigger.** Triggers are `schedule` (Sunday 18:00), `workflow_dispatch`, `repository_dispatch`. Even a working checker could not have blocked #1660 — at best it would have complained the following Sunday. Only `check-internal-links.yml` gates PRs, and that covers internal links only.
- **lychee rejects its own arguments.** `--base .` has been there since the workflow was written in July 2024, but lychee 2.x requires an absolute path or URL and moved root-relative local resolution to `--root-dir`. The binary exits 2 after ~200ms without checking a link. Because that's an arg-parse error rather than a link failure, `steps.lychee.outputs.exit_code` is never set, so `create-issue-from-file` is skipped too — no report issue, no signal at all.
- **The glob misses 94% of the docs.** Args end in `'./**/*.mdx'`; the enterprise docs are 1284 `.md` against 75 `.mdx`. `platform-helm.md` was never in scope.

Fixing all three (add `pull_request`, swap `--base .` for `--root-dir "$GITHUB_WORKSPACE"`, glob `'./**/*.md*'`) is what would actually catch the next one. Not done here — it's a separate change, and the first successful run will surface 18 months of accumulated rot, so it'll likely need an allowlist or a soft-fail period before it can gate PRs.

## Also not addressed

Editorial, tracked on EDU-1330:

- The chart version is copy-pasted into four URLs across five files. A Docusaurus constant would make the bump a one-liner.
- The 25.1/25.2/25.3 pages point at chart 0.36.1 (appVersion `v26.1.3`), which postdates those releases.
- 0.36.1 is already behind — 0.37.0 and 0.38.0 (appVersion `v26.1.4`) exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDU-1330]: https://seqera.atlassian.net/browse/EDU-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ