### PR TITLE
ci(links): include .md files in the weekly link check

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,13 +18,13 @@ jobs:
           fetch-depth: 1
 
       - name: Remove TODO and README files from link checking
-        run: find platform-enterprise_versioned_docs -type f \( -name 'README.mdx' -o -name '_todo.mdx' \) -exec rm {} +
+        run: find platform-enterprise_versioned_docs -type f \( -name 'README.md' -o -name 'README.mdx' -o -name '_todo.md' -o -name '_todo.mdx' \) -exec rm {} +
 
       - name: Check external links in documentation
         id: lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
-          args: --base . -v -n -s https -s http './**/*.mdx'
+          args: --base . -v -n -s https -s http './**/*.md' './**/*.mdx'
 
       - name: Create GitHub issue for broken links
         if: steps.lychee.outputs.exit_code != 0


### PR DESCRIPTION
## Problem

The weekly `Links` workflow passes lychee a single glob:

```yaml
args: --base . -v -n -s https -s http './**/*.mdx'
```

So only `.mdx` files are checked. This repo has **1,896 `.md` files** against 351 `.mdx` — meaning the large majority of documentation pages have never had their external links validated.

That's how FD-7794 happened: all four `helm-charts` links on `enterprise/platform-helm.md` were 404ing across five doc versions, and a customer found it before CI did, because `platform-helm.md` is a `.md` file. (Link fix: #1705.)

## Change

- Add `'./**/*.md'` to the lychee globs.
- Extend the existing "Remove TODO and README files" cleanup step to also drop `README.md` and `_todo.md` from versioned docs — it already did this for the `.mdx` variants, and there are 9 such `.md` files that should get the same treatment.

## Heads-up for reviewers

The first run after merge will check ~6× more files than before and will very likely file a sizeable **Link Checker Report** issue, since none of these links have ever been validated. That backlog is pre-existing rot being surfaced, not something this PR introduces — but it's worth expecting so it isn't mistaken for a regression. If the volume is unwieldy, the `exclude` list in `lychee.toml` is the place to triage bot-blocking 403s.

YAML validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
