### PR TITLE
docs: add Claude Code desktop app SSH connection steps for Studios

### DIFF
--- a/platform-cloud/docs/studios/managing.md
+++ b/platform-cloud/docs/studios/managing.md
@@ -340,14 +340,20 @@ Once connected, you can:
 
 ### Claude Code desktop app
 
-Connecting from the Claude Code desktop app requires:
+The Claude Code desktop app requires later Connect versions than SSH access in general.
 
-- **connect-server/proxy v0.12.1 or later**
-- **connect-client v0.13.0 or later**
+:::info[**Prerequisites**]
 
-Earlier versions do not run remote commands through a shell, so the app's environment checks fail on connect.
+You need the following:
 
-The Claude Code desktop app reads `~/.ssh/config`, but its **SSH Host** field accepts a hostname only — it cannot parse the `<username>@<studio-session-id>` pair. Define a host alias, then reference the alias by name.
+- **Connect server and proxy**: Version 0.12.1 or later
+- **Connect client**: Version 0.13.0 or later
+
+:::
+
+Because earlier versions do not run remote commands through a shell, the app's environment checks fail on connect.
+
+The Claude Code desktop app reads `~/.ssh/config`, but its **SSH Host** field accepts a hostname only. It cannot parse the `<username>@<studio-session-id>` pair. Define a host alias, then reference the alias in the app.
 
 1. Add an entry to `~/.ssh/config`:
 
@@ -359,15 +365,15 @@ The Claude Code desktop app reads `~/.ssh/config`, but its **SSH Host** field ac
        IdentityFile ~/.ssh/id_ed25519
    ```
 
-   The `<username>@<studio-session-id>` pair belongs in `User`. Only the connect domain belongs in `HostName`.
+   Put the `<username>@<studio-session-id>` pair in `User`, and only the connect domain in `HostName`.
 
 2. Add an SSH connection in the app:
 
-   - **SSH Host**: `my-studio` — the alias, not the full connection string
+   - **SSH Host**: `my-studio`
    - **SSH Port**: `2222`
 
 :::warning
-Set **SSH Port** explicitly. The app does not apply the `Port` value from `~/.ssh/config` and defaults to port 22, which fails with a handshake timeout.
+Set **SSH Port** explicitly. The app ignores the `Port` value in `~/.ssh/config` and defaults to port 22. The connection then fails with a handshake timeout.
 :::
 
 ### SSH authentication

--- a/platform-cloud/docs/studios/managing.md
+++ b/platform-cloud/docs/studios/managing.md
@@ -338,6 +338,38 @@ Once connected, you can:
 - Debug code running in the Studio
 - Install packages
 
+### Claude Code desktop app
+
+Connecting from the Claude Code desktop app requires:
+
+- **connect-server/proxy v0.12.1 or later**
+- **connect-client v0.13.0 or later**
+
+Earlier versions do not run remote commands through a shell, so the app's environment checks fail on connect.
+
+The Claude Code desktop app reads `~/.ssh/config`, but its **SSH Host** field accepts a hostname only — it cannot parse the `<username>@<studio-session-id>` pair. Define a host alias, then reference the alias by name.
+
+1. Add an entry to `~/.ssh/config`:
+
+   ```
+   Host my-studio
+       HostName connect.connect.cloud.seqera.io
+       User alice@a01ac8894
+       Port 2222
+       IdentityFile ~/.ssh/id_ed25519
+   ```
+
+   The `<username>@<studio-session-id>` pair belongs in `User`. Only the connect domain belongs in `HostName`.
+
+2. Add an SSH connection in the app:
+
+   - **SSH Host**: `my-studio` — the alias, not the full connection string
+   - **SSH Port**: `2222`
+
+:::warning
+Set **SSH Port** explicitly. The app does not apply the `Port` value from `~/.ssh/config` and defaults to port 22, which fails with a handshake timeout.
+:::
+
 ### SSH authentication
 
 SSH connections use public key authentication:

--- a/platform-cloud/docs/studios/managing.md
+++ b/platform-cloud/docs/studios/managing.md
@@ -340,20 +340,18 @@ Once connected, you can:
 
 ### Claude Code desktop app
 
-The Claude Code desktop app requires later Connect versions than SSH access in general.
+The Claude Code desktop app requires later Connect versions than other SSH connection methods.
 
 :::info[**Prerequisites**]
 
 You need the following:
 
-- **Connect server and proxy**: Version 0.12.1 or later
-- **Connect client**: Version 0.13.0 or later
+- Connect server and proxy version 0.12.1 or later
+- Connect client version 0.13.0 or later
 
 :::
 
-Because earlier versions do not run remote commands through a shell, the app's environment checks fail on connect.
-
-The Claude Code desktop app reads `~/.ssh/config`, but its **SSH Host** field accepts a hostname only. It cannot parse the `<username>@<studio-session-id>` pair. Define a host alias, then reference the alias in the app.
+The app reads `~/.ssh/config`, but its **SSH Host** field accepts a hostname only. It cannot parse the `<username>@<studio-session-id>` pair. Define a host alias, then reference the alias in the app.
 
 1. Add an entry to `~/.ssh/config`:
 
@@ -375,6 +373,8 @@ The Claude Code desktop app reads `~/.ssh/config`, but its **SSH Host** field ac
 :::warning
 Set **SSH Port** explicitly. The app ignores the `Port` value in `~/.ssh/config` and defaults to port 22. The connection then fails with a handshake timeout.
 :::
+
+If the connection fails, see [SSH connections](../troubleshooting_and_faqs/studios_troubleshooting#ssh-connections-public-preview).
 
 ### SSH authentication
 

--- a/platform-cloud/docs/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-cloud/docs/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -184,6 +184,33 @@ Host <connect-domain>
   Port <port>
 ```
 
+### AI coding assistant fails with `Pseudo-terminal will not be allocated`
+
+```bash
+ssh alice@a01ac8894@connect.example.com -p 2222
+# Pseudo-terminal will not be allocated because stdin is not a terminal.
+```
+
+This issue occurs when an AI coding assistant runs `ssh` as a subprocess, such as Claude Code in a terminal. The assistant doesn't attach a terminal to stdin, and the SSH client refuses to allocate a pseudo-terminal. To resolve, force pseudo-terminal allocation with `-tt`:
+
+```bash
+ssh -tt alice@a01ac8894@connect.example.com -p 2222
+```
+
+### Claude Code desktop app fails with `Couldn't inspect the remote machine`
+
+```
+Connecting to remote host...
+Detecting remote OS and shell...
+Couldn't inspect the remote machine.
+```
+
+This issue occurs when the Connect server and proxy are earlier than version 0.12.1, or the Connect client is earlier than version 0.13.0. Earlier versions don't run remote commands through a shell, and the app's environment checks fail. To resolve, ensure your Studio runs Connect client 0.13.0 or later. See [Claude Code desktop app](../studios/managing#claude-code-desktop-app) for setup instructions.
+
+### Claude Code desktop app fails with `Timed out while waiting for handshake`
+
+This issue occurs because the app ignores the `Port` value in `~/.ssh/config` and defaults to port 22. To resolve, set **SSH Port** to `2222` in the app's connection settings. See [Claude Code desktop app](../studios/managing#claude-code-desktop-app) for setup instructions.
+
 ### SSH connection string format
 
 **Correct format:**

--- a/platform-enterprise_docs/studios/managing.md
+++ b/platform-enterprise_docs/studios/managing.md
@@ -324,14 +324,20 @@ Once connected, you can:
 
 ### Claude Code desktop app
 
-Connecting from the Claude Code desktop app requires:
+The Claude Code desktop app requires later Connect versions than SSH access in general.
 
-- **connect-server/proxy v0.12.1 or later**
-- **connect-client v0.13.0 or later**
+:::info[**Prerequisites**]
 
-Earlier versions do not run remote commands through a shell, so the app's environment checks fail on connect.
+You need the following:
 
-The Claude Code desktop app reads `~/.ssh/config`, but its **SSH Host** field accepts a hostname only — it cannot parse the `<username>@<studio-session-id>` pair. Define a host alias, then reference the alias by name.
+- **Connect server and proxy**: Version 0.12.1 or later
+- **Connect client**: Version 0.13.0 or later
+
+:::
+
+Because earlier versions do not run remote commands through a shell, the app's environment checks fail on connect.
+
+The Claude Code desktop app reads `~/.ssh/config`, but its **SSH Host** field accepts a hostname only. It cannot parse the `<username>@<studio-session-id>` pair. Define a host alias, then reference the alias in the app.
 
 1. Add an entry to `~/.ssh/config`:
 
@@ -343,15 +349,15 @@ The Claude Code desktop app reads `~/.ssh/config`, but its **SSH Host** field ac
        IdentityFile ~/.ssh/id_ed25519
    ```
 
-   The `<username>@<studio-session-id>` pair belongs in `User`. Only the connect domain belongs in `HostName`.
+   Put the `<username>@<studio-session-id>` pair in `User`, and only the connect domain in `HostName`.
 
 2. Add an SSH connection in the app:
 
-   - **SSH Host**: `my-studio` — the alias, not the full connection string
+   - **SSH Host**: `my-studio`
    - **SSH Port**: `2222`
 
 :::warning
-Set **SSH Port** explicitly. The app does not apply the `Port` value from `~/.ssh/config` and defaults to port 22, which fails with a handshake timeout.
+Set **SSH Port** explicitly. The app ignores the `Port` value in `~/.ssh/config` and defaults to port 22. The connection then fails with a handshake timeout.
 :::
 
 ### SSH authentication

--- a/platform-enterprise_docs/studios/managing.md
+++ b/platform-enterprise_docs/studios/managing.md
@@ -324,20 +324,18 @@ Once connected, you can:
 
 ### Claude Code desktop app
 
-The Claude Code desktop app requires later Connect versions than SSH access in general.
+The Claude Code desktop app requires later Connect versions than other SSH connection methods.
 
 :::info[**Prerequisites**]
 
 You need the following:
 
-- **Connect server and proxy**: Version 0.12.1 or later
-- **Connect client**: Version 0.13.0 or later
+- Connect server and proxy version 0.12.1 or later
+- Connect client version 0.13.0 or later
 
 :::
 
-Because earlier versions do not run remote commands through a shell, the app's environment checks fail on connect.
-
-The Claude Code desktop app reads `~/.ssh/config`, but its **SSH Host** field accepts a hostname only. It cannot parse the `<username>@<studio-session-id>` pair. Define a host alias, then reference the alias in the app.
+The app reads `~/.ssh/config`, but its **SSH Host** field accepts a hostname only. It cannot parse the `<username>@<studio-session-id>` pair. Define a host alias, then reference the alias in the app.
 
 1. Add an entry to `~/.ssh/config`:
 
@@ -359,6 +357,8 @@ The Claude Code desktop app reads `~/.ssh/config`, but its **SSH Host** field ac
 :::warning
 Set **SSH Port** explicitly. The app ignores the `Port` value in `~/.ssh/config` and defaults to port 22. The connection then fails with a handshake timeout.
 :::
+
+If the connection fails, see [SSH connections](../troubleshooting_and_faqs/studios_troubleshooting#ssh-connections-public-preview).
 
 ### SSH authentication
 

--- a/platform-enterprise_docs/studios/managing.md
+++ b/platform-enterprise_docs/studios/managing.md
@@ -322,6 +322,38 @@ Once connected, you can:
 - Debug code running in the Studio
 - Install packages
 
+### Claude Code desktop app
+
+Connecting from the Claude Code desktop app requires:
+
+- **connect-server/proxy v0.12.1 or later**
+- **connect-client v0.13.0 or later**
+
+Earlier versions do not run remote commands through a shell, so the app's environment checks fail on connect.
+
+The Claude Code desktop app reads `~/.ssh/config`, but its **SSH Host** field accepts a hostname only — it cannot parse the `<username>@<studio-session-id>` pair. Define a host alias, then reference the alias by name.
+
+1. Add an entry to `~/.ssh/config`:
+
+   ```
+   Host my-studio
+       HostName connect.example.com
+       User alice@a01ac8894
+       Port 2222
+       IdentityFile ~/.ssh/id_ed25519
+   ```
+
+   The `<username>@<studio-session-id>` pair belongs in `User`. Only the connect domain belongs in `HostName`.
+
+2. Add an SSH connection in the app:
+
+   - **SSH Host**: `my-studio` — the alias, not the full connection string
+   - **SSH Port**: `2222`
+
+:::warning
+Set **SSH Port** explicitly. The app does not apply the `Port` value from `~/.ssh/config` and defaults to port 22, which fails with a handshake timeout.
+:::
+
 ### SSH authentication
 
 SSH connections use public key authentication:

--- a/platform-enterprise_docs/troubleshooting_and_faqs/studios_troubleshooting.md
+++ b/platform-enterprise_docs/troubleshooting_and_faqs/studios_troubleshooting.md
@@ -229,6 +229,33 @@ Host <connect-domain>
   Port <port>
 ```
 
+#### AI coding assistant fails with `Pseudo-terminal will not be allocated`
+
+```bash
+ssh alice@a01ac8894@connect.example.com -p 2222
+# Pseudo-terminal will not be allocated because stdin is not a terminal.
+```
+
+This issue occurs when an AI coding assistant runs `ssh` as a subprocess, such as Claude Code in a terminal. The assistant doesn't attach a terminal to stdin, and the SSH client refuses to allocate a pseudo-terminal. To resolve, force pseudo-terminal allocation with `-tt`:
+
+```bash
+ssh -tt alice@a01ac8894@connect.example.com -p 2222
+```
+
+#### Claude Code desktop app fails with `Couldn't inspect the remote machine`
+
+```
+Connecting to remote host...
+Detecting remote OS and shell...
+Couldn't inspect the remote machine.
+```
+
+This issue occurs when the connect-server/proxy is earlier than version 0.12.1, or the Connect client is earlier than version 0.13.0. Earlier versions don't run remote commands through a shell, and the app's environment checks fail. To resolve, upgrade the connect-server/proxy to 0.12.1 or later, and ensure your Studio runs Connect client 0.13.0 or later. See [Claude Code desktop app](../studios/managing#claude-code-desktop-app) for setup instructions.
+
+#### Claude Code desktop app fails with `Timed out while waiting for handshake`
+
+This issue occurs because the app ignores the `Port` value in `~/.ssh/config` and defaults to port 22. To resolve, set **SSH Port** to `2222` in the app's connection settings. See [Claude Code desktop app](../studios/managing#claude-code-desktop-app) for setup instructions.
+
 #### SSH connection string format
 
 **Correct format:**


### PR DESCRIPTION
Steps for connecting to a Studio via Claude Code desktop app remote SSH