### PR TITLE
docs: Restructure Studios getting-started tutorial [EDU-1408]

### DIFF
--- a/platform-cloud/docs/getting-started/studios.md
+++ b/platform-cloud/docs/getting-started/studios.md
@@ -1,75 +1,92 @@
 ---
 title: "Studios for interactive analysis"
-description: "Creating interactive analysis Studios for Jupyter, R-IDE, VS Code, and more"
-date: "24 Feb 2025"
+description: "Create Jupyter, R-IDE, VS Code, and Xpra Studio sessions with custom Conda environments and mounted pipeline data"
+date created: "2025-02-24"
+last updated: "2026-08-11"
 tags: [platform, studios, jupyter, r-ide, xpra, vscode, conda]
 toc_max_heading_level: 3
 ---
 
-[Studios](../studios/overview) allows users to host a variety of container images directly in Seqera Platform compute environments for analysis using popular environments including [Jupyter](https://jupyter.org/) (Python) and an [R-IDE](https://github.com/seqeralabs/r-ide) (R), [Visual Studio Code](https://code.visualstudio.com/) IDEs, and [Xpra](https://xpra.org/index.html) remote desktops. Each Studio session provides a dedicated interactive environment that encapsulates the live environment.
-This guide explores how Studios integrates with your existing workflows, bridging the gap between pipeline execution and interactive analysis. It details how to set up and use each type of Studio, demonstrating a practical use case for each.
+[Studios](../studios/overview) runs interactive analysis environments — [Jupyter](https://jupyter.org/) notebooks, an [R-IDE](https://github.com/seqeralabs/r-ide), [Visual Studio Code](https://code.visualstudio.com/), and [Xpra](https://xpra.org/index.html) remote desktops — on your Seqera Platform compute environments, with your cloud data mounted directly into each session.
 
-:::info[**Prerequisites**]
-You will need the following to get started:
+In this tutorial, you'll set up a compute environment and mount public pipeline data, then build a Studio for each environment type:
+
+- [**Jupyter**](#jupyter-visualize-protein-structure-predictions): visualize protein structures predicted by *nf-core/proteinfold*.
+- [**R-IDE**](#r-ide-explore-rna-seq-differential-expression-results): explore RNA-Seq differential expression results in a Shiny app.
+- [**Xpra**](#xpra-view-genetic-variants-in-igv): view genetic variants from the 1000 Genomes Project in IGV desktop.
+- [**VS Code**](#vs-code-develop-nextflow-pipelines): create a Nextflow development environment with nf-core tools.
+
+Each example stands alone. Complete the [setup](#set-up-a-compute-environment) once, then jump to the environment you use.
+
+### Before you begin
+
+You need:
 
 - At least the **Maintain** workspace [user role](../orgs-and-teams/roles) to create and configure Studios.
-- An [AWS Batch compute environment](../compute-envs/aws-batch#create-a-seqera-aws-batch-compute-environment) (**without Fargate**) with sufficient resources (minimum: 2 CPUs, 8192 MB RAM).
 - Valid [credentials](../credentials/overview) for your cloud storage account and compute environment.
 - [Data Explorer](../data/data-explorer) enabled in your workspace.
-:::
 
 :::note
-The scripts and instructions provided in this guide were tested on 24 February 2025. Library and package versions recommended here may become outdated and lead to unexpected results over time.
+The library and package versions pinned in these examples may become outdated over time and lead to unexpected results.
 :::
 
-## Jupyter: Python-based visualization of protein structure prediction data
+## Set up a compute environment
 
-Jupyter notebooks enable interactive analysis using Python libraries and tools. For example, Py3DMol is a tool used for visualizing and comparing structures produced by workflows such as [nf-core/proteinfold](https://nf-co.re/proteinfold/1.1.1), a bioinformatics best-practice analysis pipeline for protein 3D structure prediction. This section demonstrates how to create an AWS Batch compute environment, add the nf-core AWS megatests public proteinfold data to your workspace, create a Jupyter Studio, and run the provided Python script to produce interactive composite 3D images of the [H1065 sequence](https://predictioncenter.org/casp14/multimer_results.cgi?target=H1065).
+The examples in this tutorial use an [AWS Batch compute environment](../compute-envs/aws-batch#create-a-seqera-aws-batch-compute-environment). Studios also supports [AWS Cloud](../compute-envs/aws-cloud), [Azure Cloud](../compute-envs/azure-cloud), and [Google Cloud](../compute-envs/google-cloud) compute environments — see [Add a Studio](../studios/add-studio) for requirements per platform.
 
-:::note
-This script and instructions can also be used to visualize the structures from *nf-core/proteinfold* runs performed with your own public or private data.
-:::
+If you don't have an existing AWS Batch compute environment, create one with the following attributes:
 
-#### Create an AWS Batch compute environment
-
-Studios require an AWS Batch compute environment. If you do not have an existing compute environment available, [create one](../compute-envs/aws-batch#create-a-seqera-aws-batch-compute-environment) with the following attributes:
-
-- **Region**: To minimize costs, your compute environment should be in the same region as your data. To browse the nf-core AWS megatests public data optimally, select **eu-west-1**.
+- **Region**: To minimize costs, create the compute environment in the same region as your data. Each example below lists the region of its public dataset.
 - **Provisioning model**: Use **On-demand** EC2 instances.
-- Studios does not support AWS Fargate. Do not enable **Use Fargate for head job**.
-- At least 2 available CPUs and 8192 MB of RAM.
+- Do not enable **Use Fargate for head job**. Studios does not support AWS Fargate.
+- At least 2 available CPUs and 8192 MB of RAM. The VS Code example needs 4 CPUs and 16384 MB of RAM.
 
-#### Add data using Data Explorer
+:::note
+Studio sessions compete for resources with pipeline runs on a shared compute environment. Ensure the compute environment has sufficient resources to run both.
+:::
 
-For the purposes of this guide, add the proteinfold results (H1065 sequence) from the nf-core AWS megatests S3 bucket to your workspace using Data Explorer:
+## Add public data with Data Explorer
+
+Each example mounts a public dataset into the Studio session:
+
+| Example | Bucket path                                                                              | Region      |
+| ------- | ---------------------------------------------------------------------------------------- | ----------- |
+| Jupyter | `s3://nf-core-awsmegatests/proteinfold/results-9bea0dc4ebb26358142afbcab3d7efd962d3a820` | `eu-west-1` |
+| R-IDE   | `s3://nf-core-awsmegatests`                                                              | `eu-west-1` |
+| Xpra    | `s3://1000genomes`                                                                       | `us-east-1` |
+| VS Code | `s3://ngi-igenomes/test-data/`                                                           | `eu-west-1` |
+
+To add a bucket to your workspace:
 
 1. From the **Data Explorer** tab, select **Add cloud bucket**.
 1. Specify the bucket details:
     - **Provider**: AWS
-    - **Bucket path**: `s3://nf-core-awsmegatests/proteinfold/results-9bea0dc4ebb26358142afbcab3d7efd962d3a820`
-    - A unique **Name** for the bucket, such as `nf-core-awsmegatests-proteinfold-h1065`
+    - **Bucket path**: the path from the table above
+    - A unique **Name** for the bucket, such as `nf-core-awsmegatests`
     - **Credentials**: **Public**
     - An optional bucket **Description**
 1. Select **Add**.
 
 :::info
-To use your own pipeline data for interactive visualization, add the cloud bucket that contains the results of your *nf-core/proteinfold* pipeline run. See [Add a cloud bucket](./quickstart-demo/add-data#add-a-cloud-bucket) for more information.
+To analyze your own pipeline results instead, add the cloud bucket that contains them. See [Add a cloud bucket](./quickstart-demo/add-data#add-a-cloud-bucket).
 :::
 
-### Create a Jupyter Studio session
+## Jupyter: Visualize protein structure predictions
 
-From the **Studios** tab, select **Add a Studio** and complete the following:
-- In the **Compute & Data** tab:
+Jupyter notebooks enable interactive analysis with Python libraries and tools. In this example, you use [Py3DMol](https://pypi.org/project/py3Dmol/) to visualize and compare protein structures produced by [nf-core/proteinfold](https://nf-co.re/proteinfold/1.1.1), rendering interactive composite 3D images of the [H1065 sequence](https://predictioncenter.org/casp14/multimer_results.cgi?target=H1065) from the nf-core AWS megatests public dataset. The same script works with the results of your own *nf-core/proteinfold* runs.
+
+### Create the Jupyter Studio
+
+1. From the **Studios** tab, select **Add Studio**.
+1. In the **Compute & Data** tab:
     - Select your AWS Batch compute environment.
-        :::note
-        Studio sessions compete for computing resources when sharing compute environments. Ensure your shared compute environment has sufficient resources to run both your pipelines and Studio sessions.
-        :::
     - Optional: Enter CPU and memory allocations. The default values are 2 CPUs and 8192 MB memory (RAM).
-    - Mount data using Data Explorer: Mount the S3 bucket or directory path that contains the nf-core AWS megatests proteinfold data, or the work directory of your *nf-core/proteinfold* run.
-- In the **General config** tab:
+    - Mount the proteinfold bucket you added with Data Explorer, or the results directory of your own *nf-core/proteinfold* run.
+1. In the **General config** tab:
     - Select the latest **Jupyter** container image template from the list.
     - Optional: Enter a unique name and description for the Studio.
     - Check **Install Conda packages** and paste the following into the YAML textfield:
+
     ```yaml
     channels:
     - schrodinger
@@ -84,14 +101,18 @@ From the **Studios** tab, select **Add a Studio** and complete the following:
       - mdtraj==1.10.3
       - py3dmol==2.4.2
     ```
-- Select **Add** or choose to **Add and start** a Studio session immediately.
-- If you chose to **Add** the Studio in the preceding step, select **Connect** in the options menu to open a Studio session in a new browser tab.
+
+1. Select **Add and start**, then select **Connect** in the options menu to open the session in a new browser tab when it is running.
+
+:::tip
+Installing Conda packages builds a custom container environment for your session. For the package syntax, prerequisites, and other ways to customize a Studio — including your own container images — see [Custom environments](../studios/custom-envs).
+:::
 
 ### Visualize protein structures
 
-The following Python script visualizes and compares protein structures produced by Alphafold 2 and ESMFold, creating a composite interactive 3D image of the two structures with contrasting colors. The script aligns mobile structures to reference structures, retrieves lists of C-alpha atoms from both structures, creates views for individual and combined structures, and creates an interactive view of the individual and combined structures using Py3DMol.
+The following Python script creates a composite interactive 3D image of the structures predicted by AlphaFold2 and ESMFold in contrasting colors. It aligns the mobile structure to the reference structure with Biopython's `Superimposer`, then renders individual and combined interactive views with Py3DMol.
 
-Run the following script in your Jupyter notebook to install the necessary packages and perform visualization:
+Run the script in your Jupyter notebook:
 
 <details>
 <summary>Full Python script</summary>
@@ -210,205 +231,28 @@ Run the following script in your Jupyter notebook to install the necessary packa
     ```
 
 </details>
-<details>
-<summary>Python script individual steps</summary>
-
-    1. Import libraries:
-
-        ```python
-        import py3Dmol
-        from IPython.display import display
-        from Bio import PDB
-        from Bio.PDB import Superimposer
-        import numpy as np
-        ```
-
-    1. Set up PDB file paths:
-
-        ```python
-        # Keep file paths unchanged to visualize structures of the H1065 sequence in nf-core AWS megatests.
-        # Update file paths (to PDB files) to visualize structures of your own nf-core/proteinfold output data.
-        alphafold2_multimer_standard = "/workspace/data/nf-core-awsmegatests-proteinfold-h1065/mode_alphafold2_multimer/alphafold2/standard/H1065.alphafold.pdb"
-        esmfold_multimer = "/workspace/data/nf-core-awsmegatests-proteinfold-h1065/mode_esmfold_multimer/esmfold/H1065.pdb"
-        ```
-
-    1. Load structures from the PDB files and retrieve lists of C-alpha atoms from both structures:
-
-        ```python
-        def align_structures(ref_pdb_path, mobile_pdb_path):
-            """Align mobile structure to reference structure and return aligned coordinates"""
-            # Set up parser
-            parser = PDB.PDBParser()
-
-            # Load structures
-            ref_structure = parser.get_structure("reference", ref_pdb_path)
-            mobile_structure = parser.get_structure("mobile", mobile_pdb_path)
-
-            # Get lists of C-alpha atoms from both structures
-            ref_atoms = []
-            mobile_atoms = []
-
-            for model in ref_structure:
-                for chain in model:
-                    for residue in chain:
-                        if 'CA' in residue:
-                            ref_atoms.append(residue['CA'])
-
-            for model in mobile_structure:
-                for chain in model:
-                    for residue in chain:
-                        if 'CA' in residue:
-                            mobile_atoms.append(residue['CA'])
-        ```
-
-    1. Align structures using Superimposer:
-
-        ```python
-        # Align structures using Superimposer
-        super_imposer = Superimposer()
-        super_imposer.set_atoms(ref_atoms, mobile_atoms)
-        super_imposer.apply(mobile_structure.get_atoms())
-
-        # Save aligned structure
-        io = PDB.PDBIO()
-        io.set_structure(mobile_structure)
-        aligned_pdb_path = "./"+mobile_pdb_path.split("/")[-1].replace('.pdb', '_aligned.pdb')
-        io.save(aligned_pdb_path)
-
-        return aligned_pdb_path
-        ```
-
-    1. Create a view for a single structure:
-
-        ```python
-        def create_structure_view(pdb_path, color, width=400, height=400, label=None):
-            """Create a view for a single structure"""
-            view = py3Dmol.view(width=width, height=height)
-
-            with open(pdb_path, 'r') as f:
-                pdb_data = f.read()
-            view.addModel(pdb_data, "pdb")
-            view.setStyle({'model': -1}, {'cartoon': {'color': color}})
-            view.zoomTo()
-
-            if label:
-                view.addLabel(label, {
-                    'position': {'x': 0, 'y': 0, 'z': 0},
-                    'backgroundColor': color,
-                    'fontColor': 'white'
-                })
-
-            return view
-        ```
-
-    1. Create individual and combined structure views:
-
-        ```python
-        def visualize_structures(pdb1_path, pdb2_path):
-            # Align the second structure to the first
-            aligned_pdb2_path = align_structures(pdb1_path, pdb2_path)
-
-            # Create three separate views
-            view1 = create_structure_view(pdb1_path, 'blue', label="AlphaFold2")
-            view2 = create_structure_view(aligned_pdb2_path, 'darkgrey', label="ESMFold")
-
-            # Create combined view
-            view3 = py3Dmol.view(width=800, height=400)
-
-            # Load and display first structure (AlphaFold2)
-            with open(pdb1_path, 'r') as f:
-                pdb1_data = f.read()
-            view3.addModel(pdb1_data, "pdb")
-            view3.setStyle({'model': -1}, {'cartoon': {'color': 'blue'}})
-
-            # Load and display aligned second structure (ESMFold)
-            with open(aligned_pdb2_path, 'r') as f:
-                pdb2_data = f.read()
-            view3.addModel(pdb2_data, "pdb")
-            view3.setStyle({'model': 1}, {'cartoon': {'color': 'darkgrey'}})
-
-            # Set up the combined view
-            view3.zoomTo()
-
-            # Add labels for combined view
-            view3.addLabel("AlphaFold2", {'position': {'x': -20, 'y': 0, 'z': 0}, 'backgroundColor': 'blue', 'fontColor': 'white'})
-            view3.addLabel("ESMFold", {'position': {'x': 20, 'y': 0, 'z': 0}, 'backgroundColor': 'darkgrey', 'fontColor': 'white'})
-
-            return view1, view2, view3
-        ```
-
-    1. Display interactive 3D structure views:
-
-        ```python
-        # Visualize the structures
-        view1, view2, view3 = visualize_structures(alphafold2_multimer_standard, esmfold_multimer)
-
-        # Display all views
-        print("AlphaFold2 Structure:")
-        view1.show()
-        print("\nESMFold Structure:")
-        view2.show()
-        print("\nAligned Structures:")
-        view3.show()
-        ```
-
-</details>
 
 ![Visualize predicted protein structures in a Jupyter notebook Studio](./_images/protein-vis-short-gif-1080p-cropped.gif)
 
-#### Interactive collaboration
+## R-IDE: Explore RNA-Seq differential expression results
 
-To share a link to the running Studio session with collaborators inside your workspace, select the options menu for your Jupyter Studio session, then select **Copy Studio URL**. Using this link, other authenticated users can access the session directly to collaborate in real time.
+An R-IDE enables interactive analysis with R libraries and tools. In this example, you deploy [ShinyNGS](https://github.com/pinin4fjords/shinyngs), a Shiny web app created by members of the nf-core community, to explore public RNA sequencing data that was processed by *nf-core/rnaseq* to quantify gene expression, followed by *nf-core/differentialabundance* to derive differential expression statistics.
 
-## R-IDE: Analyze RNASeq data and differential expression statistics
+### Create the R-IDE Studio
 
-An R-IDE enables interactive analysis using R libraries and tools. For example, Shiny for R enables you to render functions in a reactive application and build a custom user interface to explore your data. The public data used in this section consists of RNA sequencing data that was processed by the *nf-core/rnaseq* pipeline to quantify gene expression, followed by *nf-core/differentialabundance* to derive differential expression statistics. This section demonstrates how to create a Studio to perform further analysis with these results from cloud storage. One of these outputs is web app that can be deployed for interactive analysis.
-
-#### Create an AWS Batch compute environment
-
-Studios require an AWS Batch compute environment. If you do not have an existing compute environment available, [create one](../compute-envs/aws-batch#create-a-seqera-aws-batch-compute-environment) with the following attributes:
-
-- **Region**: To minimize costs, your compute environment should be in the same region as your data. To browse the nf-core AWS megatests public data optimally, select **eu-west-1**.
-- **Provisioning model**: Use **On-demand** EC2 instances.
-- Studios does not support AWS Fargate. Do not enable **Use Fargate for head job**.
-- At least 2 available CPUs and 8192 MB of RAM.
-
-#### Add data using Data Explorer
-
-For the purposes of this guide, add the nf-core AWS megatests S3 bucket to your workspace using Data Explorer:
-
-1. From the **Data Explorer** tab, select **Add cloud bucket**.
-1. Specify the bucket details:
-    - **Provider**: AWS
-    - **Bucket path**: `s3://nf-core-awsmegatests`
-    - A unique **Name** for the bucket, such as `nf-core-awsmegatests`
-    - **Credentials**: **Public**
-    - An optional bucket **Description**
-1. Select **Add**.
-
-:::info
-To use your own pipeline data for interactive analysis, add the cloud bucket that contains the results of your *nf-core/differentialabundance* pipeline run. See [Add a cloud bucket](./quickstart-demo/add-data#add-a-cloud-bucket) for more information.
-:::
-
-### Create an R-IDE Studio session
-
-From the **Studios** tab, select **Add a Studio** and complete the following:
-- In the **Compute & Data** tab:
+1. From the **Studios** tab, select **Add Studio**.
+1. In the **Compute & Data** tab:
     - Select your AWS Batch compute environment.
-      :::note
-      Studio sessions compete for computing resources when sharing compute environments. Ensure your compute environment has sufficient resources to run both your pipelines and Studio sessions.
-      :::
     - Optional: Enter CPU and memory allocations. The default values are 2 CPUs and 8192 MB memory (RAM).
-    - Mount data using Data Explorer: Mount the nf-core AWS megatests S3 bucket, or the directory path that contains the results of your *nf-core/differentialabundance* pipeline run.
-- In the **General config** tab:
+    - Mount the nf-core AWS megatests bucket you added with Data Explorer, or the results directory of your own *nf-core/differentialabundance* run.
+1. In the **General config** tab:
     - Select the latest **R-IDE** container image template from the list.
     - Optional: Enter a unique name and description for the Studio.
-- Select **Add** or choose to **Add and start** a Studio session immediately.
-- If you chose to **Add** the Studio in the preceding step, select **Start** in the options menu, then **Connect** to open a Studio session in a new browser tab when it is running.
+1. Select **Add and start**, then select **Connect** in the options menu to open the session in a new browser tab when it is running.
 
-### Configure environment and explore data in a web app
+### Deploy the ShinyNGS app
 
-The following R script installs and configures the prerequisite packages and libraries to deploy ShinyNGS, a web application created by members of the nf-core community to explore genomic data. The script also downloads the RDS file from nf-core AWS megatests to use as input data for the app's various plots, heatmaps, and tables. To use your own *nf-core/rnaseq* and *nf-core/differentialabundance* results, modify the script as instructed in step 2 below:
+The following R script installs the prerequisite packages, downloads the RDS input file, and launches the app's plots, heatmaps, and tables. To use your own *nf-core/rnaseq* and *nf-core/differentialabundance* results, replace the download URL in step 2:
 
 <details>
 <summary>R script individual steps</summary>
@@ -453,54 +297,22 @@ The following R script installs and configures the prerequisite packages and lib
 
 ![Explore the RShiny app](./quickstart-demo/assets/rnaseq-diffab-rshiny-app-explore.gif)
 
-#### Interactive collaboration
+## Xpra: View genetic variants in IGV
 
-To share a link to the running session with collaborators inside your workspace, select the options menu for your R-IDE session, then select **Copy Studio URL**. Using this link, other authenticated users can access the session directly to collaborate in real time.
+Xpra provides a remote desktop inside the Studio session. In this example, you install [IGV desktop](https://igv.org/) with Conda and visually explore genomic data from the [1000 Genomes Project](https://www.coriell.org/1/NHGRI/Collections/1000-Genomes-Project-Collection/1000-Genomes-Project).
 
-## Xpra: Visualize genetic variants with IGV
+### Create the Xpra Studio
 
-Xpra provides remote desktop functionality that enables many interactive analysis and troubleshooting workflows. One such workflow is to perform genetic variant visualization using IGV desktop, a powerful open-source tool for the visual exploration of genomic data. This section demonstrates how to add public data from the [1000 Genomes project](https://www.coriell.org/1/NHGRI/Collections/1000-Genomes-Project-Collection/1000-Genomes-Project) to your workspace, set up an Xpra environment with IGV desktop pre-installed, and explore a variant of interest.
-
-#### Create an AWS Batch compute environment
-
-Studios require an AWS Batch compute environment. If you do not have an existing compute environment available, [create one](../compute-envs/aws-batch#create-a-seqera-aws-batch-compute-environment) with the following attributes:
-
-- **Region**: To minimize costs, your compute environment should be in the same region as your data. To browse the 1000 Genomes public data optimally, select **us-east-1**.
-- **Provisioning model**: Use **On-demand** EC2 instances.
-- Studios does not support AWS Fargate. Do not enable **Use Fargate for head job**.
-- At least 2 available CPUs and 8192 MB of RAM.
-
-#### Add data using Data Explorer
-
-Add the 1000 Genomes S3 bucket to your workspace using Data Explorer:
-
-1. From the **Data Explorer** tab, select **Add cloud bucket**.
-1. Specify the bucket details:
-    - **Provider**: AWS
-    - **Bucket path**: `s3://1000genomes`
-    - A unique **Name** for the bucket, such as `1000G`
-    - **Credentials**: **Public**
-    - An optional bucket **Description**
-1. Select **Add**.
-
-:::info
-To use your own data for interactive analysis, see [Add a cloud bucket](./quickstart-demo/add-data#add-a-cloud-bucket) for instructions to add your own public or private cloud bucket.
-:::
-
-### Create an Xpra Studio session
-
-From the **Studios** tab, select **Add a Studio** and complete the following:
-- In the **Compute & Data** tab:
+1. From the **Studios** tab, select **Add Studio**.
+1. In the **Compute & Data** tab:
     - Select your AWS Batch compute environment.
-      :::note
-      Studio sessions compete for computing resources when sharing compute environments. Ensure your compute environment has sufficient resources to run both your pipelines and Studio sessions.
-      :::
     - Optional: Enter CPU and memory allocations.
-    - Mount the 1000 Genomes S3 bucket you added previously using Data Explorer.
-- In the **General config** tab:
+    - Mount the 1000 Genomes bucket you added with Data Explorer.
+1. In the **General config** tab:
     - Select the latest **Xpra** container image template from the list.
     - Optional: Enter a unique name and description for the Studio.
     - Check **Install Conda packages** and paste the following into the YAML textfield:
+
         ```yaml
         channels:
           - conda-forge
@@ -509,8 +321,8 @@ From the **Studios** tab, select **Add a Studio** and complete the following:
           - igv
           - samtools
         ```
-- Select **Add** or choose to **Add and start** a session immediately.
-- If you chose to **Add** the Studio in the preceding step, select **Connect** in the options menu to open a session in a new browser tab.
+
+1. Select **Add and start**, then select **Connect** in the options menu to open the session in a new browser tab when it is running.
 
 ### View variants in IGV desktop
 
@@ -518,53 +330,25 @@ From the **Studios** tab, select **Add a Studio** and complete the following:
 1. In IGV, change the genome version to hg19.
 1. Select **File**, then **Load from file**, then navigate to `/workspace/data/xpra-1000Genomes/phase3/data/HG00096/high_coverage_alignment` and select the `.bai` file, as shown below:
     ![Load BAM file in IGV desktop](./_images/xpra-data-studios-IGV-load-bam.png)
-1. Search for PCSK9 and zoom into one of the exons of the gene. A coverage graph and reads should be shown, as below:
+1. Search for PCSK9 and zoom into one of the exons of the gene. A coverage graph and reads are shown, as below:
     ![BAM file view](./_images/xpra-data-studios-IGV-view-bam.png)
 
-#### Interactive collaboration
+## VS Code: Develop Nextflow pipelines
 
-To share a link to the running session with collaborators inside your workspace, select the options menu for your Xpra session, then select **Copy Studio URL**. Using this link, other authenticated users can access the session directly to collaborate in real time.
+VS Code Studios give you a portable, interactive Nextflow development environment. The template includes the [Nextflow VS Code extension](https://marketplace.visualstudio.com/items?itemName=nextflow.nextflow), which uses the Nextflow language server to provide syntax highlighting, code navigation, code completion, and diagnostics for Nextflow scripts and configuration files. In this example, you add Conda and nf-core tools, run *nf-core/fetchngs* with its `test` profile, and scaffold a new pipeline with the nf-core template.
 
-## VS Code: Create an interactive Nextflow development environment
+### Create the VS Code Studio
 
-Using Studios and Visual Studio Code allows you to create a portable and interactive Nextflow development environment with all the tools you need to develop and run Nextflow pipelines. This section demonstrates how to set up a VS Code Studio with Conda and nf-core tools, add public data and run the *nf-core/fetchngs* pipeline with the `test` profile, and create a VS Code project to start coding your own Nextflow pipelines. The Studio includes the [Nextflow VS Code extension](https://marketplace.visualstudio.com/items?itemName=nextflow.nextflow), which makes use of the Nextflow language server to provide syntax highlighting, code navigation, code completion, and diagnostics for Nextflow scripts and configuration files.
-
-#### Create an AWS Batch compute environment
-
-Studios require an AWS Batch compute environment. If you do not have an existing compute environment available, [create one](../compute-envs/aws-batch#create-a-seqera-aws-batch-compute-environment) with the following attributes:
-
-- **Region**: To minimize costs, your compute environment should be in the same region as your data. To use the iGenomes public data bucket that contains the *nf-core/fetchngs* `test` profile data, select **eu-west-1**.
-- **Provisioning model**: Use **On-demand** EC2 instances.
-- Studios does not support AWS Fargate. Do not enable **Use Fargate for head job**.
-- At least 4 available CPUs and 16384 MB of RAM.
-
-#### Add data using Data Explorer
-
-The *nf-core/fetchngs* pipeline uses data from the NGI iGenomes public dataset for its `test` profile. To add this data to your workspace:
-
-1. From the **Data Explorer** tab, select **Add cloud bucket**.
-1. Specify the bucket details:
-      - **Provider**: AWS
-      - **Bucket path**: `s3://ngi-igenomes/test-data/`
-      - A unique **Name** for the bucket, such as `ngi-igenomes-test-data`
-      - **Credentials**: **Public**
-      - An optional bucket **Description**
-1. Select **Add**.
-
-### Create a VS Code Studio session
-
-From the **Studios** tab, select **Add a Studio** and complete the following:
-- In the **Compute & Data** tab:
+1. From the **Studios** tab, select **Add Studio**.
+1. In the **Compute & Data** tab:
     - Select your AWS Batch compute environment.
-      :::note
-      Studio sessions compete for computing resources when sharing compute environments. Shared compute environments must have sufficient resources to run both your pipelines and Studio sessions.
-      :::
     - Allocate at least 4 CPUs and 16384 MB RAM.
-    - Mount data using Data Explorer: To run *nf-core/fetchngs* with the `test` profile, mount the NGI iGenomes S3 bucket you added previously. Mount any other data directories you need to run and code your own Nextflow pipelines.
-- In the **General config** tab:
+    - Mount the NGI iGenomes bucket you added with Data Explorer, plus any data directories you need for your own pipelines. The *nf-core/fetchngs* `test` profile uses the NGI iGenomes public data.
+1. In the **General config** tab:
     - Select the latest **VS Code** container image template from the list.
     - Optional: Enter a unique name and description for the Studio.
     - Check **Install Conda packages** and paste the following into the YAML textfield:
+
         ```yaml
         channels:
           - conda-forge
@@ -574,17 +358,17 @@ From the **Studios** tab, select **Add a Studio** and complete the following:
           - nf-core
           - conda
         ```
-- Select **Add** or choose to **Add and start** a Studio session immediately.
-- If you chose to **Add** the Studio in the preceding step, select **Connect** in the options menu to open a Studio session in a new browser tab.
-- Once inside the Studio session, run `code .` to use the clipboard.
+
+1. Select **Add and start**, then select **Connect** in the options menu to open the session in a new browser tab when it is running.
+1. Inside the Studio session, run `code .` to use the clipboard.
 
 :::tip
-See [User and workspace settings](https://code.visualstudio.com/docs/editor/settings) if you wish to import existing VS Code configuration and preferences to your Studio session's VS Code environment.
+See [User and workspace settings](https://code.visualstudio.com/docs/editor/settings) to import your existing VS Code configuration and preferences into the session.
 :::
 
 ### Run *nf-core/fetchngs* with Conda
 
-Run the following Nextflow command to run *nf-core/fetchngs* with Conda:
+Run the following command in the session terminal:
 
 ```shell
 nextflow run nf-core/fetchngs -profile test,conda --outdir ./nf-core-fetchngs-conda-out -resume
@@ -592,11 +376,22 @@ nextflow run nf-core/fetchngs -profile test,conda --outdir ./nf-core-fetchngs-co
 
 ### Write a Nextflow pipeline with nf-core tools
 
-- Run `nf-core pipelines create` to create a new pipeline. Choose which parts of the nf-core template you want to use.
-- Run `code [your new pipeline]` to open the new pipeline as a project in VSCode. This allows you to code your pipeline with the help of the Nextflow language server and nf-core tools.
+1. Run `nf-core pipelines create` to create a new pipeline. Choose which parts of the nf-core template you want to use.
+1. Run `code <your new pipeline>` to open the new pipeline as a project in VS Code and develop it with the help of the Nextflow language server and nf-core tools.
 
 ![VS Code Studio session](./_images/guide-vs-code-studio-nf-env-1080p-cropped.gif)
 
-#### Interactive collaboration
+## Share a session with collaborators
 
-To share a link to the running session with collaborators inside your workspace, select the options menu for your VS Code Studio session, then select **Copy Studio URL**. Using this link, other authenticated users can access the session directly to collaborate in real time.
+To share a running Studio session with collaborators inside your workspace, select the options menu for the session, then select **Copy Studio URL**. Other authenticated workspace users can use this link to access the session directly and collaborate in real time.
+
+## Stop and manage your sessions
+
+A Studio session runs — and consumes compute resources — until you stop it or it encounters a technical issue. To stop, restart, or inspect the configuration of your sessions, see [Manage Studios](../studios/managing).
+
+## Next steps
+
+- [Custom environments](../studios/custom-envs): Add Conda packages to a Seqera-provided image or bring your own container image.
+- [Example custom Studios](../studios/example-studios): Ready-to-use Dockerfiles and pre-built images for Marimo, Streamlit, CELLxGENE, Shiny, and more.
+- [Add a Studio from a Git repository](../studios/add-studio-git-repo): Build a Studio directly from a repository that contains a Dockerfile.
+- [Studios troubleshooting](../troubleshooting_and_faqs/studios_troubleshooting): Fixes for common session and build issues.

--- a/platform-enterprise_docs/getting-started/studios.md
+++ b/platform-enterprise_docs/getting-started/studios.md
@@ -1,76 +1,92 @@
 ---
 title: "Studios for interactive analysis"
-description: "Creating interactive analysis Studios for Jupyter, RStudio, VS Code, and more"
-date: "24 Feb 2025"
-tags: [platform, studios, jupyter, rstudio, xpra, vscode, conda]
+description: "Create Jupyter, R-IDE, VS Code, and Xpra Studio sessions with custom Conda environments and mounted pipeline data"
+date created: "2025-02-24"
+last updated: "2026-08-11"
+tags: [platform, studios, jupyter, r-ide, xpra, vscode, conda]
 toc_max_heading_level: 3
 ---
 
-[Studios](../studios/overview) allows users to host a variety of container images directly in Seqera Platform compute environments for analysis using popular environments including [Jupyter](https://jupyter.org/) (Python) an [R-IDE](https://github.com/seqeralabs/r-ide), [Visual Studio Code](https://code.visualstudio.com/) IDEs, and [Xpra](https://xpra.org/index.html) remote desktops. Each Studio session provides a dedicated interactive environment that encapsulates the live environment.
+[Studios](../studios/overview) runs interactive analysis environments — [Jupyter](https://jupyter.org/) notebooks, an [R-IDE](https://github.com/seqeralabs/r-ide), [Visual Studio Code](https://code.visualstudio.com/), and [Xpra](https://xpra.org/index.html) remote desktops — on your Seqera Platform compute environments, with your cloud data mounted directly into each session.
 
-This guide explores how Studios integrates with your existing workflows, bridging the gap between pipeline execution and interactive analysis. It details how to set up and use each type of Studio, demonstrating a practical use case for each.
+In this tutorial, you'll set up a compute environment and mount public pipeline data, then build a Studio for each environment type:
 
-:::info[**Prerequisites**]
-You will need the following to get started:
+- [**Jupyter**](#jupyter-visualize-protein-structure-predictions): visualize protein structures predicted by *nf-core/proteinfold*.
+- [**R-IDE**](#r-ide-explore-rna-seq-differential-expression-results): explore RNA-Seq differential expression results in a Shiny app.
+- [**Xpra**](#xpra-view-genetic-variants-in-igv): view genetic variants from the 1000 Genomes Project in IGV desktop.
+- [**VS Code**](#vs-code-develop-nextflow-pipelines): create a Nextflow development environment with nf-core tools.
+
+Each example stands alone. Complete the [setup](#set-up-a-compute-environment) once, then jump to the environment you use.
+
+### Before you begin
+
+You need:
 
 - At least the **Maintain** workspace [user role](../orgs-and-teams/roles) to create and configure Studios.
-- An [AWS Batch compute environment](../compute-envs/aws-batch#automatic-configuration-of-batch-resources) (**without Fargate**) with sufficient resources (minimum: 2 CPUs, 8192 MB RAM).
 - Valid [credentials](../credentials/overview) for your cloud storage account and compute environment.
 - [Data Explorer](../data/data-explorer) enabled in your workspace.
-:::
 
 :::note
-The scripts and instructions provided in this guide were tested on 24 February 2025. Library and package versions recommended here may become outdated and lead to unexpected results over time.
+The library and package versions pinned in these examples may become outdated over time and lead to unexpected results.
 :::
 
-## Jupyter: Python-based visualization of protein structure prediction data
+## Set up a compute environment
 
-Jupyter notebooks enable interactive analysis using Python libraries and tools. For example, Py3DMol is a tool used for visualizing and comparing structures produced by workflows such as [*nf-core/proteinfold*](https://nf-co.re/proteinfold/1.1.1), a bioinformatics best-practice analysis pipeline for protein 3D structure prediction. This section demonstrates how to create an AWS Batch compute environment, add the nf-core AWS megatests public proteinfold data to your workspace, create a Jupyter Studio, and run the provided Python script to produce interactive composite 3D images of the [H1065 sequence](https://predictioncenter.org/casp14/multimer_results.cgi?target=H1065).
+The examples in this tutorial use an [AWS Batch compute environment](../compute-envs/aws-batch#create-a-seqera-aws-batch-compute-environment). Studios also supports [AWS Cloud](../compute-envs/aws-cloud) and [Google Cloud](../compute-envs/google-cloud) compute environments — see [Add a Studio](../studios/add-studio) for requirements per platform.
 
-:::note
-This script and instructions can also be used to visualize the structures from *nf-core/proteinfold* runs performed with your own public or private data.
-:::
+If you don't have an existing AWS Batch compute environment, create one with the following attributes:
 
-#### Create an AWS Batch compute environment
-
-Studios require an AWS Batch compute environment. If you do not have an existing compute environment available, [create one](../compute-envs/aws-batch#automatic-configuration-of-batch-resources) with the following attributes:
-
-- **Region**: To minimize costs, your compute environment should be in the same region as your data. To browse the nf-core AWS megatests public data optimally, select **eu-west-1**.
+- **Region**: To minimize costs, create the compute environment in the same region as your data. Each example below lists the region of its public dataset.
 - **Provisioning model**: Use **On-demand** EC2 instances.
-- Studios does not support AWS Fargate. Do not enable **Use Fargate for head job**.
-- At least 2 available CPUs and 8192 MB of RAM.
+- Do not enable **Use Fargate for head job**. Studios does not support AWS Fargate.
+- At least 2 available CPUs and 8192 MB of RAM. The VS Code example needs 4 CPUs and 16384 MB of RAM.
 
-#### Add data using Data Explorer
+:::note
+Studio sessions compete for resources with pipeline runs on a shared compute environment. Ensure the compute environment has sufficient resources to run both.
+:::
 
-For the purposes of this guide, add the proteinfold results (H1065 sequence) from the nf-core AWS megatests S3 bucket to your workspace using Data Explorer:
+## Add public data with Data Explorer
+
+Each example mounts a public dataset into the Studio session:
+
+| Example | Bucket path                                                                              | Region      |
+| ------- | ---------------------------------------------------------------------------------------- | ----------- |
+| Jupyter | `s3://nf-core-awsmegatests/proteinfold/results-9bea0dc4ebb26358142afbcab3d7efd962d3a820` | `eu-west-1` |
+| R-IDE   | `s3://nf-core-awsmegatests`                                                              | `eu-west-1` |
+| Xpra    | `s3://1000genomes`                                                                       | `us-east-1` |
+| VS Code | `s3://ngi-igenomes/test-data/`                                                           | `eu-west-1` |
+
+To add a bucket to your workspace:
 
 1. From the **Data Explorer** tab, select **Add cloud bucket**.
 1. Specify the bucket details:
     - **Provider**: AWS
-    - **Bucket path**: `s3://nf-core-awsmegatests/proteinfold/results-9bea0dc4ebb26358142afbcab3d7efd962d3a820`
-    - A unique **Name** for the bucket, such as `nf-core-awsmegatests-proteinfold-h1065`
+    - **Bucket path**: the path from the table above
+    - A unique **Name** for the bucket, such as `nf-core-awsmegatests`
     - **Credentials**: **Public**
     - An optional bucket **Description**
 1. Select **Add**.
 
 :::info
-To use your own pipeline data for interactive visualization, add the cloud bucket that contains the results of your *nf-core/proteinfold* pipeline run. See [Add a cloud bucket](./quickstart-demo/add-data#add-a-cloud-bucket) for more information.
+To analyze your own pipeline results instead, add the cloud bucket that contains them. See [Add a cloud bucket](./quickstart-demo/add-data#add-a-cloud-bucket).
 :::
 
-### Create a Jupyter Studio
+## Jupyter: Visualize protein structure predictions
 
-From the **Studios** tab, select **Add a Studio** and complete the following:
-- In the **Compute & Data** tab:
+Jupyter notebooks enable interactive analysis with Python libraries and tools. In this example, you use [Py3DMol](https://pypi.org/project/py3Dmol/) to visualize and compare protein structures produced by [nf-core/proteinfold](https://nf-co.re/proteinfold/1.1.1), rendering interactive composite 3D images of the [H1065 sequence](https://predictioncenter.org/casp14/multimer_results.cgi?target=H1065) from the nf-core AWS megatests public dataset. The same script works with the results of your own *nf-core/proteinfold* runs.
+
+### Create the Jupyter Studio
+
+1. From the **Studios** tab, select **Add Studio**.
+1. In the **Compute & Data** tab:
     - Select your AWS Batch compute environment.
-        :::note
-        Studio sessions compete for computing resources when sharing compute environments. Ensure your shared compute environment has sufficient resources to run both your pipelines and Studio sessions.
-        :::
     - Optional: Enter CPU and memory allocations. The default values are 2 CPUs and 8192 MB memory (RAM).
-    - Mount data using Data Explorer: Mount the S3 bucket or directory path that contains the nf-core AWS megatests proteinfold data, or the pipeline work directory of your *nf-core/proteinfold* run.
-- In the **General config** tab:
+    - Mount the proteinfold bucket you added with Data Explorer, or the results directory of your own *nf-core/proteinfold* run.
+1. In the **General config** tab:
     - Select the latest **Jupyter** container image template from the list.
     - Optional: Enter a unique name and description for the Studio.
     - Check **Install Conda packages** and paste the following into the YAML textfield:
+
     ```yaml
     channels:
     - schrodinger
@@ -85,14 +101,18 @@ From the **Studios** tab, select **Add a Studio** and complete the following:
       - mdtraj==1.10.3
       - py3dmol==2.4.2
     ```
-- Select **Add** or choose to **Add and start** a Studio session immediately.
-- If you chose to **Add** the Studio in the preceding step, select **Connect** in the options menu to open a Studio session in a new browser tab.
+
+1. Select **Add and start**, then select **Connect** in the options menu to open the session in a new browser tab when it is running.
+
+:::tip
+Installing Conda packages builds a custom container environment for your session. For the package syntax, prerequisites, and other ways to customize a Studio — including your own container images — see [Custom environments](../studios/custom-envs).
+:::
 
 ### Visualize protein structures
 
-The following Python script visualizes and compares protein structures produced by Alphafold 2 and ESMFold, creating a composite interactive 3D image of the two structures with contrasting colors. The script aligns mobile structures to reference structures, retrieves lists of C-alpha atoms from both structures, creates views for individual and combined structures, and creates an interactive view of the individual and combined structures using Py3DMol.
+The following Python script creates a composite interactive 3D image of the structures predicted by AlphaFold2 and ESMFold in contrasting colors. It aligns the mobile structure to the reference structure with Biopython's `Superimposer`, then renders individual and combined interactive views with Py3DMol.
 
-Run the following script in your Jupyter notebook to install the necessary packages and perform visualization:
+Run the script in your Jupyter notebook:
 
 <details>
 <summary>Full Python script</summary>
@@ -211,210 +231,33 @@ Run the following script in your Jupyter notebook to install the necessary packa
     ```
 
 </details>
-<details>
-<summary>Python script individual steps</summary>
-
-    1. Import libraries:
-
-        ```python
-        import py3Dmol
-        from IPython.display import display
-        from Bio import PDB
-        from Bio.PDB import Superimposer
-        import numpy as np
-        ```
-
-    1. Set up PDB file paths:
-
-        ```python
-        # Keep file paths unchanged to visualize structures of the H1065 sequence in nf-core AWS megatests.
-        # Update file paths (to PDB files) to visualize structures of your own nf-core/proteinfold output data.
-        alphafold2_multimer_standard = "/workspace/data/nf-core-awsmegatests-proteinfold-h1065/mode_alphafold2_multimer/alphafold2/standard/H1065.alphafold.pdb"
-        esmfold_multimer = "/workspace/data/nf-core-awsmegatests-proteinfold-h1065/mode_esmfold_multimer/esmfold/H1065.pdb"
-        ```
-
-    1. Load structures from the PDB files and retrieve lists of C-alpha atoms from both structures:
-
-        ```python
-        def align_structures(ref_pdb_path, mobile_pdb_path):
-            """Align mobile structure to reference structure and return aligned coordinates"""
-            # Set up parser
-            parser = PDB.PDBParser()
-
-            # Load structures
-            ref_structure = parser.get_structure("reference", ref_pdb_path)
-            mobile_structure = parser.get_structure("mobile", mobile_pdb_path)
-
-            # Get lists of C-alpha atoms from both structures
-            ref_atoms = []
-            mobile_atoms = []
-
-            for model in ref_structure:
-                for chain in model:
-                    for residue in chain:
-                        if 'CA' in residue:
-                            ref_atoms.append(residue['CA'])
-
-            for model in mobile_structure:
-                for chain in model:
-                    for residue in chain:
-                        if 'CA' in residue:
-                            mobile_atoms.append(residue['CA'])
-        ```
-
-    1. Align structures using Superimposer:
-
-        ```python
-        # Align structures using Superimposer
-        super_imposer = Superimposer()
-        super_imposer.set_atoms(ref_atoms, mobile_atoms)
-        super_imposer.apply(mobile_structure.get_atoms())
-
-        # Save aligned structure
-        io = PDB.PDBIO()
-        io.set_structure(mobile_structure)
-        aligned_pdb_path = "./"+mobile_pdb_path.split("/")[-1].replace('.pdb', '_aligned.pdb')
-        io.save(aligned_pdb_path)
-
-        return aligned_pdb_path
-        ```
-
-    1. Create a view for a single structure:
-
-        ```python
-        def create_structure_view(pdb_path, color, width=400, height=400, label=None):
-            """Create a view for a single structure"""
-            view = py3Dmol.view(width=width, height=height)
-
-            with open(pdb_path, 'r') as f:
-                pdb_data = f.read()
-            view.addModel(pdb_data, "pdb")
-            view.setStyle({'model': -1}, {'cartoon': {'color': color}})
-            view.zoomTo()
-
-            if label:
-                view.addLabel(label, {
-                    'position': {'x': 0, 'y': 0, 'z': 0},
-                    'backgroundColor': color,
-                    'fontColor': 'white'
-                })
-
-            return view
-        ```
-
-    1. Create individual and combined structure views:
-
-        ```python
-        def visualize_structures(pdb1_path, pdb2_path):
-            # Align the second structure to the first
-            aligned_pdb2_path = align_structures(pdb1_path, pdb2_path)
-
-            # Create three separate views
-            view1 = create_structure_view(pdb1_path, 'blue', label="AlphaFold2")
-            view2 = create_structure_view(aligned_pdb2_path, 'darkgrey', label="ESMFold")
-
-            # Create combined view
-            view3 = py3Dmol.view(width=800, height=400)
-
-            # Load and display first structure (AlphaFold2)
-            with open(pdb1_path, 'r') as f:
-                pdb1_data = f.read()
-            view3.addModel(pdb1_data, "pdb")
-            view3.setStyle({'model': -1}, {'cartoon': {'color': 'blue'}})
-
-            # Load and display aligned second structure (ESMFold)
-            with open(aligned_pdb2_path, 'r') as f:
-                pdb2_data = f.read()
-            view3.addModel(pdb2_data, "pdb")
-            view3.setStyle({'model': 1}, {'cartoon': {'color': 'darkgrey'}})
-
-            # Set up the combined view
-            view3.zoomTo()
-
-            # Add labels for combined view
-            view3.addLabel("AlphaFold2", {'position': {'x': -20, 'y': 0, 'z': 0}, 'backgroundColor': 'blue', 'fontColor': 'white'})
-            view3.addLabel("ESMFold", {'position': {'x': 20, 'y': 0, 'z': 0}, 'backgroundColor': 'darkgrey', 'fontColor': 'white'})
-
-            return view1, view2, view3
-        ```
-
-    1. Display interactive 3D structure views:
-
-        ```python
-        # Visualize the structures
-        view1, view2, view3 = visualize_structures(alphafold2_multimer_standard, esmfold_multimer)
-
-        # Display all views
-        print("AlphaFold2 Structure:")
-        view1.show()
-        print("\nESMFold Structure:")
-        view2.show()
-        print("\nAligned Structures:")
-        view3.show()
-        ```
-
-</details>
 
 ![Visualize predicted protein structures in a Jupyter notebook Studio](./_images/protein-vis-short-gif-1080p-cropped.gif)
 
-#### Interactive collaboration
+## R-IDE: Explore RNA-Seq differential expression results
 
-To share a link to the running Studio session with collaborators inside your workspace, select the options menu for your Jupyter Studio session, then select **Copy Studio URL**. Using this link, other authenticated users can access the session directly to collaborate in real time.
+An R-IDE enables interactive analysis with R libraries and tools. In this example, you deploy [ShinyNGS](https://github.com/pinin4fjords/shinyngs), a Shiny web app created by members of the nf-core community, to explore public RNA sequencing data that was processed by *nf-core/rnaseq* to quantify gene expression, followed by *nf-core/differentialabundance* to derive differential expression statistics.
 
-## R-IDE: Analyze RNASeq data and differential expression statistics
+### Create the R-IDE Studio
 
-The R-IDE enables interactive analysis using R libraries and tools. For example, Shiny for R enables you to render functions in a reactive application and build a custom user interface to explore your data. The public data used in this section consists of RNA sequencing data that was processed by the *nf-core/rnaseq* pipeline to quantify gene expression, followed by *nf-core/differentialabundance* to derive differential expression statistics. This section demonstrates how to create a Studio to perform further analysis with these results from cloud storage. One of these outputs is a web application that can be deployed for interactive analysis.
-
-#### Create an AWS Batch compute environment
-
-Studios require an AWS Batch compute environment. If you do not have an existing compute environment available, [create one](../compute-envs/aws-batch#automatic-configuration-of-batch-resources) with the following attributes:
-
-- **Region**: To minimize costs, your compute environment should be in the same region as your data. To browse the nf-core AWS megatests public data optimally, select **eu-west-1**.
-- **Provisioning model**: Use **On-Demand** EC2 instances.
-- Studios does not support AWS Fargate. Do not enable **Use Fargate for head job**.
-- At least 2 available CPUs and 8192 MB of RAM.
-
-#### Add data using Data Explorer
-
-For the purposes of this guide, add the nf-core AWS megatests S3 bucket to your workspace using Data Explorer:
-
-1. From the **Data Explorer** tab, select **Add cloud bucket**.
-1. Specify the bucket details:
-    - **Provider**: AWS
-    - **Bucket path**: `s3://nf-core-awsmegatests`
-    - A unique **Name** for the bucket, such as `nf-core-awsmegatests`
-    - **Credentials**: **Public**
-    - An optional bucket **Description**
-1. Select **Add**.
-
-:::info
-To use your own pipeline data for interactive analysis, add the cloud bucket that contains the results of your *nf-core/differentialabundance* pipeline run. See [Add a cloud bucket](./quickstart-demo/add-data#add-a-cloud-bucket) for more information.
-:::
-
-### Create an R-IDE Studio
-
-From the **Studios** tab, select **Add a Studio** and complete the following:
-- In the **Compute & Data** tab:
+1. From the **Studios** tab, select **Add Studio**.
+1. In the **Compute & Data** tab:
     - Select your AWS Batch compute environment.
-      :::note
-      Studio sessions compete for computing resources when sharing compute environments. Ensure your compute environment has sufficient resources to run both your pipelines and Studio sessions.
-      :::
     - Optional: Enter CPU and memory allocations. The default values are 2 CPUs and 8192 MB memory (RAM).
-    - Mount data using Data Explorer: Mount the nf-core AWS megatests S3 bucket, or the directory path that contains the results of your *nf-core/differentialabundance* pipeline run.
-- In the **General config** tab:
+    - Mount the nf-core AWS megatests bucket you added with Data Explorer, or the results directory of your own *nf-core/differentialabundance* run.
+1. In the **General config** tab:
     - Select the latest **R-IDE** container image template from the list.
     - Optional: Enter a unique name and description for the Studio.
-- Select **Add** or choose to **Add and start** a Studio session immediately.
-- If you chose to **Add** the Studio in the preceding step, select **Start** in the options menu, then **Connect** to open a Studio session in a new browser tab when it is running.
+1. Select **Add and start**, then select **Connect** in the options menu to open the session in a new browser tab when it is running.
 
-### Configure environment and explore data in the web app
+### Deploy the ShinyNGS app
 
-The following R script installs and configures the prerequisite packages and libraries to deploy ShinyNGS, a web application created by members of the nf-core community to explore genomic data. The script also downloads the RDS file from nf-core AWS megatests to use as input data for the web app's various plots, heatmaps, and tables. To use your own *nf-core/rnaseq* and *nf-core/differentialabundance* results, modify the script as instructed in step 2 below:
+The following R script installs the prerequisite packages, downloads the RDS input file, and launches the app's plots, heatmaps, and tables. To use your own *nf-core/rnaseq* and *nf-core/differentialabundance* results, replace the download URL in step 2:
 
 <details>
 <summary>R script individual steps</summary>
 
-    1. Configure the R-IDE with installed packages, including [ShinyNGS](https://github.com/pinin4fjords/shinyngs):
+    1. Configure the R-IDE session with installed packages, including [ShinyNGS](https://github.com/pinin4fjords/shinyngs):
 
         ```r
         if (!require("BiocManager", quietly = TRUE))
@@ -452,54 +295,22 @@ The following R script installs and configures the prerequisite packages and lib
 
 </details>
 
-#### Interactive collaboration
+## Xpra: View genetic variants in IGV
 
-To share a link to the running session with collaborators inside your workspace, select the options menu for your R-IDE session, then select **Copy Studio URL**. Using this link, other authenticated users can access the session directly to collaborate in real time.
+Xpra provides a remote desktop inside the Studio session. In this example, you install [IGV desktop](https://igv.org/) with Conda and visually explore genomic data from the [1000 Genomes Project](https://www.coriell.org/1/NHGRI/Collections/1000-Genomes-Project-Collection/1000-Genomes-Project).
 
-## Xpra: Visualize genetic variants with IGV
+### Create the Xpra Studio
 
-Xpra provides remote desktop functionality that enables many interactive analysis and troubleshooting workflows. One such workflow is to perform genetic variant visualization using IGV desktop, a powerful open-source tool for the visual exploration of genomic data. This section demonstrates how to add public data from the [1000 Genomes project](https://www.coriell.org/1/NHGRI/Collections/1000-Genomes-Project-Collection/1000-Genomes-Project) to your workspace, set up an Xpra environment with IGV desktop pre-installed, and explore a variant of interest.
-
-#### Create an AWS Batch compute environment
-
-Studios require an AWS Batch compute environment. If you do not have an existing compute environment available, [create one](../compute-envs/aws-batch#automatic-configuration-of-batch-resources) with the following attributes:
-
-- **Region**: To minimize costs, your compute environment should be in the same region as your data. To browse the 1000 Genomes public data optimally, select **us-east-1**.
-- **Provisioning model**: Use **On-demand** EC2 instances.
-- Studios does not support AWS Fargate. Do not enable **Use Fargate for head job**.
-- At least 2 available CPUs and 8192 MB of RAM.
-
-#### Add data using Data Explorer
-
-Add the 1000 Genomes S3 bucket to your workspace using Data Explorer:
-
-1. From the **Data Explorer** tab, select **Add cloud bucket**.
-1. Specify the bucket details:
-    - **Provider**: AWS
-    - **Bucket path**: `s3://1000genomes`
-    - A unique **Name** for the bucket, such as `1000G`
-    - **Credentials**: **Public**
-    - An optional bucket **Description**
-1. Select **Add**.
-
-:::info
-To use your own data for interactive analysis, see [Add a cloud bucket](./quickstart-demo/add-data#add-a-cloud-bucket) for instructions to add your own public or private cloud bucket.
-:::
-
-### Create an Xpra Studio
-
-From the **Studios** tab, select **Add a Studio** and complete the following:
-- In the **Compute & Data** tab:
+1. From the **Studios** tab, select **Add Studio**.
+1. In the **Compute & Data** tab:
     - Select your AWS Batch compute environment.
-      :::note
-      Studio sessions compete for computing resources when sharing compute environments. Ensure your compute environment has sufficient resources to run both your pipelines and Studio sessions.
-      :::
     - Optional: Enter CPU and memory allocations.
-    - Mount the 1000 Genomes S3 bucket you added previously using Data Explorer.
-- In the **General config** tab:
+    - Mount the 1000 Genomes bucket you added with Data Explorer.
+1. In the **General config** tab:
     - Select the latest **Xpra** container image template from the list.
     - Optional: Enter a unique name and description for the Studio.
     - Check **Install Conda packages** and paste the following into the YAML textfield:
+
         ```yaml
         channels:
           - conda-forge
@@ -508,8 +319,8 @@ From the **Studios** tab, select **Add a Studio** and complete the following:
           - igv
           - samtools
         ```
-- Select **Add** or choose to **Add and start** a session immediately.
-- If you chose to **Add** the Studio in the preceding step, select **Connect** in the options menu to open a session in a new browser tab.
+
+1. Select **Add and start**, then select **Connect** in the options menu to open the session in a new browser tab when it is running.
 
 ### View variants in IGV desktop
 
@@ -517,53 +328,25 @@ From the **Studios** tab, select **Add a Studio** and complete the following:
 1. In IGV, change the genome version to hg19.
 1. Select **File**, then **Load from file**, then navigate to `/workspace/data/xpra-1000Genomes/phase3/data/HG00096/high_coverage_alignment` and select the `.bai` file, as shown below:
     ![Load BAM file in IGV desktop](./_images/xpra-data-studios-IGV-load-bam.png)
-1. Search for PCSK9 and zoom into one of the exons of the gene. A coverage graph and reads should be shown, as below:
+1. Search for PCSK9 and zoom into one of the exons of the gene. A coverage graph and reads are shown, as below:
     ![BAM file view](./_images/xpra-data-studios-IGV-view-bam.png)
 
-#### Interactive collaboration
+## VS Code: Develop Nextflow pipelines
 
-To share a link to the running session with collaborators inside your workspace, select the options menu for your Xpra session, then select **Copy Studio URL**. Using this link, other authenticated users can access the session directly to collaborate in real time.
+VS Code Studios give you a portable, interactive Nextflow development environment. The template includes the [Nextflow VS Code extension](https://marketplace.visualstudio.com/items?itemName=nextflow.nextflow), which uses the Nextflow language server to provide syntax highlighting, code navigation, code completion, and diagnostics for Nextflow scripts and configuration files. In this example, you add Conda and nf-core tools, run *nf-core/fetchngs* with its `test` profile, and scaffold a new pipeline with the nf-core template.
 
-## VS Code: Create an interactive Nextflow development environment
+### Create the VS Code Studio
 
-Using Studios and Visual Studio Code allows you to create a portable and interactive Nextflow development environment with all the tools you need to develop and run Nextflow pipelines. This section demonstrates how to set up a VS Code Studio with Conda and nf-core tools, add public data and run the *nf-core/fetchngs* pipeline with the `test` profile, and create a VS Code project to start coding your own Nextflow pipelines. The Studio includes the [Nextflow VS Code extension](https://marketplace.visualstudio.com/items?itemName=nextflow.nextflow), which makes use of the Nextflow language server to provide syntax highlighting, code navigation, code completion, and diagnostics for Nextflow scripts and configuration files.
-
-#### Create an AWS Batch compute environment
-
-Studios require an AWS Batch compute environment. If you do not have an existing compute environment available, [create one](../compute-envs/aws-batch#automatic-configuration-of-batch-resources) with the following attributes:
-
-- **Region**: To minimize costs, your compute environment should be in the same region as your data. To use the iGenomes public data bucket that contains the *nf-core/fetchngs* `test` profile data, select **eu-west-1**.
-- **Provisioning model**: Use **On-demand** EC2 instances.
-- Studios does not support AWS Fargate. Do not enable **Use Fargate for head job**.
-- At least 4 available CPUs and 16384 MB of RAM.
-
-#### Add data using Data Explorer
-
-The *nf-core/fetchngs* pipeline uses data from the NGI iGenomes public dataset for its `test` profile. To add this data to your workspace:
-
-1. From the **Data Explorer** tab, select **Add cloud bucket**.
-1. Specify the bucket details:
-      - **Provider**: AWS
-      - **Bucket path**: `s3://ngi-igenomes/test-data/`
-      - A unique **Name** for the bucket, such as `ngi-igenomes-test-data`
-      - **Credentials**: **Public**
-      - An optional bucket **Description**
-1. Select **Add**.
-
-### Create a VS Code Studio
-
-From the **Studios** tab, select **Add a Studio** and complete the following:
-- In the **Compute & Data** tab:
+1. From the **Studios** tab, select **Add Studio**.
+1. In the **Compute & Data** tab:
     - Select your AWS Batch compute environment.
-      :::note
-      Studio sessions compete for computing resources when sharing compute environments. Shared compute environments must have sufficient resources to run both your pipelines and Studio sessions.
-      :::
     - Allocate at least 4 CPUs and 16384 MB RAM.
-    - Mount data using Data Explorer: To run *nf-core/fetchngs* with the `test` profile, mount the NGI iGenomes S3 bucket you added previously. Mount any other data directories you need to run and code your own Nextflow pipelines.
-- In the **General config** tab:
+    - Mount the NGI iGenomes bucket you added with Data Explorer, plus any data directories you need for your own pipelines. The *nf-core/fetchngs* `test` profile uses the NGI iGenomes public data.
+1. In the **General config** tab:
     - Select the latest **VS Code** container image template from the list.
     - Optional: Enter a unique name and description for the Studio.
     - Check **Install Conda packages** and paste the following into the YAML textfield:
+
         ```yaml
         channels:
           - conda-forge
@@ -573,17 +356,17 @@ From the **Studios** tab, select **Add a Studio** and complete the following:
           - nf-core
           - conda
         ```
-- Select **Add** or choose to **Add and start** a Studio session immediately.
-- If you chose to **Add** the Studio in the preceding step, select **Connect** in the options menu to open a Studio session in a new browser tab.
-- Once inside the Studio session, run `code .` to use the clipboard.
+
+1. Select **Add and start**, then select **Connect** in the options menu to open the session in a new browser tab when it is running.
+1. Inside the Studio session, run `code .` to use the clipboard.
 
 :::tip
-See [User and workspace settings](https://code.visualstudio.com/docs/editor/settings) if you wish to import existing VS Code configuration and preferences to your Studio session's VS Code environment.
+See [User and workspace settings](https://code.visualstudio.com/docs/editor/settings) to import your existing VS Code configuration and preferences into the session.
 :::
 
 ### Run *nf-core/fetchngs* with Conda
 
-Run the following Nextflow command to run *nf-core/fetchngs* with Conda:
+Run the following command in the session terminal:
 
 ```shell
 nextflow run nf-core/fetchngs -profile test,conda --outdir ./nf-core-fetchngs-conda-out -resume
@@ -591,11 +374,22 @@ nextflow run nf-core/fetchngs -profile test,conda --outdir ./nf-core-fetchngs-co
 
 ### Write a Nextflow pipeline with nf-core tools
 
-- Run `nf-core pipelines create` to create a new pipeline. Choose which parts of the nf-core template you want to use.
-- Run `code [NEW_PIPELINE]` to open the new pipeline as a project in VSCode. This allows you to code your pipeline with the help of the Nextflow language server and nf-core tools.
+1. Run `nf-core pipelines create` to create a new pipeline. Choose which parts of the nf-core template you want to use.
+1. Run `code <your new pipeline>` to open the new pipeline as a project in VS Code and develop it with the help of the Nextflow language server and nf-core tools.
 
 ![VS Code Studio session](./_images/guide-vs-code-studio-nf-env-1080p-cropped.gif)
 
-#### Interactive collaboration
+## Share a session with collaborators
 
-To share a link to the running session with collaborators inside your workspace, select the options menu for your VS Code Studio session, then select **Copy Studio URL**. Using this link, other authenticated users can access the session directly to collaborate in real time.
+To share a running Studio session with collaborators inside your workspace, select the options menu for the session, then select **Copy Studio URL**. Other authenticated workspace users can use this link to access the session directly and collaborate in real time.
+
+## Stop and manage your sessions
+
+A Studio session runs — and consumes compute resources — until you stop it or it encounters a technical issue. To stop, restart, or inspect the configuration of your sessions, see [Manage Studios](../studios/managing).
+
+## Next steps
+
+- [Custom environments](../studios/custom-envs): Add Conda packages to a Seqera-provided image or bring your own container image.
+- [Example custom Studios](../studios/example-studios): Ready-to-use Dockerfiles and pre-built images for Marimo, Streamlit, CELLxGENE, Shiny, and more.
+- [Add a Studio from a Git repository](../studios/add-studio-git-repo): Build a Studio directly from a repository that contains a Dockerfile.
+- [Studios troubleshooting](../troubleshooting_and_faqs/studios_troubleshooting): Fixes for common session and build issues.


### PR DESCRIPTION
## Description

Restructures the Studios getting-started tutorial for Platform Cloud and Platform Enterprise to remove duplication, correct outdated compute environment requirements, and route readers to the follow-on Studios pages.

### Changes

- **Consolidated duplicated setup**: compute environment creation, the Data Explorer bucket procedure, and the session-sharing instructions were repeated once per IDE example (Jupyter, R-IDE, Xpra, VS Code). They're now single shared sections, with a per-example table of public data buckets and regions.
- **Removed the duplicated Jupyter script**: the Python visualization script appeared twice (full script plus a step-by-step copy). The full script remains in a collapsible block.
- **Goal-first intro**: the tutorial now opens with what you'll build, with in-page links to each of the four Studio examples, and a "Before you begin" prerequisites list.
- **Corrected compute environment support**: the tutorial claimed Studios requires an AWS Batch compute environment. The Cloud edition now also lists AWS Cloud, Azure Cloud, and Google Cloud; the Enterprise edition lists AWS Cloud and Google Cloud, matching each edition's Studios overview.
- **Aligned UI text** with the current product (**Add Studio**, **Add and start**) and replaced the hard-dated "tested on 24 February 2025" disclaimer with a general package-versions note.
- **Added routing sections**: a new "Stop and manage your sessions" section links to Manage Studios, and a "Next steps" section links to Custom environments, Example custom Studios, Add a Studio from a Git repository, and Studios troubleshooting.
- The Enterprise edition mirrors the Cloud edition, minus Azure Cloud and the Cloud-only RShiny demo recording.

All relative links, anchors, and image paths verified against both doc trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)