### PR TITLE
chore: fix FUSION_REFRESH_TIMEOUT language to be more explicit

### DIFF
--- a/platform-cloud/docs/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-cloud/docs/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -92,14 +92,14 @@ By default, Fusion does not resync objects from remotely mounted data-link(s) af
 
 If you have a running session with data mounted and the underlying storage is updated, the data is not resynced to the Studio session.
 
-You can change this behavior when you [add a Studio session](../studios/add-studio) by setting the `FUSION_REFRESH_TIMEOUT` environment variable to a number of seconds (e.g., `30`). Fusion then refreshes the view of the mounted data links at that interval.
+You can change this behavior when you [add a Studio session](../studios/add-studio) by setting the `FUSION_REFRESH_TIMEOUT` environment variable to a number of seconds (e.g., `120`). Fusion refreshes the view of the mounted data links at that interval.
 
 :::note
-Setting the environment variable _inside_ an already running Studio session by executing the command `export FUSION_REFRESH_TIMEOUT=30` won't change the behavior of the outer Fusion session. Set the environment variable in the **General config** section during Studio creation.
+Setting the environment variable _inside_ an already running Studio session by executing the command `export FUSION_REFRESH_TIMEOUT=120` won't change the behavior of the outer Fusion session. Set the environment variable in the **General config** section during Studio creation.
 :::
 
 :::warning
-This is an experimental feature and can cause consistency issues in the Fusion namespace, resulting in data loss.
+Fusion has a two minute buffer prior to attempting to upload the working chunk, so the minimum safe setting for `FUSION_REFRESH_TIMEOUT` is `120`. Setting a lower value risks creation of orphaned chunks in the Studio environment which are not recoverable nor ever uploaded back to object storage. 
 :::
 
 ## Custom environments and container images

--- a/platform-cloud/docs/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-cloud/docs/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -99,7 +99,7 @@ Setting the environment variable _inside_ an already running Studio session by e
 :::
 
 :::warning
-Fusion has a two minute buffer prior to attempting to upload the working chunk, so the minimum safe setting for `FUSION_REFRESH_TIMEOUT` is `120`. Setting a lower value risks creation of orphaned chunks in the Studio environment which are not recoverable nor ever uploaded back to object storage. 
+Fusion waits two minutes before it uploads the working chunk. Always set `FUSION_REFRESH_TIMEOUT` to `120` or higher. Lower values can create orphaned chunks in the Studio environment that are never uploaded to object storage and cannot be recovered.
 :::
 
 ## Custom environments and container images

--- a/platform-enterprise_docs/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-enterprise_docs/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -94,7 +94,7 @@ Setting the environment variable _inside_ an already running Studio session by e
 :::
 
 :::warning
-Fusion has a two minute buffer prior to attempting to upload the working chunk, so the minimum safe setting for `FUSION_REFRESH_TIMEOUT` is `120`. Setting a lower value risks creation of orphaned chunks in the Studio environment which are not recoverable nor ever uploaded back to object storage. 
+Fusion waits two minutes before it uploads the working chunk. Always set `FUSION_REFRESH_TIMEOUT` to `120` or higher. Lower values can create orphaned chunks in the Studio environment that are never uploaded to object storage and cannot be recovered.
 :::
 
 ## Custom environments and container images

--- a/platform-enterprise_docs/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-enterprise_docs/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -87,14 +87,14 @@ By default, Fusion does not resync objects from remotely mounted data-link(s) af
 
 If you have a running session with data mounted and the underlying storage is updated, the data is not resynced to the Studio session.
 
-You can change this behavior when you [add a Studio session](../studios/add-studio) by setting the `FUSION_REFRESH_TIMEOUT` environment variable to a number of seconds (e.g., `30`). Fusion then refreshes the view of the mounted data links at that interval.
+You can change this behavior when you [add a Studio session](../studios/add-studio) by setting the `FUSION_REFRESH_TIMEOUT` environment variable to a number of seconds (e.g., `120`). Fusion then refreshes the view of the mounted data links at that interval.
 
 :::note
-Setting the environment variable _inside_ an already running Studio session by executing the command `export FUSION_REFRESH_TIMEOUT=30` won't change the behavior of the outer Fusion session. Set the environment variable in the **General config** section during Studio creation.
+Setting the environment variable _inside_ an already running Studio session by executing the command `export FUSION_REFRESH_TIMEOUT=120` won't change the behavior of the outer Fusion session. Set the environment variable in the **General config** section during Studio creation.
 :::
 
 :::warning
-This is an experimental feature and can cause consistency issues in the Fusion namespace, resulting in data loss.
+Fusion has a two minute buffer prior to attempting to upload the working chunk, so the minimum safe setting for `FUSION_REFRESH_TIMEOUT` is `120`. Setting a lower value risks creation of orphaned chunks in the Studio environment which are not recoverable nor ever uploaded back to object storage. 
 :::
 
 ## Custom environments and container images

--- a/platform-enterprise_versioned_docs/version-25.2/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-enterprise_versioned_docs/version-25.2/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -81,16 +81,16 @@ This is displayed because logging is set to `stderr` by default to ensure all lo
 
 By default, Fusion does not resync objects from remotely mounted data-link(s) after initial mounting.
 
-If you have a running session with data mounted and the underlying storage is updated, the data will not be resynced to the Studio session.
+If you have a running session with data mounted and the underlying storage is updated, the data is not resynced to the Studio session.
 
-You can change this behavior when you [add a Studio session](../studios/add-studio) by defining the `FUSION_REFRESH_TIMEOUT` environment variable to a specified number of seconds (e.g., `30`). This will force Fusion to refresh the view of the mounted data-link(s) at the specified interval.
+You can change this behavior when you [add a Studio session](../studios/add-studio) by setting the `FUSION_REFRESH_TIMEOUT` environment variable to a number of seconds (e.g., `120`). Fusion refreshes the view of the mounted data-links at that interval.
 
 :::note
-Setting the environment variable _inside_ an already running Studio session by executing the command `export FUSION_REFRESH_TIMEOUT=30` won't change the behavior of the outer Fusion session. The environment variable should be set in the "General config" section durion Studio creation.
+Setting the environment variable _inside_ an already running Studio session by executing the command `export FUSION_REFRESH_TIMEOUT=120` won't change the behavior of the outer Fusion session. Set the environment variable in the **General config** section durion Studio creation.
 :::
 
 :::warning
-This is an experimental feature and may cause consistency issues in the Fusion namespace, resulting in data loss.
+Fusion has a two minute buffer prior to attempting to upload the working chunk, so the minimum safe setting for `FUSION_REFRESH_TIMEOUT` is `120`. Setting a lower value risks creation of orphaned chunks in the Studio environment which are not recoverable nor ever uploaded back to object storage. 
 :::
 
 ## Container template image security scan false positives

--- a/platform-enterprise_versioned_docs/version-25.2/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-enterprise_versioned_docs/version-25.2/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -90,7 +90,7 @@ Setting the environment variable _inside_ an already running Studio session by e
 :::
 
 :::warning
-Fusion has a two minute buffer prior to attempting to upload the working chunk, so the minimum safe setting for `FUSION_REFRESH_TIMEOUT` is `120`. Setting a lower value risks creation of orphaned chunks in the Studio environment which are not recoverable nor ever uploaded back to object storage. 
+Fusion waits two minutes before it uploads the working chunk. Always set `FUSION_REFRESH_TIMEOUT` to `120` or higher. Lower values can create orphaned chunks in the Studio environment that are never uploaded to object storage and cannot be recovered.
 :::
 
 ## Container template image security scan false positives

--- a/platform-enterprise_versioned_docs/version-25.3/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-enterprise_versioned_docs/version-25.3/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -87,16 +87,16 @@ This is displayed because logging is set to `stderr` by default to ensure all lo
 
 By default, Fusion does not resync objects from remotely mounted data-link(s) after initial mounting.
 
-If you have a running session with data mounted and the underlying storage is updated, the data will not be resynced to the Studio session.
+If you have a running session with data mounted and the underlying storage is updated, the data is not resynced to the Studio session.
 
-You can change this behavior when you are [adding a Studio session](../studios/add-studio) by defining the `FUSION_REFRESH_TIMEOUT` environment variable to a specified number of seconds (e.g., `30`). This will force Fusion to refresh the view of the mounted data-link(s) at the specified interval.
+You can change this behavior when you [add a Studio session](../studios/add-studio) by setting the `FUSION_REFRESH_TIMEOUT` environment variable to a number of seconds (e.g., `120`). Fusion refreshes the view of the mounted data-links at that interval.
 
 :::note
-Setting the environment variable _inside_ an already running Studio session by executing the command `export FUSION_REFRESH_TIMEOUT=30` won't change the behavior of the outer Fusion session. The environment variable should be set in the "General config" section durion Studio creation.
+Setting the environment variable _inside_ an already running Studio session by executing the command `export FUSION_REFRESH_TIMEOUT=120` won't change the behavior of the outer Fusion session. Set the environment variable in the **General config** section durion Studio creation.
 :::
 
 :::warning
-This is an experimental feature and may cause consistency issues in the Fusion namespace, resulting in data loss.
+Fusion has a two minute buffer prior to attempting to upload the working chunk, so the minimum safe setting for `FUSION_REFRESH_TIMEOUT` is `120`. Setting a lower value risks creation of orphaned chunks in the Studio environment which are not recoverable nor ever uploaded back to object storage. 
 :::
 
 ## When starting an existing Studio session, extra processes are not automatically restarted

--- a/platform-enterprise_versioned_docs/version-25.3/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-enterprise_versioned_docs/version-25.3/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -96,7 +96,7 @@ Setting the environment variable _inside_ an already running Studio session by e
 :::
 
 :::warning
-Fusion has a two minute buffer prior to attempting to upload the working chunk, so the minimum safe setting for `FUSION_REFRESH_TIMEOUT` is `120`. Setting a lower value risks creation of orphaned chunks in the Studio environment which are not recoverable nor ever uploaded back to object storage. 
+Fusion waits two minutes before it uploads the working chunk. Always set `FUSION_REFRESH_TIMEOUT` to `120` or higher. Lower values can create orphaned chunks in the Studio environment that are never uploaded to object storage and cannot be recovered.
 :::
 
 ## When starting an existing Studio session, extra processes are not automatically restarted

--- a/platform-enterprise_versioned_docs/version-26.1/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-enterprise_versioned_docs/version-26.1/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -87,16 +87,16 @@ This is displayed because logging is set to `stderr` by default to ensure all lo
 
 By default, Fusion does not resync objects from remotely mounted data-link(s) after initial mounting.
 
-If you have a running session with data mounted and the underlying storage is updated, the data will not be resynced to the Studio session.
+If you have a running session with data mounted and the underlying storage is updated, the data is not resynced to the Studio session.
 
-You can change this behavior when you are [adding a Studio session](../studios/add-studio) by defining the `FUSION_REFRESH_TIMEOUT` environment variable to a specified number of seconds (e.g., `30`). This will force Fusion to refresh the view of the mounted data-link(s) at the specified interval.
+You can change this behavior when you [add a Studio session](../studios/add-studio) by setting the `FUSION_REFRESH_TIMEOUT` environment variable to a number of seconds (e.g., `120`). Fusion refreshes the view of the mounted data-links at that interval.
 
 :::note
-Setting the environment variable _inside_ an already running Studio session by executing the command `export FUSION_REFRESH_TIMEOUT=30` won't change the behavior of the outer Fusion session. The environment variable should be set in the "General config" section durion Studio creation.
+Setting the environment variable _inside_ an already running Studio session by executing the command `export FUSION_REFRESH_TIMEOUT=120` won't change the behavior of the outer Fusion session. Set the environment variable in the **General config** section durion Studio creation.
 :::
 
 :::warning
-This is an experimental feature and may cause consistency issues in the Fusion namespace, resulting in data loss.
+Fusion has a two minute buffer prior to attempting to upload the working chunk, so the minimum safe setting for `FUSION_REFRESH_TIMEOUT` is `120`. Setting a lower value risks creation of orphaned chunks in the Studio environment which are not recoverable nor ever uploaded back to object storage. 
 :::
 
 ## When starting an existing Studio session, extra processes are not automatically restarted

--- a/platform-enterprise_versioned_docs/version-26.1/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-enterprise_versioned_docs/version-26.1/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -96,7 +96,7 @@ Setting the environment variable _inside_ an already running Studio session by e
 :::
 
 :::warning
-Fusion has a two minute buffer prior to attempting to upload the working chunk, so the minimum safe setting for `FUSION_REFRESH_TIMEOUT` is `120`. Setting a lower value risks creation of orphaned chunks in the Studio environment which are not recoverable nor ever uploaded back to object storage. 
+Fusion waits two minutes before it uploads the working chunk. Always set `FUSION_REFRESH_TIMEOUT` to `120` or higher. Lower values can create orphaned chunks in the Studio environment that are never uploaded to object storage and cannot be recovered.
 :::
 
 ## When starting an existing Studio session, extra processes are not automatically restarted


### PR DESCRIPTION
[Slack discussion](https://seqera.slack.com/archives/C053KDKLEQJ/p1785427337717179)